### PR TITLE
refactor: 서비스 전반 로깅 추가

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -7,11 +7,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
   private final OAuth2Properties oAuth2Properties;
@@ -28,6 +30,7 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
   public void onAuthenticationFailure(
       HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
       throws IOException {
+    log.warn("OAuth2 로그인 실패: {}", exception.getMessage());
     authorizationRequestRepository.deleteCookie(response);
 
     String errorMessage =

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -9,12 +9,14 @@ import com.gakkaweo.backend.auth.util.CookieUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
   private final AuthService authService;
@@ -38,6 +40,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
       HttpServletRequest request, HttpServletResponse response, Authentication authentication)
       throws IOException {
     CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+    log.info("OAuth2 로그인 성공: memberId={}", oAuth2User.getMember().getPublicId());
     TokenPair tokenPair = authService.issueTokens(oAuth2User.getMember());
 
     response.addHeader(

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/CustomOAuth2UserService.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.auth.oauth2.service;
 import com.gakkaweo.backend.auth.oauth2.CustomOAuth2User;
 import com.gakkaweo.backend.auth.oauth2.dto.OAuthAttributes;
 import com.gakkaweo.backend.domain.member.entity.Member;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -10,6 +11,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
   private final OAuthMemberService oAuthMemberService;
@@ -23,6 +25,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     OAuth2User oAuth2User = super.loadUser(userRequest);
 
     String registrationId = userRequest.getClientRegistration().getRegistrationId();
+    log.info("OAuth2 사용자 정보 로드: provider={}", registrationId);
     OAuthAttributes attributes = OAuthAttributes.of(registrationId, oAuth2User.getAttributes());
     Member member = oAuthMemberService.findOrCreateMember(attributes);
 

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/OAuthMemberService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/OAuthMemberService.java
@@ -7,10 +7,12 @@ import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
 import com.gakkaweo.backend.domain.member.service.NicknameGenerator;
 import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 public class OAuthMemberService {
 
   private final SocialAccountRepository socialAccountRepository;
@@ -47,6 +49,7 @@ public class OAuthMemberService {
   private Member registerNewMember(OAuthAttributes attributes) {
     String nickname = nicknameGenerator.generate();
     Member member = memberRepository.save(new Member(nickname));
+    log.info("신규 회원 가입: provider={}, memberId={}", attributes.provider(), member.getPublicId());
 
     SocialAccount socialAccount =
         new SocialAccount(member, attributes.provider(), attributes.providerId());

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
@@ -11,11 +11,13 @@ import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import io.jsonwebtoken.Claims;
 import java.time.Duration;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 public class AuthService {
 
   public static final String BLACKLIST_PREFIX = "blacklist:jti:";
@@ -41,6 +43,7 @@ public class AuthService {
     String accessToken =
         jwtProvider.createAccessToken(member.getPublicId(), member.getRole().name());
     String refreshToken = refreshTokenService.createRefreshToken(member);
+    log.info("토큰 발급: memberId={}", member.getPublicId());
     return new TokenPair(accessToken, refreshToken);
   }
 
@@ -53,6 +56,7 @@ public class AuthService {
     String accessToken =
         jwtProvider.createAccessToken(member.getPublicId(), member.getRole().name());
 
+    log.info("토큰 갱신: memberId={}", member.getPublicId());
     return new TokenPair(accessToken, newRawRefreshToken);
   }
 
@@ -66,6 +70,7 @@ public class AuthService {
           .opsForValue()
           .set(BLACKLIST_PREFIX + jti, "logout", Duration.ofMillis(remainingMillis));
     }
+    log.info("로그아웃: jti={}", jti);
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
@@ -13,10 +13,12 @@ import java.time.LocalDateTime;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 public class RefreshTokenService {
 
   private final RefreshTokenRepository refreshTokenRepository;
@@ -50,11 +52,13 @@ public class RefreshTokenService {
             .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
 
     if (existing.isRevoked()) {
+      log.warn("Refresh Token 재사용 감지: familyId={}", existing.getFamilyId());
       revokeFamily(existing.getFamilyId());
       throw new BusinessException(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
     }
 
     if (existing.getExpiresAt().isBefore(LocalDateTime.now())) {
+      log.warn("만료된 Refresh Token 사용 시도: familyId={}", existing.getFamilyId());
       existing.setRevoked(true);
       throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
     }
@@ -76,6 +80,7 @@ public class RefreshTokenService {
   public void revokeFamily(UUID familyId) {
     List<RefreshToken> tokens = refreshTokenRepository.findByFamilyId(familyId);
     tokens.forEach(token -> token.setRevoked(true));
+    log.info("Token Family 폐기: familyId={}, count={}", familyId, tokens.size());
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.gakkaweo.backend.common.exception;
 
 import java.time.LocalDateTime;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @SuppressWarnings("unused")
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -18,6 +20,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<?> handleBusinessException(BusinessException e) {
     ErrorCode errorCode = e.getErrorCode();
+    log.warn("비즈니스 예외 발생: {} - {}", errorCode.name(), errorCode.getMessage());
     ErrorBody body =
         new ErrorBody(
             errorCode.getStatus().value(),
@@ -33,6 +36,7 @@ public class GlobalExceptionHandler {
         e.getBindingResult().getFieldErrors().stream()
             .map(error -> error.getField() + ": " + error.getDefaultMessage())
             .collect(Collectors.joining(", "));
+    log.warn("유효성 검증 실패: {}", message);
     ErrorBody body =
         new ErrorBody(
             HttpStatus.BAD_REQUEST.value(),
@@ -44,6 +48,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(MissingServletRequestParameterException.class)
   public ResponseEntity<?> handleMissingParameter(MissingServletRequestParameterException e) {
+    log.warn("필수 파라미터 누락: {}", e.getMessage());
     ErrorBody body =
         new ErrorBody(
             HttpStatus.BAD_REQUEST.value(),
@@ -55,6 +60,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
   public ResponseEntity<?> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+    log.warn("지원하지 않는 HTTP 메서드: {}", e.getMessage());
     ErrorBody body =
         new ErrorBody(
             HttpStatus.METHOD_NOT_ALLOWED.value(),
@@ -67,6 +73,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
   public ResponseEntity<?> handleOptimisticLock(
       ObjectOptimisticLockingFailureException ignoredException) {
+    log.warn("낙관적 락 충돌 발생");
     ErrorCode errorCode = ErrorCode.CONCURRENT_MODIFICATION;
     ErrorBody body =
         new ErrorBody(

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
@@ -71,9 +71,8 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
-  public ResponseEntity<?> handleOptimisticLock(
-      ObjectOptimisticLockingFailureException ignoredException) {
-    log.warn("낙관적 락 충돌 발생");
+  public ResponseEntity<?> handleOptimisticLock(ObjectOptimisticLockingFailureException e) {
+    log.warn("낙관적 락 충돌 발생: entity={}, id={}", e.getPersistentClassName(), e.getIdentifier());
     ErrorCode errorCode = ErrorCode.CONCURRENT_MODIFICATION;
     ErrorBody body =
         new ErrorBody(

--- a/backend/src/main/java/com/gakkaweo/backend/controller/HealthCheckController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/controller/HealthCheckController.java
@@ -8,7 +8,6 @@ public class HealthCheckController {
 
   @GetMapping("/health")
   public String health() {
-    System.out.println("Health check endpoint called");
     return "hello";
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -27,11 +27,13 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 public class DailyGameService {
 
   private static final ZoneId KST = ZoneId.of("Asia/Seoul");
@@ -102,6 +104,13 @@ public class DailyGameService {
 
     gameSessionRepository.save(session);
 
+    log.info(
+        "추측 제출: memberId={}, sentenceId={}, similarity={}, isCorrect={}",
+        memberPublicId,
+        request.sentenceId(),
+        similarity,
+        isCorrect);
+
     return new GuessResponse(
         similarity,
         session.getAttemptCount(),
@@ -137,6 +146,8 @@ public class DailyGameService {
 
     session.markGivenUp();
     gameSessionRepository.save(session);
+
+    log.info("게임 포기: memberId={}, sentenceId={}", memberPublicId, sentenceId);
 
     return new GiveUpResponse(
         sentence.getSentence(),
@@ -198,6 +209,10 @@ public class DailyGameService {
               try {
                 return gameSessionRepository.save(new GameSession(member, sentence));
               } catch (DataIntegrityViolationException e) {
+                log.debug(
+                    "세션 동시 생성 감지, 기존 세션 재조회: memberId={}, sentenceId={}",
+                    member.getPublicId(),
+                    sentence.getPublicId());
                 return gameSessionRepository
                     .findByMemberAndSentence(member, sentence)
                     .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));


### PR DESCRIPTION
## 관련 이슈

Closes #21 

## 변경 사항

- `GlobalExceptionHandler` — 5개 핸들러에 `log.warn` 추가
- `DailyGameService` — 추측 제출/포기 `log.info`, 세션 동시 생성 `log.debug`
- `AuthService` — 토큰 발급/갱신/로그아웃 `log.info`
- `RefreshTokenService` — Token 재사용/만료 `log.warn`, Family 폐기 `log.info`
- `OAuth2LoginSuccessHandler` — 로그인 성공 `log.info`
- `OAuth2LoginFailureHandler` — 로그인 실패 `log.warn`
- `CustomOAuth2UserService` — 사용자 정보 로드 `log.info`
- `OAuthMemberService` — 신규 회원 가입 `log.info`
- `HealthCheckController` — `System.out.println()` 제거

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
