### PR TITLE
refactor: LocalDateTime → Instant UTC 시간 통일

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
@@ -9,7 +9,7 @@ import com.gakkaweo.backend.domain.member.entity.Member;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.UUID;
@@ -35,7 +35,7 @@ public class RefreshTokenService {
     String rawToken = UUID.randomUUID().toString();
     String tokenHash = hashToken(rawToken);
     UUID familyId = UUID.randomUUID();
-    LocalDateTime expiresAt = LocalDateTime.now().plus(jwtProperties.getRefreshExpiration());
+    Instant expiresAt = Instant.now().plus(jwtProperties.getRefreshExpiration());
 
     RefreshToken refreshToken = new RefreshToken(member, tokenHash, familyId, expiresAt);
     refreshTokenRepository.save(refreshToken);
@@ -57,7 +57,7 @@ public class RefreshTokenService {
       throw new BusinessException(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
     }
 
-    if (existing.getExpiresAt().isBefore(LocalDateTime.now())) {
+    if (existing.getExpiresAt().isBefore(Instant.now())) {
       log.warn("만료된 Refresh Token 사용 시도: familyId={}", existing.getFamilyId());
       existing.setRevoked(true);
       throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
@@ -67,7 +67,7 @@ public class RefreshTokenService {
 
     String newRawToken = UUID.randomUUID().toString();
     String newTokenHash = hashToken(newRawToken);
-    LocalDateTime expiresAt = LocalDateTime.now().plus(jwtProperties.getRefreshExpiration());
+    Instant expiresAt = Instant.now().plus(jwtProperties.getRefreshExpiration());
 
     RefreshToken newRefreshToken =
         new RefreshToken(existing.getMember(), newTokenHash, existing.getFamilyId(), expiresAt);

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.gakkaweo.backend.common.exception;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
             errorCode.getStatus().value(),
             errorCode.name(),
             errorCode.getMessage(),
-            LocalDateTime.now().toString());
+            Instant.now().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
@@ -39,10 +39,7 @@ public class GlobalExceptionHandler {
     log.warn("유효성 검증 실패: {}", message);
     ErrorBody body =
         new ErrorBody(
-            HttpStatus.BAD_REQUEST.value(),
-            "VALIDATION_FAILED",
-            message,
-            LocalDateTime.now().toString());
+            HttpStatus.BAD_REQUEST.value(), "VALIDATION_FAILED", message, Instant.now().toString());
     return ResponseEntity.badRequest().body(body);
   }
 
@@ -54,7 +51,7 @@ public class GlobalExceptionHandler {
             HttpStatus.BAD_REQUEST.value(),
             "MISSING_PARAMETER",
             e.getMessage(),
-            LocalDateTime.now().toString());
+            Instant.now().toString());
     return ResponseEntity.badRequest().body(body);
   }
 
@@ -66,7 +63,7 @@ public class GlobalExceptionHandler {
             HttpStatus.METHOD_NOT_ALLOWED.value(),
             "METHOD_NOT_ALLOWED",
             e.getMessage(),
-            LocalDateTime.now().toString());
+            Instant.now().toString());
     return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(body);
   }
 
@@ -79,7 +76,7 @@ public class GlobalExceptionHandler {
             errorCode.getStatus().value(),
             errorCode.name(),
             errorCode.getMessage(),
-            LocalDateTime.now().toString());
+            Instant.now().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/SentenceUpload.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/SentenceUpload.java
@@ -12,7 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,7 +37,7 @@ public class SentenceUpload {
   @Column(nullable = false)
   private Integer recordCount;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   public SentenceUpload(Member admin, String fileName, Integer recordCount) {
     this.admin = admin;
@@ -47,6 +47,6 @@ public class SentenceUpload {
 
   @PrePersist
   protected void onCreate() {
-    this.createdAt = LocalDateTime.now();
+    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/auth/entity/RefreshToken.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/auth/entity/RefreshToken.java
@@ -12,7 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -40,13 +40,13 @@ public class RefreshToken {
   private UUID familyId;
 
   @Column(nullable = false)
-  private LocalDateTime expiresAt;
+  private Instant expiresAt;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   @Setter private boolean revoked = false;
 
-  public RefreshToken(Member member, String tokenHash, UUID familyId, LocalDateTime expiresAt) {
+  public RefreshToken(Member member, String tokenHash, UUID familyId, Instant expiresAt) {
     this.member = member;
     this.tokenHash = tokenHash;
     this.familyId = familyId;
@@ -55,6 +55,6 @@ public class RefreshToken {
 
   @PrePersist
   protected void onCreate() {
-    this.createdAt = LocalDateTime.now();
+    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
@@ -10,8 +10,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -49,7 +49,7 @@ public class DailySentence {
   @Column(length = 20)
   private DailySentenceStatus status = DailySentenceStatus.ACTIVE;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   public DailySentence(String sentence) {
     this.sentence = sentence;
@@ -57,6 +57,6 @@ public class DailySentence {
 
   @PrePersist
   protected void onCreate() {
-    this.createdAt = LocalDateTime.now();
+    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -18,7 +18,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -56,13 +56,13 @@ public class GameSession {
 
   private Integer attemptCount = 0;
 
-  private LocalDateTime clearedAt;
+  private Instant clearedAt;
 
   @Version private Integer version;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 
   public GameSession(Member member, DailySentence sentence) {
     this.member = member;
@@ -81,7 +81,7 @@ public class GameSession {
 
   public void markCleared() {
     this.status = GameSessionStatus.CLEARED;
-    this.clearedAt = LocalDateTime.now();
+    this.clearedAt = Instant.now();
   }
 
   public void markGivenUp() {
@@ -94,12 +94,12 @@ public class GameSession {
 
   @PrePersist
   protected void onCreate() {
-    this.createdAt = LocalDateTime.now();
-    this.updatedAt = LocalDateTime.now();
+    this.createdAt = Instant.now();
+    this.updatedAt = Instant.now();
   }
 
   @PreUpdate
   protected void onUpdate() {
-    this.updatedAt = LocalDateTime.now();
+    this.updatedAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GuessHistory.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GuessHistory.java
@@ -12,7 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,7 +40,7 @@ public class GuessHistory {
   @Column(nullable = false)
   private Integer attemptNumber;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   public GuessHistory(
       GameSession session, String guessText, BigDecimal similarity, Integer attemptNumber) {
@@ -52,6 +52,6 @@ public class GuessHistory {
 
   @PrePersist
   protected void onCreate() {
-    this.createdAt = LocalDateTime.now();
+    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/Member.java
@@ -11,7 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -44,9 +44,9 @@ public class Member {
   @Column(length = 20)
   private MemberRole role = MemberRole.USER;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 
   public Member(String nickname) {
     this.nickname = nickname;
@@ -54,12 +54,12 @@ public class Member {
 
   @PrePersist
   protected void onCreate() {
-    this.createdAt = LocalDateTime.now();
-    this.updatedAt = LocalDateTime.now();
+    this.createdAt = Instant.now();
+    this.updatedAt = Instant.now();
   }
 
   @PreUpdate
   protected void onUpdate() {
-    this.updatedAt = LocalDateTime.now();
+    this.updatedAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/SocialAccount.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/SocialAccount.java
@@ -14,7 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -47,7 +47,7 @@ public class SocialAccount {
   @Column(length = 255)
   private String email;
 
-  private LocalDateTime connectedAt;
+  private Instant connectedAt;
 
   public SocialAccount(Member member, SocialProvider provider, String providerId) {
     this.member = member;
@@ -57,6 +57,6 @@ public class SocialAccount {
 
   @PrePersist
   protected void onCreate() {
-    this.connectedAt = LocalDateTime.now();
+    this.connectedAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/GameStatusResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/GameStatusResponse.java
@@ -1,7 +1,7 @@
 package com.gakkaweo.backend.game.dto;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 public record GameStatusResponse(
@@ -9,4 +9,4 @@ public record GameStatusResponse(
     String gameStatus,
     BigDecimal bestSimilarity,
     int attemptCount,
-    LocalDateTime clearedAt) {}
+    Instant clearedAt) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/GuessHistoryResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/GuessHistoryResponse.java
@@ -1,11 +1,11 @@
 package com.gakkaweo.backend.game.dto;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 public record GuessHistoryResponse(List<GuessEntry> guesses) {
 
   public record GuessEntry(
-      String guessText, BigDecimal similarity, int attemptNumber, LocalDateTime createdAt) {}
+      String guessText, BigDecimal similarity, int attemptNumber, Instant createdAt) {}
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/GuessResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/GuessResponse.java
@@ -1,11 +1,11 @@
 package com.gakkaweo.backend.game.dto;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record GuessResponse(
     BigDecimal similarity,
     Integer attemptNumber,
     boolean isCorrect,
     String gameStatus,
-    LocalDateTime timestamp) {}
+    Instant timestamp) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/TodayResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/TodayResponse.java
@@ -1,12 +1,8 @@
 package com.gakkaweo.backend.game.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
 public record TodayResponse(
-    UUID sentenceId,
-    String hintMask,
-    int wordCount,
-    List<Integer> charCounts,
-    LocalDateTime expiresAt) {}
+    UUID sentenceId, String hintMask, int wordCount, List<Integer> charCounts, Instant expiresAt) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -21,8 +21,8 @@ import com.gakkaweo.backend.game.util.HintMaskGenerator;
 import com.gakkaweo.backend.infra.ai.service.SimilarityService;
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -68,7 +68,7 @@ public class DailyGameService {
     DailySentence sentence = findTodaySentence();
     HintMaskGenerator.HintMask hint = hintMaskGenerator.generate(sentence.getSentence());
 
-    LocalDateTime expiresAt = LocalDate.now(KST).plusDays(1).atStartOfDay();
+    Instant expiresAt = LocalDate.now(KST).plusDays(1).atStartOfDay(KST).toInstant();
 
     return new TodayResponse(
         sentence.getPublicId(),
@@ -116,7 +116,7 @@ public class DailyGameService {
         session.getAttemptCount(),
         isCorrect,
         session.getStatus().name(),
-        LocalDateTime.now());
+        Instant.now());
   }
 
   @Transactional(readOnly = true)
@@ -129,7 +129,7 @@ public class DailyGameService {
 
     boolean isCorrect = similarity.compareTo(gameProperties.getSimilarityThreshold()) >= 0;
 
-    return new GuessResponse(similarity, null, isCorrect, null, LocalDateTime.now());
+    return new GuessResponse(similarity, null, isCorrect, null, Instant.now());
   }
 
   @Transactional

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -8,6 +8,9 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
   jpa:
     hibernate:
       ddl-auto: validate

--- a/backend/src/main/resources/db/migration/V3__timestamp_to_timestamptz.sql
+++ b/backend/src/main/resources/db/migration/V3__timestamp_to_timestamptz.sql
@@ -1,0 +1,31 @@
+-- members
+ALTER TABLE members
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ,
+    ALTER COLUMN updated_at TYPE TIMESTAMPTZ;
+
+-- social_accounts
+ALTER TABLE social_accounts
+    ALTER COLUMN connected_at TYPE TIMESTAMPTZ;
+
+-- daily_sentences (used_at DATE는 유지)
+ALTER TABLE daily_sentences
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ;
+
+-- game_sessions
+ALTER TABLE game_sessions
+    ALTER COLUMN cleared_at TYPE TIMESTAMPTZ,
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ,
+    ALTER COLUMN updated_at TYPE TIMESTAMPTZ;
+
+-- guess_history
+ALTER TABLE guess_history
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ;
+
+-- sentence_uploads
+ALTER TABLE sentence_uploads
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ;
+
+-- refresh_tokens
+ALTER TABLE refresh_tokens
+    ALTER COLUMN expires_at TYPE TIMESTAMPTZ,
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       POSTGRES_DB: gakkaweo
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
+      TZ: UTC
+    command: postgres -c timezone=UTC
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d gakkaweo"]
       interval: 10s
@@ -21,6 +23,8 @@ services:
       - "${REDIS_PORT}:6379"
     volumes:
       - redisdata:/data
+    environment:
+      TZ: UTC
     command: >
       redis-server
       --appendonly yes


### PR DESCRIPTION
## 관련 이슈

Closes #23 

## 변경 사항

- Flyway V3: 7개 테이블 TIMESTAMP → TIMESTAMPTZ 마이그레이션
- Entity 7개의 LocalDateTime 필드를 Instant로 변환
- DTO 4개의 시간 타입을 Instant로 변환
- Service 3개(DailyGameService, RefreshTokenService, GlobalExceptionHandler) Instant 적용
- Docker Compose: PostgreSQL `timezone=UTC`, 컨테이너 `TZ=UTC` 명시
- application.yaml: `write-dates-as-timestamps: false` 추가
- 변경 후 `LocalDateTime.now()` 호출 0건, 시스템 타임존 의존 코드 제거 완료

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- `DailySentence.usedAt`(LocalDate), `LocalDate.now(KST)` 게임 데이 판별은 비즈니스 로직이므로 유지
- 기존 데이터는 개발 단계이므로 보존하지 않음 (DB 볼륨 재생성 필요)