### PR TITLE
feat: 카카오/구글/네이버 OAuth 2.0 소셜 로그인 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/backend/src/main/java/com/gakkaweo/backend/auth/config/OAuth2Properties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/config/OAuth2Properties.java
@@ -1,0 +1,13 @@
+package com.gakkaweo.backend.auth.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.oauth2")
+@Getter
+@RequiredArgsConstructor
+public class OAuth2Properties {
+
+  private final String authorizedRedirectUri;
+}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/CookieAuthorizationRequestRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/CookieAuthorizationRequestRepository.java
@@ -1,0 +1,140 @@
+package com.gakkaweo.backend.auth.oauth2;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gakkaweo.backend.auth.config.CookieProperties;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieAuthorizationRequestRepository
+    implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+  private static final String COOKIE_NAME = "oauth2_auth_request";
+  private static final int COOKIE_EXPIRE_SECONDS = 300;
+
+  private final CookieProperties cookieProperties;
+  private final ObjectMapper objectMapper;
+
+  public CookieAuthorizationRequestRepository(
+      CookieProperties cookieProperties, ObjectMapper objectMapper) {
+    this.cookieProperties = cookieProperties;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+    return findCookieValue(request);
+  }
+
+  @Override
+  public void saveAuthorizationRequest(
+      OAuth2AuthorizationRequest authorizationRequest,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    if (authorizationRequest == null) {
+      deleteCookie(response);
+      return;
+    }
+
+    String serialized = serialize(authorizationRequest);
+    ResponseCookie cookie =
+        ResponseCookie.from(COOKIE_NAME, serialized)
+            .path("/")
+            .httpOnly(true)
+            .secure(cookieProperties.isSecure())
+            .sameSite("Lax")
+            .maxAge(COOKIE_EXPIRE_SECONDS)
+            .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest removeAuthorizationRequest(
+      HttpServletRequest request, HttpServletResponse response) {
+    OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+    if (authorizationRequest != null) {
+      deleteCookie(response);
+    }
+    return authorizationRequest;
+  }
+
+  public void deleteCookie(HttpServletResponse response) {
+    ResponseCookie cookie =
+        ResponseCookie.from(COOKIE_NAME, "")
+            .path("/")
+            .httpOnly(true)
+            .secure(cookieProperties.isSecure())
+            .sameSite("Lax")
+            .maxAge(0)
+            .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+  }
+
+  private OAuth2AuthorizationRequest findCookieValue(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return null;
+    }
+    for (Cookie cookie : cookies) {
+      if (COOKIE_NAME.equals(cookie.getName())) {
+        return deserialize(cookie.getValue());
+      }
+    }
+    return null;
+  }
+
+  private String serialize(OAuth2AuthorizationRequest request) {
+    Map<String, Object> data =
+        Map.of(
+            "authorizationUri", request.getAuthorizationUri(),
+            "clientId", request.getClientId(),
+            "redirectUri", request.getRedirectUri(),
+            "scopes", request.getScopes(),
+            "state", request.getState(),
+            "additionalParameters", request.getAdditionalParameters(),
+            "authorizationRequestUri", request.getAuthorizationRequestUri(),
+            "attributes", request.getAttributes());
+    try {
+      return Base64.getUrlEncoder()
+          .withoutPadding()
+          .encodeToString(objectMapper.writeValueAsBytes(data));
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("OAuth2 인증 요청 직렬화 실패", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private OAuth2AuthorizationRequest deserialize(String value) {
+    try {
+      byte[] bytes = Base64.getUrlDecoder().decode(value);
+      Map<String, Object> data =
+          objectMapper.readValue(bytes, new TypeReference<Map<String, Object>>() {});
+
+      return OAuth2AuthorizationRequest.authorizationCode()
+          .authorizationUri((String) data.get("authorizationUri"))
+          .clientId((String) data.get("clientId"))
+          .redirectUri((String) data.get("redirectUri"))
+          .scopes(new HashSet<>((List<String>) data.get("scopes")))
+          .state((String) data.get("state"))
+          .additionalParameters((Map<String, Object>) data.get("additionalParameters"))
+          .authorizationRequestUri((String) data.get("authorizationRequestUri"))
+          .attributes(attrs -> attrs.putAll((Map<String, Object>) data.get("attributes")))
+          .build();
+    } catch (IOException e) {
+      throw new IllegalStateException("OAuth2 인증 요청 역직렬화 실패", e);
+    }
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/CustomOAuth2User.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/CustomOAuth2User.java
@@ -1,0 +1,37 @@
+package com.gakkaweo.backend.auth.oauth2;
+
+import com.gakkaweo.backend.domain.member.entity.Member;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+  private final Member member;
+  private final Map<String, Object> attributes;
+
+  public CustomOAuth2User(Member member, Map<String, Object> attributes) {
+    this.member = member;
+    this.attributes = attributes;
+  }
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + member.getRole().name()));
+  }
+
+  @Override
+  public String getName() {
+    return member.getPublicId().toString();
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/dto/OAuthAttributes.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/dto/OAuthAttributes.java
@@ -1,0 +1,43 @@
+package com.gakkaweo.backend.auth.oauth2.dto;
+
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.member.entity.SocialProvider;
+import java.util.Map;
+
+public record OAuthAttributes(SocialProvider provider, String providerId, String email) {
+
+  public static OAuthAttributes of(String registrationId, Map<String, Object> attributes) {
+    return switch (registrationId) {
+      case "kakao" -> ofKakao(attributes);
+      case "google" -> ofGoogle(attributes);
+      case "naver" -> ofNaver(attributes);
+      default -> throw new BusinessException(ErrorCode.OAUTH_PROVIDER_NOT_SUPPORTED);
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static OAuthAttributes ofKakao(Map<String, Object> attributes) {
+    String providerId = String.valueOf(attributes.get("id"));
+    Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+    String email = kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
+    return new OAuthAttributes(SocialProvider.KAKAO, providerId, email);
+  }
+
+  private static OAuthAttributes ofGoogle(Map<String, Object> attributes) {
+    String providerId = (String) attributes.get("sub");
+    String email = (String) attributes.get("email");
+    return new OAuthAttributes(SocialProvider.GOOGLE, providerId, email);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static OAuthAttributes ofNaver(Map<String, Object> attributes) {
+    Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+    if (response == null) {
+      throw new BusinessException(ErrorCode.OAUTH_PROVIDER_NOT_SUPPORTED);
+    }
+    String providerId = (String) response.get("id");
+    String email = (String) response.get("email");
+    return new OAuthAttributes(SocialProvider.NAVER, providerId, email);
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,37 @@
+package com.gakkaweo.backend.auth.oauth2.handler;
+
+import com.gakkaweo.backend.auth.config.OAuth2Properties;
+import com.gakkaweo.backend.auth.oauth2.CookieAuthorizationRequestRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+  private final OAuth2Properties oAuth2Properties;
+  private final CookieAuthorizationRequestRepository authorizationRequestRepository;
+
+  public OAuth2LoginFailureHandler(
+      OAuth2Properties oAuth2Properties,
+      CookieAuthorizationRequestRepository authorizationRequestRepository) {
+    this.oAuth2Properties = oAuth2Properties;
+    this.authorizationRequestRepository = authorizationRequestRepository;
+  }
+
+  @Override
+  public void onAuthenticationFailure(
+      HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
+      throws IOException {
+    authorizationRequestRepository.deleteCookie(response);
+
+    String errorMessage =
+        URLEncoder.encode(exception.getLocalizedMessage(), StandardCharsets.UTF_8);
+    response.sendRedirect(oAuth2Properties.getAuthorizedRedirectUri() + "?error=" + errorMessage);
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,54 @@
+package com.gakkaweo.backend.auth.oauth2.handler;
+
+import com.gakkaweo.backend.auth.config.OAuth2Properties;
+import com.gakkaweo.backend.auth.dto.TokenPair;
+import com.gakkaweo.backend.auth.oauth2.CookieAuthorizationRequestRepository;
+import com.gakkaweo.backend.auth.oauth2.CustomOAuth2User;
+import com.gakkaweo.backend.auth.service.AuthService;
+import com.gakkaweo.backend.auth.util.CookieUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final AuthService authService;
+  private final CookieUtils cookieUtils;
+  private final OAuth2Properties oAuth2Properties;
+  private final CookieAuthorizationRequestRepository authorizationRequestRepository;
+
+  public OAuth2LoginSuccessHandler(
+      AuthService authService,
+      CookieUtils cookieUtils,
+      OAuth2Properties oAuth2Properties,
+      CookieAuthorizationRequestRepository authorizationRequestRepository) {
+    this.authService = authService;
+    this.cookieUtils = cookieUtils;
+    this.oAuth2Properties = oAuth2Properties;
+    this.authorizationRequestRepository = authorizationRequestRepository;
+  }
+
+  @Override
+  public void onAuthenticationSuccess(
+      HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+      throws IOException {
+    CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+    TokenPair tokenPair = authService.issueTokens(oAuth2User.getMember());
+
+    response.addHeader(
+        HttpHeaders.SET_COOKIE,
+        cookieUtils.createAccessTokenCookie(tokenPair.accessToken()).toString());
+    response.addHeader(
+        HttpHeaders.SET_COOKIE,
+        cookieUtils.createRefreshTokenCookie(tokenPair.refreshToken()).toString());
+
+    authorizationRequestRepository.deleteCookie(response);
+
+    response.sendRedirect(oAuth2Properties.getAuthorizedRedirectUri());
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,31 @@
+package com.gakkaweo.backend.auth.oauth2.service;
+
+import com.gakkaweo.backend.auth.oauth2.CustomOAuth2User;
+import com.gakkaweo.backend.auth.oauth2.dto.OAuthAttributes;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+  private final OAuthMemberService oAuthMemberService;
+
+  public CustomOAuth2UserService(OAuthMemberService oAuthMemberService) {
+    this.oAuthMemberService = oAuthMemberService;
+  }
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    OAuth2User oAuth2User = super.loadUser(userRequest);
+
+    String registrationId = userRequest.getClientRegistration().getRegistrationId();
+    OAuthAttributes attributes = OAuthAttributes.of(registrationId, oAuth2User.getAttributes());
+    Member member = oAuthMemberService.findOrCreateMember(attributes);
+
+    return new CustomOAuth2User(member, oAuth2User.getAttributes());
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/OAuthMemberService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/OAuthMemberService.java
@@ -1,0 +1,58 @@
+package com.gakkaweo.backend.auth.oauth2.service;
+
+import com.gakkaweo.backend.auth.oauth2.dto.OAuthAttributes;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.entity.SocialAccount;
+import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
+import com.gakkaweo.backend.domain.member.service.NicknameGenerator;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OAuthMemberService {
+
+  private final SocialAccountRepository socialAccountRepository;
+  private final MemberRepository memberRepository;
+  private final NicknameGenerator nicknameGenerator;
+
+  public OAuthMemberService(
+      SocialAccountRepository socialAccountRepository,
+      MemberRepository memberRepository,
+      NicknameGenerator nicknameGenerator) {
+    this.socialAccountRepository = socialAccountRepository;
+    this.memberRepository = memberRepository;
+    this.nicknameGenerator = nicknameGenerator;
+  }
+
+  @Transactional
+  public Member findOrCreateMember(OAuthAttributes attributes) {
+    return socialAccountRepository
+        .findByProviderAndProviderId(attributes.provider(), attributes.providerId())
+        .map(
+            existing -> {
+              updateEmailIfChanged(existing, attributes.email());
+              return existing.getMember();
+            })
+        .orElseGet(() -> registerNewMember(attributes));
+  }
+
+  private void updateEmailIfChanged(SocialAccount socialAccount, String email) {
+    if (email != null && !Objects.equals(socialAccount.getEmail(), email)) {
+      socialAccount.setEmail(email);
+    }
+  }
+
+  private Member registerNewMember(OAuthAttributes attributes) {
+    String nickname = nicknameGenerator.generate();
+    Member member = memberRepository.save(new Member(nickname));
+
+    SocialAccount socialAccount =
+        new SocialAccount(member, attributes.provider(), attributes.providerId());
+    socialAccount.setEmail(attributes.email());
+    socialAccountRepository.save(socialAccount);
+
+    return member;
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
   BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다"),
   REFRESH_TOKEN_REUSE_DETECTED(HttpStatus.UNAUTHORIZED, "보안을 위해 현재 로그인 세션이 종료되었습니다"),
   INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다"),
-  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다");
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다"),
+  OAUTH_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 프로바이더입니다");
 
   private final HttpStatus status;
   private final String message;

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -2,7 +2,13 @@ package com.gakkaweo.backend.config;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
+import com.gakkaweo.backend.auth.config.OAuth2Properties;
 import com.gakkaweo.backend.auth.jwt.JwtAuthenticationFilter;
+import com.gakkaweo.backend.auth.oauth2.CookieAuthorizationRequestRepository;
+import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginFailureHandler;
+import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginSuccessHandler;
+import com.gakkaweo.backend.auth.oauth2.service.CustomOAuth2UserService;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -10,32 +16,72 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableMethodSecurity
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final CustomOAuth2UserService customOAuth2UserService;
+  private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+  private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+  private final CookieAuthorizationRequestRepository authorizationRequestRepository;
+  private final OAuth2Properties oAuth2Properties;
 
-  public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+  public SecurityConfig(
+      JwtAuthenticationFilter jwtAuthenticationFilter,
+      CustomOAuth2UserService customOAuth2UserService,
+      OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler,
+      OAuth2LoginFailureHandler oAuth2LoginFailureHandler,
+      CookieAuthorizationRequestRepository authorizationRequestRepository,
+      OAuth2Properties oAuth2Properties) {
     this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    this.customOAuth2UserService = customOAuth2UserService;
+    this.oAuth2LoginSuccessHandler = oAuth2LoginSuccessHandler;
+    this.oAuth2LoginFailureHandler = oAuth2LoginFailureHandler;
+    this.authorizationRequestRepository = authorizationRequestRepository;
+    this.oAuth2Properties = oAuth2Properties;
   }
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.csrf(AbstractHttpConfigurer::disable)
+    http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .csrf(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
         .sessionManagement(s -> s.sessionCreationPolicy(STATELESS))
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers("/health")
-                    .permitAll()
-                    .requestMatchers("/auth/refresh")
+                auth.requestMatchers("/health", "/auth/refresh")
                     .permitAll()
                     .anyRequest()
                     .authenticated())
+        .oauth2Login(
+            oauth2 ->
+                oauth2
+                    // TODO: 프론트엔드 구현 시 .loginPage() 설정하여 기본 로그인 페이지(/login) 비활성화
+                    .authorizationEndpoint(
+                        e -> e.authorizationRequestRepository(authorizationRequestRepository))
+                    .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
+                    .successHandler(oAuth2LoginSuccessHandler)
+                    .failureHandler(oAuth2LoginFailureHandler))
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
     return http.build();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOrigins(List.of(oAuth2Properties.getAuthorizedRedirectUri()));
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedHeaders(List.of("*"));
+    configuration.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/repository/SocialAccountRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/repository/SocialAccountRepository.java
@@ -3,9 +3,11 @@ package com.gakkaweo.backend.domain.member.repository;
 import com.gakkaweo.backend.domain.member.entity.SocialAccount;
 import com.gakkaweo.backend.domain.member.entity.SocialProvider;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
 
+  @EntityGraph(attributePaths = "member")
   Optional<SocialAccount> findByProviderAndProviderId(SocialProvider provider, String providerId);
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -20,6 +20,48 @@ spring:
       host: localhost
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${OAUTH_KAKAO_CLIENT_ID}
+            client-secret: ${OAUTH_KAKAO_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope: account_email
+            client-name: Kakao
+          google:
+            client-id: ${OAUTH_GOOGLE_CLIENT_ID}
+            client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope: email
+            client-name: Google
+          naver:
+            client-id: ${OAUTH_NAVER_CLIENT_ID}
+            client-secret: ${OAUTH_NAVER_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope: email
+            client-name: Naver
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
 
 jwt:
   access-secret: ${JWT_ACCESS_SECRET}
@@ -28,6 +70,10 @@ jwt:
 
 cookie:
   secure: ${COOKIE_SECURE:false}
+
+app:
+  oauth2:
+    authorized-redirect-uri: ${OAUTH_REDIRECT_URI:http://localhost:3000}
 
 server:
   port: 8080


### PR DESCRIPTION
## 관련 이슈

Closes #12 

## 변경 사항

- spring-boot-starter-oauth2-client 의존성 추가
- application.yaml에 카카오/구글/네이버 OAuth2 registration/provider 설정
- 프로바이더별 UserInfo 응답을 providerId + email로 정규화 (OAuthAttributes)
- OAuth2 로그인/신규 회원가입 처리 (OAuthMemberService → NicknameGenerator 재사용)
- STATELESS 세션 대응을 위한 Cookie 기반 OAuth2 state 저장 (JSON 직렬화)
- 로그인 성공 시 JWT Access/Refresh Token 발급 후 Cookie 설정 + 프론트엔드 리다이렉트
- 로그인 실패 시 에러 메시지와 함께 프론트엔드 리다이렉트
- SecurityConfig에 oauth2Login + CORS 설정 추가
- SocialAccountRepository에 @EntityGraph 추가 (LAZY 로딩 문제 해결)

## 설계 결정

### OAuth 2.0 통일 (OIDC 미사용)

소셜 로그인의 목적이 신원 확인(인증)인 만큼 OIDC가 더 적합하나,
네이버 OIDC가 `email` scope를 지원하지 않아 이메일 수집이 불가능했다.
네이버만 OAuth 2.0을 쓰면 프로바이더별 인증 경로가 분리되어 복잡도가 증가하므로,
3개 프로바이더 모두 OAuth 2.0으로 통일하여 단일 `CustomOAuth2UserService`로 처리한다.

### CWE-502 역직렬화 취약점 대응

Cookie 기반 OAuth2 state 저장 시 `ObjectInputStream` 대신 Jackson JSON 직렬화를 적용했다.
`ObjectInputStream.readObject()`는 클라이언트가 조작한 쿠키로 RCE(원격 코드 실행)가 가능한
알려진 취약점(CWE-502)이므로, 타입 안전한 JSON 역직렬화로 대체하여 방어한다.

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- [구글 로그인](https://developers.google.com/identity/sign-in/web/sign-in)
- [카카오 로그인 REST API](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api)
- [네이버 로그인 API](https://developers.naver.com/docs/login/api/api.md)
- [Spring Security OAuth2 Client](https://docs.spring.io/spring-security/reference/servlet/oauth2/index.html)
- [CWE-502: Deserialization of Untrusted Data](https://cwe.mitre.org/data/definitions/502.html)
