### PR TITLE
feat: 데일리 게임 API 구현

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
@@ -15,7 +15,14 @@ public enum ErrorCode {
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다"),
   OAUTH_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 프로바이더입니다"),
   INVALID_GUESS_TEXT(HttpStatus.BAD_REQUEST, "유효하지 않은 추측 입력입니다"),
-  AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 서비스를 일시적으로 이용할 수 없습니다");
+  AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 서비스를 일시적으로 이용할 수 없습니다"),
+
+  SENTENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "오늘의 문제를 찾을 수 없습니다"),
+  SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "게임 세션을 찾을 수 없습니다"),
+  GAME_ALREADY_CLEARED(HttpStatus.CONFLICT, "이미 정답을 맞춘 게임입니다"),
+  GAME_ALREADY_GIVEN_UP(HttpStatus.CONFLICT, "이미 포기한 게임입니다"),
+  GAME_EXPIRED(HttpStatus.CONFLICT, "만료된 게임입니다"),
+  CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "동시 수정 충돌이 발생했습니다");
 
   private final HttpStatus status;
   private final String message;

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
@@ -1,18 +1,25 @@
 package com.gakkaweo.backend.common.exception;
 
 import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@SuppressWarnings("unused")
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
   @ExceptionHandler(BusinessException.class)
-  public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+  public ResponseEntity<?> handleBusinessException(BusinessException e) {
     ErrorCode errorCode = e.getErrorCode();
-    ErrorResponse body =
-        new ErrorResponse(
+    ErrorBody body =
+        new ErrorBody(
             errorCode.getStatus().value(),
             errorCode.name(),
             errorCode.getMessage(),
@@ -20,5 +27,55 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
-  private record ErrorResponse(int status, String code, String message, String timestamp) {}
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<?> handleValidationException(MethodArgumentNotValidException e) {
+    String message =
+        e.getBindingResult().getFieldErrors().stream()
+            .map(error -> error.getField() + ": " + error.getDefaultMessage())
+            .collect(Collectors.joining(", "));
+    ErrorBody body =
+        new ErrorBody(
+            HttpStatus.BAD_REQUEST.value(),
+            "VALIDATION_FAILED",
+            message,
+            LocalDateTime.now().toString());
+    return ResponseEntity.badRequest().body(body);
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<?> handleMissingParameter(MissingServletRequestParameterException e) {
+    ErrorBody body =
+        new ErrorBody(
+            HttpStatus.BAD_REQUEST.value(),
+            "MISSING_PARAMETER",
+            e.getMessage(),
+            LocalDateTime.now().toString());
+    return ResponseEntity.badRequest().body(body);
+  }
+
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<?> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+    ErrorBody body =
+        new ErrorBody(
+            HttpStatus.METHOD_NOT_ALLOWED.value(),
+            "METHOD_NOT_ALLOWED",
+            e.getMessage(),
+            LocalDateTime.now().toString());
+    return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(body);
+  }
+
+  @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+  public ResponseEntity<?> handleOptimisticLock(
+      ObjectOptimisticLockingFailureException ignoredException) {
+    ErrorCode errorCode = ErrorCode.CONCURRENT_MODIFICATION;
+    ErrorBody body =
+        new ErrorBody(
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            errorCode.getMessage(),
+            LocalDateTime.now().toString());
+    return ResponseEntity.status(errorCode.getStatus()).body(body);
+  }
+
+  record ErrorBody(int status, String code, String message, String timestamp) {}
 }

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import com.gakkaweo.backend.auth.oauth2.service.CustomOAuth2UserService;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -57,6 +58,12 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/health", "/auth/refresh")
                     .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/daily/today")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/daily/guess")
+                    .permitAll()
+                    .requestMatchers("/daily/**")
+                    .authenticated()
                     .anyRequest()
                     .authenticated())
         .oauth2Login(

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(
@@ -48,18 +47,16 @@ public class GameSession {
   @JoinColumn(name = "sentence_id", nullable = false)
   private DailySentence sentence;
 
-  @Setter
   @Enumerated(EnumType.STRING)
   @Column(length = 20)
   private GameSessionStatus status = GameSessionStatus.IN_PROGRESS;
 
-  @Setter
-  @Column(precision = 5, scale = 2)
+  @Column(precision = 4, scale = 1)
   private BigDecimal bestSimilarity = BigDecimal.ZERO;
 
-  @Setter private Integer attemptCount = 0;
+  private Integer attemptCount = 0;
 
-  @Setter private LocalDateTime clearedAt;
+  private LocalDateTime clearedAt;
 
   @Version private Integer version;
 
@@ -70,6 +67,29 @@ public class GameSession {
   public GameSession(Member member, DailySentence sentence) {
     this.member = member;
     this.sentence = sentence;
+  }
+
+  public void incrementAttempt() {
+    this.attemptCount++;
+  }
+
+  public void updateBestSimilarity(BigDecimal similarity) {
+    if (similarity.compareTo(this.bestSimilarity) > 0) {
+      this.bestSimilarity = similarity;
+    }
+  }
+
+  public void markCleared() {
+    this.status = GameSessionStatus.CLEARED;
+    this.clearedAt = LocalDateTime.now();
+  }
+
+  public void markGivenUp() {
+    this.status = GameSessionStatus.GIVEN_UP;
+  }
+
+  public boolean isInProgress() {
+    return this.status == GameSessionStatus.IN_PROGRESS;
   }
 
   @PrePersist

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GuessHistory.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GuessHistory.java
@@ -34,7 +34,7 @@ public class GuessHistory {
   @Column(nullable = false, columnDefinition = "TEXT")
   private String guessText;
 
-  @Column(nullable = false, precision = 5, scale = 2)
+  @Column(nullable = false, precision = 4, scale = 1)
   private BigDecimal similarity;
 
   @Column(nullable = false)

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/DailySentenceRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/DailySentenceRepository.java
@@ -3,9 +3,12 @@ package com.gakkaweo.backend.domain.game.repository;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import java.time.LocalDate;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DailySentenceRepository extends JpaRepository<DailySentence, Long> {
 
   Optional<DailySentence> findByUsedAt(LocalDate usedAt);
+
+  Optional<DailySentence> findByPublicId(UUID publicId);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/config/GameProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/config/GameProperties.java
@@ -1,0 +1,16 @@
+package com.gakkaweo.backend.game.config;
+
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "app.game")
+@Getter
+@Setter
+public class GameProperties {
+
+  private BigDecimal similarityThreshold = new BigDecimal("95.0");
+}

--- a/backend/src/main/java/com/gakkaweo/backend/game/controller/DailyGameController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/controller/DailyGameController.java
@@ -1,0 +1,64 @@
+package com.gakkaweo.backend.game.controller;
+
+import com.gakkaweo.backend.auth.security.CustomUserDetails;
+import com.gakkaweo.backend.game.dto.GameStatusResponse;
+import com.gakkaweo.backend.game.dto.GiveUpResponse;
+import com.gakkaweo.backend.game.dto.GuessHistoryResponse;
+import com.gakkaweo.backend.game.dto.GuessRequest;
+import com.gakkaweo.backend.game.dto.GuessResponse;
+import com.gakkaweo.backend.game.dto.TodayResponse;
+import com.gakkaweo.backend.game.service.DailyGameService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/daily")
+public class DailyGameController {
+
+  private final DailyGameService dailyGameService;
+
+  public DailyGameController(DailyGameService dailyGameService) {
+    this.dailyGameService = dailyGameService;
+  }
+
+  @GetMapping("/today")
+  public ResponseEntity<TodayResponse> getToday() {
+    return ResponseEntity.ok(dailyGameService.getToday());
+  }
+
+  @PostMapping("/guess")
+  public ResponseEntity<GuessResponse> guess(
+      @Valid @RequestBody GuessRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    if (userDetails == null) {
+      return ResponseEntity.ok(dailyGameService.guessAnonymous(request));
+    }
+    return ResponseEntity.ok(dailyGameService.guessAuthenticated(request, userDetails.publicId()));
+  }
+
+  @PostMapping("/give-up")
+  public ResponseEntity<GiveUpResponse> giveUp(
+      @RequestParam UUID sentenceId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.ok(dailyGameService.giveUp(sentenceId, userDetails.publicId()));
+  }
+
+  @GetMapping("/history")
+  public ResponseEntity<GuessHistoryResponse> getHistory(
+      @RequestParam UUID sentenceId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.ok(dailyGameService.getHistory(sentenceId, userDetails.publicId()));
+  }
+
+  @GetMapping("/status")
+  public ResponseEntity<GameStatusResponse> getStatus(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.ok(dailyGameService.getStatus(userDetails.publicId()));
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/GameStatusResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/GameStatusResponse.java
@@ -1,0 +1,12 @@
+package com.gakkaweo.backend.game.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record GameStatusResponse(
+    UUID sentenceId,
+    String gameStatus,
+    BigDecimal bestSimilarity,
+    int attemptCount,
+    LocalDateTime clearedAt) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/GiveUpResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/GiveUpResponse.java
@@ -1,0 +1,6 @@
+package com.gakkaweo.backend.game.dto;
+
+import java.math.BigDecimal;
+
+public record GiveUpResponse(
+    String sentence, int attemptCount, BigDecimal bestSimilarity, String gameStatus) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/GuessHistoryResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/GuessHistoryResponse.java
@@ -1,0 +1,11 @@
+package com.gakkaweo.backend.game.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GuessHistoryResponse(List<GuessEntry> guesses) {
+
+  public record GuessEntry(
+      String guessText, BigDecimal similarity, int attemptNumber, LocalDateTime createdAt) {}
+}

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/GuessRequest.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/GuessRequest.java
@@ -1,0 +1,9 @@
+package com.gakkaweo.backend.game.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record GuessRequest(
+    @NotNull UUID sentenceId, @NotBlank @Size(min = 2, max = 200) String guessText) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/GuessResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/GuessResponse.java
@@ -1,0 +1,11 @@
+package com.gakkaweo.backend.game.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record GuessResponse(
+    BigDecimal similarity,
+    Integer attemptNumber,
+    boolean isCorrect,
+    String gameStatus,
+    LocalDateTime timestamp) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/TodayResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/TodayResponse.java
@@ -1,0 +1,12 @@
+package com.gakkaweo.backend.game.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record TodayResponse(
+    UUID sentenceId,
+    String hintMask,
+    int wordCount,
+    List<Integer> charCounts,
+    LocalDateTime expiresAt) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -242,7 +242,9 @@ public class DailyGameService {
       throw switch (session.getStatus()) {
         case CLEARED -> new BusinessException(ErrorCode.GAME_ALREADY_CLEARED);
         case GIVEN_UP -> new BusinessException(ErrorCode.GAME_ALREADY_GIVEN_UP);
-        case EXPIRED -> new BusinessException(ErrorCode.GAME_EXPIRED);
+        case EXPIRED ->
+            new BusinessException(
+                ErrorCode.GAME_EXPIRED); // 자정 스케줄러에서 IN_PROGRESS → EXPIRED 일괄 전이 예정
         default -> new IllegalStateException("도달할 수 없는 상태: " + session.getStatus());
       };
     }

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -1,0 +1,250 @@
+package com.gakkaweo.backend.game.service;
+
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.GameSession;
+import com.gakkaweo.backend.domain.game.entity.GuessHistory;
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import com.gakkaweo.backend.domain.game.repository.GuessHistoryRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import com.gakkaweo.backend.game.config.GameProperties;
+import com.gakkaweo.backend.game.dto.GameStatusResponse;
+import com.gakkaweo.backend.game.dto.GiveUpResponse;
+import com.gakkaweo.backend.game.dto.GuessHistoryResponse;
+import com.gakkaweo.backend.game.dto.GuessRequest;
+import com.gakkaweo.backend.game.dto.GuessResponse;
+import com.gakkaweo.backend.game.dto.TodayResponse;
+import com.gakkaweo.backend.game.util.HintMaskGenerator;
+import com.gakkaweo.backend.infra.ai.service.SimilarityService;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DailyGameService {
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  private final DailySentenceRepository dailySentenceRepository;
+  private final GameSessionRepository gameSessionRepository;
+  private final GuessHistoryRepository guessHistoryRepository;
+  private final MemberRepository memberRepository;
+  private final SimilarityService similarityService;
+  private final HintMaskGenerator hintMaskGenerator;
+  private final GameProperties gameProperties;
+
+  public DailyGameService(
+      DailySentenceRepository dailySentenceRepository,
+      GameSessionRepository gameSessionRepository,
+      GuessHistoryRepository guessHistoryRepository,
+      MemberRepository memberRepository,
+      SimilarityService similarityService,
+      HintMaskGenerator hintMaskGenerator,
+      GameProperties gameProperties) {
+    this.dailySentenceRepository = dailySentenceRepository;
+    this.gameSessionRepository = gameSessionRepository;
+    this.guessHistoryRepository = guessHistoryRepository;
+    this.memberRepository = memberRepository;
+    this.similarityService = similarityService;
+    this.hintMaskGenerator = hintMaskGenerator;
+    this.gameProperties = gameProperties;
+  }
+
+  @Transactional(readOnly = true)
+  public TodayResponse getToday() {
+    DailySentence sentence = findTodaySentence();
+    HintMaskGenerator.HintMask hint = hintMaskGenerator.generate(sentence.getSentence());
+
+    LocalDateTime expiresAt = LocalDate.now(KST).plusDays(1).atStartOfDay();
+
+    return new TodayResponse(
+        sentence.getPublicId(),
+        hint.mask(),
+        hint.charCounts().size(),
+        hint.charCounts(),
+        expiresAt);
+  }
+
+  @Transactional
+  public GuessResponse guessAuthenticated(GuessRequest request, UUID memberPublicId) {
+    DailySentence sentence = findTodaySentenceByPublicId(request.sentenceId());
+    Member member = findMember(memberPublicId);
+
+    GameSession session = findOrCreateSession(member, sentence);
+
+    validateInProgress(session);
+
+    BigDecimal similarity =
+        similarityService.calculateSimilarity(
+            sentence.getId(), request.guessText(), sentence.getSentence(), remainingTtl());
+
+    boolean isCorrect = similarity.compareTo(gameProperties.getSimilarityThreshold()) >= 0;
+
+    session.incrementAttempt();
+    session.updateBestSimilarity(similarity);
+    if (isCorrect) {
+      session.markCleared();
+    }
+
+    guessHistoryRepository.save(
+        new GuessHistory(session, request.guessText(), similarity, session.getAttemptCount()));
+
+    gameSessionRepository.save(session);
+
+    return new GuessResponse(
+        similarity,
+        session.getAttemptCount(),
+        isCorrect,
+        session.getStatus().name(),
+        LocalDateTime.now());
+  }
+
+  @Transactional(readOnly = true)
+  public GuessResponse guessAnonymous(GuessRequest request) {
+    DailySentence sentence = findTodaySentenceByPublicId(request.sentenceId());
+
+    BigDecimal similarity =
+        similarityService.calculateSimilarity(
+            sentence.getId(), request.guessText(), sentence.getSentence(), remainingTtl());
+
+    boolean isCorrect = similarity.compareTo(gameProperties.getSimilarityThreshold()) >= 0;
+
+    return new GuessResponse(similarity, null, isCorrect, null, LocalDateTime.now());
+  }
+
+  @Transactional
+  public GiveUpResponse giveUp(UUID sentenceId, UUID memberPublicId) {
+    DailySentence sentence = findTodaySentenceByPublicId(sentenceId);
+    Member member = findMember(memberPublicId);
+
+    GameSession session =
+        gameSessionRepository
+            .findByMemberAndSentence(member, sentence)
+            .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+    validateInProgress(session);
+
+    session.markGivenUp();
+    gameSessionRepository.save(session);
+
+    return new GiveUpResponse(
+        sentence.getSentence(),
+        session.getAttemptCount(),
+        session.getBestSimilarity(),
+        session.getStatus().name());
+  }
+
+  @Transactional(readOnly = true)
+  public GuessHistoryResponse getHistory(UUID sentenceId, UUID memberPublicId) {
+    DailySentence sentence = findTodaySentenceByPublicId(sentenceId);
+    Member member = findMember(memberPublicId);
+
+    GameSession session =
+        gameSessionRepository
+            .findByMemberAndSentence(member, sentence)
+            .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+    List<GuessHistory> guesses =
+        guessHistoryRepository.findBySessionOrderByAttemptNumberAsc(session);
+
+    List<GuessHistoryResponse.GuessEntry> entries =
+        guesses.stream()
+            .map(
+                g ->
+                    new GuessHistoryResponse.GuessEntry(
+                        g.getGuessText(),
+                        g.getSimilarity(),
+                        g.getAttemptNumber(),
+                        g.getCreatedAt()))
+            .toList();
+
+    return new GuessHistoryResponse(entries);
+  }
+
+  @Transactional(readOnly = true)
+  public GameStatusResponse getStatus(UUID memberPublicId) {
+    DailySentence sentence = findTodaySentence();
+    Member member = findMember(memberPublicId);
+
+    return gameSessionRepository
+        .findByMemberAndSentence(member, sentence)
+        .map(
+            session ->
+                new GameStatusResponse(
+                    sentence.getPublicId(),
+                    session.getStatus().name(),
+                    session.getBestSimilarity(),
+                    session.getAttemptCount(),
+                    session.getClearedAt()))
+        .orElse(new GameStatusResponse(sentence.getPublicId(), null, BigDecimal.ZERO, 0, null));
+  }
+
+  private GameSession findOrCreateSession(Member member, DailySentence sentence) {
+    return gameSessionRepository
+        .findByMemberAndSentence(member, sentence)
+        .orElseGet(
+            () -> {
+              try {
+                return gameSessionRepository.save(new GameSession(member, sentence));
+              } catch (DataIntegrityViolationException e) {
+                return gameSessionRepository
+                    .findByMemberAndSentence(member, sentence)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+              }
+            });
+  }
+
+  private Duration remainingTtl() {
+    ZonedDateTime now = ZonedDateTime.now(KST);
+    ZonedDateTime midnight = now.toLocalDate().plusDays(1).atStartOfDay(KST);
+    Duration remaining = Duration.between(now, midnight);
+    return remaining.isNegative() || remaining.isZero() ? Duration.ofMinutes(1) : remaining;
+  }
+
+  private DailySentence findTodaySentence() {
+    LocalDate today = LocalDate.now(KST);
+    return dailySentenceRepository
+        .findByUsedAt(today)
+        .orElseThrow(() -> new BusinessException(ErrorCode.SENTENCE_NOT_FOUND));
+  }
+
+  private DailySentence findTodaySentenceByPublicId(UUID publicId) {
+    DailySentence sentence =
+        dailySentenceRepository
+            .findByPublicId(publicId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.SENTENCE_NOT_FOUND));
+    LocalDate today = LocalDate.now(KST);
+    if (!today.equals(sentence.getUsedAt())) {
+      throw new BusinessException(ErrorCode.SENTENCE_NOT_FOUND);
+    }
+    return sentence;
+  }
+
+  private Member findMember(UUID publicId) {
+    return memberRepository
+        .findByPublicId(publicId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+  }
+
+  private void validateInProgress(GameSession session) {
+    if (!session.isInProgress()) {
+      throw switch (session.getStatus()) {
+        case CLEARED -> new BusinessException(ErrorCode.GAME_ALREADY_CLEARED);
+        case GIVEN_UP -> new BusinessException(ErrorCode.GAME_ALREADY_GIVEN_UP);
+        case EXPIRED -> new BusinessException(ErrorCode.GAME_EXPIRED);
+        default -> new IllegalStateException("도달할 수 없는 상태: " + session.getStatus());
+      };
+    }
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/game/util/HintMaskGenerator.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/util/HintMaskGenerator.java
@@ -1,0 +1,28 @@
+package com.gakkaweo.backend.game.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HintMaskGenerator {
+
+  public HintMask generate(String sentence) {
+    String[] words = sentence.split("\\s+");
+    List<Integer> charCounts = new ArrayList<>();
+    StringBuilder mask = new StringBuilder();
+
+    for (int i = 0; i < words.length; i++) {
+      int length = words[i].length();
+      charCounts.add(length);
+      mask.append("_".repeat(length));
+      if (i < words.length - 1) {
+        mask.append(" ");
+      }
+    }
+
+    return new HintMask(mask.toString(), charCounts);
+  }
+
+  public record HintMask(String mask, List<Integer> charCounts) {}
+}

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/config/AiServiceProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/config/AiServiceProperties.java
@@ -12,5 +12,4 @@ public class AiServiceProperties {
 
   private final String url;
   private final Duration timeout;
-  private final Duration similarityCacheTtl;
 }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/SimilarityService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/SimilarityService.java
@@ -4,6 +4,8 @@ import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.infra.ai.client.AiServiceClient;
 import com.gakkaweo.backend.infra.ai.client.dto.SimilarityResponse;
+import com.gakkaweo.backend.infra.ai.exception.AiServiceException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import java.math.BigDecimal;
@@ -61,7 +63,10 @@ public class SimilarityService {
                 aiServiceClient.calculateSimilarity(sentenceText, normalized);
             return BigDecimal.valueOf(response.score()).setScale(1, RoundingMode.HALF_UP);
           });
-    } catch (Exception e) {
+    } catch (CallNotPermittedException e) {
+      log.warn("서킷 브레이커 OPEN 상태: {}", e.getMessage());
+      throw new BusinessException(ErrorCode.AI_SERVICE_UNAVAILABLE);
+    } catch (AiServiceException e) {
       log.warn("AI 서비스 호출 실패: {}", e.getMessage());
       throw new BusinessException(ErrorCode.AI_SERVICE_UNAVAILABLE);
     }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/SimilarityService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/SimilarityService.java
@@ -4,10 +4,10 @@ import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.infra.ai.client.AiServiceClient;
 import com.gakkaweo.backend.infra.ai.client.dto.SimilarityResponse;
-import com.gakkaweo.backend.infra.ai.config.AiServiceProperties;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -22,23 +22,21 @@ public class SimilarityService {
   private final AiServiceClient aiServiceClient;
   private final TextNormalizer textNormalizer;
   private final StringRedisTemplate redisTemplate;
-  private final AiServiceProperties properties;
   private final CircuitBreaker circuitBreaker;
 
   public SimilarityService(
       AiServiceClient aiServiceClient,
       TextNormalizer textNormalizer,
       StringRedisTemplate redisTemplate,
-      AiServiceProperties properties,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     this.aiServiceClient = aiServiceClient;
     this.textNormalizer = textNormalizer;
     this.redisTemplate = redisTemplate;
-    this.properties = properties;
     this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("aiService");
   }
 
-  public BigDecimal calculateSimilarity(Long sentenceId, String guessText, String sentenceText) {
+  public BigDecimal calculateSimilarity(
+      Long sentenceId, String guessText, String sentenceText, Duration cacheTtl) {
     String normalized = textNormalizer.normalize(guessText);
     if (normalized.isEmpty()) {
       throw new BusinessException(ErrorCode.INVALID_GUESS_TEXT);
@@ -50,34 +48,23 @@ public class SimilarityService {
       return cached;
     }
 
-    BigDecimal score = callWithCircuitBreaker(sentenceText, normalized, cacheKey);
-    saveToCache(cacheKey, score);
+    BigDecimal score = callWithCircuitBreaker(sentenceText, normalized);
+    saveToCache(cacheKey, score, cacheTtl);
     return score;
   }
 
-  private BigDecimal callWithCircuitBreaker(
-      String sentenceText, String normalized, String cacheKey) {
+  private BigDecimal callWithCircuitBreaker(String sentenceText, String normalized) {
     try {
       return circuitBreaker.executeSupplier(
           () -> {
             SimilarityResponse response =
                 aiServiceClient.calculateSimilarity(sentenceText, normalized);
-            return BigDecimal.valueOf(response.score());
+            return BigDecimal.valueOf(response.score()).setScale(1, RoundingMode.HALF_UP);
           });
     } catch (Exception e) {
-      return fallback(cacheKey, e);
+      log.warn("AI 서비스 호출 실패: {}", e.getMessage());
+      throw new BusinessException(ErrorCode.AI_SERVICE_UNAVAILABLE);
     }
-  }
-
-  private BigDecimal fallback(String cacheKey, Throwable t) {
-    log.warn("AI 서비스 호출 실패, 캐시 폴백 시도: {}", t.getMessage());
-
-    BigDecimal cached = getFromCache(cacheKey);
-    if (cached != null) {
-      return cached;
-    }
-
-    throw new BusinessException(ErrorCode.AI_SERVICE_UNAVAILABLE);
   }
 
   private String buildCacheKey(Long sentenceId, String normalizedText) {
@@ -97,9 +84,8 @@ public class SimilarityService {
     return null;
   }
 
-  private void saveToCache(String cacheKey, BigDecimal score) {
+  private void saveToCache(String cacheKey, BigDecimal score, Duration ttl) {
     try {
-      Duration ttl = properties.getSimilarityCacheTtl();
       redisTemplate.opsForValue().set(cacheKey, score.toPlainString(), ttl);
     } catch (Exception e) {
       log.warn("Redis 캐시 저장 실패: {}", e.getMessage());

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -77,7 +77,6 @@ app:
   ai-service:
     url: ${AI_SERVICE_URL:http://localhost:8000}
     timeout: ${AI_SERVICE_TIMEOUT:3s}
-    similarity-cache-ttl: 24h
   game:
     similarity-threshold: ${SIMILARITY_THRESHOLD:95.0}
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -78,6 +78,8 @@ app:
     url: ${AI_SERVICE_URL:http://localhost:8000}
     timeout: ${AI_SERVICE_TIMEOUT:3s}
     similarity-cache-ttl: 24h
+  game:
+    similarity-threshold: ${SIMILARITY_THRESHOLD:95.0}
 
 resilience4j:
   circuitbreaker:

--- a/backend/src/main/resources/db/migration/V2__change_similarity_scale.sql
+++ b/backend/src/main/resources/db/migration/V2__change_similarity_scale.sql
@@ -1,0 +1,4 @@
+ALTER TABLE game_sessions
+    ALTER COLUMN best_similarity TYPE DECIMAL(4, 1);
+ALTER TABLE guess_history
+    ALTER COLUMN similarity TYPE DECIMAL(4, 1);


### PR DESCRIPTION
## 관련 이슈

Closes #17 

## 변경 사항

### 게임 API (5개 엔드포인트)
- `GET /daily/today` — 오늘의 문제 조회 (힌트 마스크 + 어절별 글자 수). 익명 가능
- `POST /daily/guess` — 추측 제출. 익명은 유사도만 반환, 로그인은 GameSession/GuessHistory 저장
- `POST /daily/give-up` — 포기 (정답 공개). 로그인 필수
- `GET /daily/history` — 당일 추측 이력 조회. 로그인 필수
- `GET /daily/status` — 게임 상태 조회. 로그인 필수

### SimilarityService 리팩터링
- fallback 메서드의 캐시 재조회가 항상 miss인 dead code 제거
- 고정 TTL(24h) 대신 호출자가 KST 자정까지 남은 시간을 계산하여 전달
- AI 응답 스코어를 소수점 1자리로 반올림(`HALF_UP`)

### 기반 작업
- ErrorCode 6개 추가 + GlobalExceptionHandler 보강 (Validation 400, MissingParam 400, MethodNotAllowed 405, OptimisticLock 409)
- `GameSession` 도메인 메서드 캡슐화 (`@Setter` 제거 → `incrementAttempt`, `updateBestSimilarity`, `markCleared`, `markGivenUp`)
- `GameProperties` — 정답 임계값 설정 (`app.game.similarity-threshold`, 기본 95.0)
- `HintMaskGenerator` — 어절 분리 힌트 마스크 + charCounts 배열 런타임 생성
- 유사도 스코어 `DECIMAL(5,2)` → `DECIMAL(4,1)` 통일 (Flyway V2)

### 설계 결정 배경
- **익명 플레이**: `POST /daily/guess`를 `permitAll`로 열고 `@AuthenticationPrincipal`이 null이면 익명. 유사도만 반환 (DB 미저장)
- **낙관적 락**: GameSession `@Version`으로 동시 수정 감지 → 409 응답, 클라이언트 재시도에 위임
- **레이스 컨디션 방어**: 동시 첫 추측 시 `DataIntegrityViolationException` catch 후 재조회
- **힌트 마스크 런타임 생성**: DB 저장 없이 sentence 기반으로 생성. 저장 비용 없음
- **캐시 TTL 동적화**: KST 자정에 문제가 바뀌므로 자정까지 남은 시간만 캐싱. 23:50 입력 시 TTL 10분
- **오늘 날짜 검증**: `findTodaySentenceByPublicId`에서 `usedAt == today(KST)` 검증. 과거 문장 접근 차단

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
