### PR TITLE
refactor: auth 도메인 레이어 패키지 구조 분리

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
@@ -2,10 +2,10 @@ package com.gakkaweo.backend.auth.service;
 
 import com.gakkaweo.backend.auth.dto.AuthResponse;
 import com.gakkaweo.backend.auth.dto.TokenPair;
-import com.gakkaweo.backend.auth.entity.RefreshToken;
 import com.gakkaweo.backend.auth.jwt.JwtProvider;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.auth.entity.RefreshToken;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import io.jsonwebtoken.Claims;

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
@@ -1,10 +1,10 @@
 package com.gakkaweo.backend.auth.service;
 
 import com.gakkaweo.backend.auth.config.JwtProperties;
-import com.gakkaweo.backend.auth.entity.RefreshToken;
-import com.gakkaweo.backend.auth.repository.RefreshTokenRepository;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.auth.entity.RefreshToken;
+import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;

--- a/backend/src/main/java/com/gakkaweo/backend/domain/auth/entity/RefreshToken.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/auth/entity/RefreshToken.java
@@ -1,4 +1,4 @@
-package com.gakkaweo.backend.auth.entity;
+package com.gakkaweo.backend.domain.auth.entity;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;

--- a/backend/src/main/java/com/gakkaweo/backend/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/auth/repository/RefreshTokenRepository.java
@@ -1,6 +1,6 @@
-package com.gakkaweo.backend.auth.repository;
+package com.gakkaweo.backend.domain.auth.repository;
 
-import com.gakkaweo.backend.auth.entity.RefreshToken;
+import com.gakkaweo.backend.domain.auth.entity.RefreshToken;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;


### PR DESCRIPTION
## 관련 이슈

Closes #19 

## 변경 사항

- `auth/entity/RefreshToken.java` → `domain/auth/entity/`로 이동
- `auth/repository/RefreshTokenRepository.java` → `domain/auth/repository/`로 이동
- `AuthService`, `RefreshTokenService` import 경로 갱신

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- `domain/game/` 패키지 구조 참조 — game 모듈과 동일한 domain 분리 패턴 적용
 