### PR TITLE
feat: 자정 문장 선정 스케줄러 구현

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/BackendApplication.java
+++ b/backend/src/main/java/com/gakkaweo/backend/BackendApplication.java
@@ -3,9 +3,11 @@ package com.gakkaweo.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class BackendApplication {
 
   public static void main(String[] args) {

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/DailySentenceRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/DailySentenceRepository.java
@@ -5,10 +5,17 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DailySentenceRepository extends JpaRepository<DailySentence, Long> {
 
   Optional<DailySentence> findByUsedAt(LocalDate usedAt);
 
   Optional<DailySentence> findByPublicId(UUID publicId);
+
+  @Query(
+      value =
+          "SELECT * FROM daily_sentences WHERE used_at IS NULL AND status = 'ACTIVE' ORDER BY RANDOM() LIMIT 1",
+      nativeQuery = true)
+  Optional<DailySentence> findRandomUnusedSentence();
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GameSessionRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GameSessionRepository.java
@@ -5,8 +5,20 @@ import com.gakkaweo.backend.domain.game.entity.GameSession;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GameSessionRepository extends JpaRepository<GameSession, Long> {
 
   Optional<GameSession> findByMemberAndSentence(Member member, DailySentence sentence);
+
+  @Modifying
+  @Query(
+      "UPDATE GameSession g SET g.status ="
+          + " com.gakkaweo.backend.domain.game.entity.GameSessionStatus.EXPIRED"
+          + " WHERE g.sentence = :sentence"
+          + " AND g.status ="
+          + " com.gakkaweo.backend.domain.game.entity.GameSessionStatus.IN_PROGRESS")
+  int expireInProgressSessions(@Param("sentence") DailySentence sentence);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -1,0 +1,88 @@
+package com.gakkaweo.backend.game.scheduler;
+
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Slf4j
+public class DailySentenceScheduler {
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  private final DailySentenceRepository dailySentenceRepository;
+  private final GameSessionRepository gameSessionRepository;
+
+  public DailySentenceScheduler(
+      DailySentenceRepository dailySentenceRepository,
+      GameSessionRepository gameSessionRepository) {
+    this.dailySentenceRepository = dailySentenceRepository;
+    this.gameSessionRepository = gameSessionRepository;
+  }
+
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  public void selectDailySentence() {
+    log.info("일일 스케줄러 시작");
+    try {
+      expireYesterdaySessions();
+      selectTodaySentence();
+      log.info("일일 스케줄러 완료");
+    } catch (Exception e) {
+      log.error("일일 스케줄러 실패: {}", e.getMessage(), e);
+    }
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void onApplicationReady() {
+    LocalDate today = LocalDate.now(KST);
+    if (dailySentenceRepository.findByUsedAt(today).isEmpty()) {
+      log.info("오늘 날짜 기준으로 선택된 문장이 없어 즉시 선정을 진행합니다.");
+      selectDailySentence();
+    }
+  }
+
+  @Transactional
+  public void expireYesterdaySessions() {
+    LocalDate yesterday = LocalDate.now(KST).minusDays(1);
+    dailySentenceRepository
+        .findByUsedAt(yesterday)
+        .ifPresent(
+            sentence -> {
+              int count = gameSessionRepository.expireInProgressSessions(sentence);
+              if (count > 0) {
+                log.info("전날 세션 만료 처리: date={}, count={}", yesterday, count);
+              }
+            });
+  }
+
+  @Transactional
+  public void selectTodaySentence() {
+    LocalDate today = LocalDate.now(KST);
+
+    if (dailySentenceRepository.findByUsedAt(today).isPresent()) {
+      log.info("오늘의 문장이 이미 선정됨: date={}", today);
+      return;
+    }
+
+    DailySentence sentence =
+        dailySentenceRepository
+            .findRandomUnusedSentence()
+            .orElseThrow(
+                () -> {
+                  log.error("사용 가능한 문장이 없음 — 문장 추가 필요");
+                  return new IllegalStateException("사용 가능한 문장이 없습니다");
+                });
+
+    sentence.setUsedAt(today);
+    dailySentenceRepository.save(sentence);
+    log.info("오늘의 문장 선정: date={}, sentenceId={}", today, sentence.getPublicId());
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -33,11 +33,16 @@ public class DailySentenceScheduler {
     log.info("일일 스케줄러 시작");
     try {
       expireYesterdaySessions();
-      selectTodaySentence();
-      log.info("일일 스케줄러 완료");
     } catch (Exception e) {
-      log.error("일일 스케줄러 실패: {}", e.getMessage(), e);
+      log.error("전날 세션 만료 처리 실패: {}", e.getMessage(), e);
     }
+
+    try {
+      selectTodaySentence();
+    } catch (Exception e) {
+      log.error("오늘의 문장 선정 실패: {}", e.getMessage(), e);
+    }
+    log.info("일일 스케줄러 완료");
   }
 
   @EventListener(ApplicationReadyEvent.class)
@@ -75,11 +80,7 @@ public class DailySentenceScheduler {
     DailySentence sentence =
         dailySentenceRepository
             .findRandomUnusedSentence()
-            .orElseThrow(
-                () -> {
-                  log.error("사용 가능한 문장이 없음 — 문장 추가 필요");
-                  return new IllegalStateException("사용 가능한 문장이 없습니다");
-                });
+            .orElseThrow(() -> new IllegalStateException("사용 가능한 문장이 없음 — 문장 추가 필요"));
 
     sentence.setUsedAt(today);
     dailySentenceRepository.save(sentence);

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -257,9 +257,7 @@ public class DailyGameService {
       throw switch (session.getStatus()) {
         case CLEARED -> new BusinessException(ErrorCode.GAME_ALREADY_CLEARED);
         case GIVEN_UP -> new BusinessException(ErrorCode.GAME_ALREADY_GIVEN_UP);
-        case EXPIRED ->
-            new BusinessException(
-                ErrorCode.GAME_EXPIRED); // 자정 스케줄러에서 IN_PROGRESS → EXPIRED 일괄 전이 예정
+        case EXPIRED -> new BusinessException(ErrorCode.GAME_EXPIRED);
         default -> new IllegalStateException("도달할 수 없는 상태: " + session.getStatus());
       };
     }


### PR DESCRIPTION
## 관련 이슈

Closes #25 

## 변경 사항

- KST 자정에 미사용 ACTIVE 문장 중 랜덤 선정, `used_at` 기록
- 전날 IN_PROGRESS 게임 세션 일괄 EXPIRED 처리
- 세션 만료와 문장 선정을 별도 `@Transactional`로 분리 (문장 소진 시 세션 만료 롤백 방지)
- 서버 재기동 시 오늘 문장 미선정이면 즉시 선정 (`ApplicationReadyEvent`)
- `BackendApplication`에 `@EnableScheduling` 추가
- `DailyGameService.validateInProgress()` 스케줄러 예정 주석 제거
- 코드 리뷰 반영: try-catch 분리 (세션 만료 실패 시에도 문장 선정 진행), 중복 로깅 제거

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
