### PR TITLE
feat: 포기 시 정답 비공개 및 어제의 정답 공개

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/GiveUpResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/GiveUpResponse.java
@@ -2,5 +2,4 @@ package com.gakkaweo.backend.game.dto;
 
 import java.math.BigDecimal;
 
-public record GiveUpResponse(
-    String sentence, int attemptCount, BigDecimal bestSimilarity, String gameStatus) {}
+public record GiveUpResponse(int attemptCount, BigDecimal bestSimilarity, String gameStatus) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/TodayResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/TodayResponse.java
@@ -1,8 +1,15 @@
 package com.gakkaweo.backend.game.dto;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 public record TodayResponse(
-    UUID sentenceId, String hintMask, int wordCount, List<Integer> charCounts, Instant expiresAt) {}
+    UUID sentenceId,
+    String hintMask,
+    int wordCount,
+    List<Integer> charCounts,
+    Instant expiresAt,
+    String yesterdaySentence,
+    LocalDate yesterdayDate) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -10,7 +10,7 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Component
 @Slf4j
@@ -20,25 +20,28 @@ public class DailySentenceScheduler {
 
   private final DailySentenceRepository dailySentenceRepository;
   private final GameSessionRepository gameSessionRepository;
+  private final TransactionTemplate transactionTemplate;
 
   public DailySentenceScheduler(
       DailySentenceRepository dailySentenceRepository,
-      GameSessionRepository gameSessionRepository) {
+      GameSessionRepository gameSessionRepository,
+      TransactionTemplate transactionTemplate) {
     this.dailySentenceRepository = dailySentenceRepository;
     this.gameSessionRepository = gameSessionRepository;
+    this.transactionTemplate = transactionTemplate;
   }
 
   @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
   public void selectDailySentence() {
     log.info("일일 스케줄러 시작");
     try {
-      expireYesterdaySessions();
+      transactionTemplate.executeWithoutResult(status -> expireYesterdaySessions());
     } catch (Exception e) {
       log.error("전날 세션 만료 처리 실패: {}", e.getMessage(), e);
     }
 
     try {
-      selectTodaySentence();
+      transactionTemplate.executeWithoutResult(status -> selectTodaySentence());
     } catch (Exception e) {
       log.error("오늘의 문장 선정 실패: {}", e.getMessage(), e);
     }
@@ -54,8 +57,7 @@ public class DailySentenceScheduler {
     }
   }
 
-  @Transactional
-  public void expireYesterdaySessions() {
+  private void expireYesterdaySessions() {
     LocalDate yesterday = LocalDate.now(KST).minusDays(1);
     dailySentenceRepository
         .findByUsedAt(yesterday)
@@ -68,8 +70,7 @@ public class DailySentenceScheduler {
             });
   }
 
-  @Transactional
-  public void selectTodaySentence() {
+  private void selectTodaySentence() {
     LocalDate today = LocalDate.now(KST);
 
     if (dailySentenceRepository.findByUsedAt(today).isPresent()) {

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -70,12 +70,21 @@ public class DailyGameService {
 
     Instant expiresAt = LocalDate.now(KST).plusDays(1).atStartOfDay(KST).toInstant();
 
+    LocalDate yesterday = LocalDate.now(KST).minusDays(1);
+    String yesterdaySentence =
+        dailySentenceRepository
+            .findByUsedAt(yesterday)
+            .map(DailySentence::getSentence)
+            .orElse(null);
+
     return new TodayResponse(
         sentence.getPublicId(),
         hint.mask(),
         hint.charCounts().size(),
         hint.charCounts(),
-        expiresAt);
+        expiresAt,
+        yesterdaySentence,
+        yesterdaySentence != null ? yesterday : null);
   }
 
   @Transactional
@@ -150,10 +159,7 @@ public class DailyGameService {
     log.info("게임 포기: memberId={}, sentenceId={}", memberPublicId, sentenceId);
 
     return new GiveUpResponse(
-        sentence.getSentence(),
-        session.getAttemptCount(),
-        session.getBestSimilarity(),
-        session.getStatus().name());
+        session.getAttemptCount(), session.getBestSimilarity(), session.getStatus().name());
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
## 관련 이슈

Closes #27 

## 변경 사항

- `GiveUpResponse`에서 `sentence` 필드 제거 — 포기해도 정답을 알 수 없도록 변경
- `TodayResponse`에 `yesterdaySentence`, `yesterdayDate` 필드 추가 — 다음 날 어제의 정답 일괄 공개
- `DailyGameService.getToday()`에서 어제 출제 문장 조회 로직 추가
- `DailySentenceScheduler`의 `@Transactional` self-invocation 버그를 `TransactionTemplate`으로 수정

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- 어뷰징 시나리오: 포기 → 정답 확인 → 커뮤니티 공유 → 타 사용자 1트 클리어
- self-invocation 문제: 같은 클래스 내 `@Transactional` 메서드 호출 시 프록시를 거치지 않아 트랜잭션 미적용