### PR TITLE
feat: 클리어 후 추가 시도 허용 로직 구현

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -92,6 +92,10 @@ public class GameSession {
     return this.status == GameSessionStatus.IN_PROGRESS;
   }
 
+  public boolean isCleared() {
+    return this.status == GameSessionStatus.CLEARED;
+  }
+
   @PrePersist
   protected void onCreate() {
     this.createdAt = Instant.now();

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GuessHistoryRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GuessHistoryRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GuessHistoryRepository extends JpaRepository<GuessHistory, Long> {
 
   List<GuessHistory> findBySessionOrderByAttemptNumberAsc(GameSession session);
+
+  long countBySession(GameSession session);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -94,7 +94,7 @@ public class DailyGameService {
 
     GameSession session = findOrCreateSession(member, sentence);
 
-    validateInProgress(session);
+    validateGuessAllowed(session);
 
     BigDecimal similarity =
         similarityService.calculateSimilarity(
@@ -102,14 +102,18 @@ public class DailyGameService {
 
     boolean isCorrect = similarity.compareTo(gameProperties.getSimilarityThreshold()) >= 0;
 
-    session.incrementAttempt();
-    session.updateBestSimilarity(similarity);
-    if (isCorrect) {
-      session.markCleared();
+    if (session.isInProgress()) {
+      session.incrementAttempt();
+      if (isCorrect) {
+        session.markCleared();
+      }
     }
+    session.updateBestSimilarity(similarity);
+
+    int guessSequence = (int) guessHistoryRepository.countBySession(session) + 1;
 
     guessHistoryRepository.save(
-        new GuessHistory(session, request.guessText(), similarity, session.getAttemptCount()));
+        new GuessHistory(session, request.guessText(), similarity, guessSequence));
 
     gameSessionRepository.save(session);
 
@@ -256,6 +260,17 @@ public class DailyGameService {
     return memberRepository
         .findByPublicId(publicId)
         .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+  }
+
+  private void validateGuessAllowed(GameSession session) {
+    if (session.isInProgress() || session.isCleared()) {
+      return;
+    }
+    throw switch (session.getStatus()) {
+      case GIVEN_UP -> new BusinessException(ErrorCode.GAME_ALREADY_GIVEN_UP);
+      case EXPIRED -> new BusinessException(ErrorCode.GAME_EXPIRED);
+      default -> new IllegalStateException("도달할 수 없는 상태: " + session.getStatus());
+    };
   }
 
   private void validateInProgress(GameSession session) {


### PR DESCRIPTION
## 관련 이슈

Closes #29 

## 변경 사항

- `GameSession.isCleared()` 편의 메서드 추가
- `GuessHistoryRepository.countBySession()` 추가
- `DailyGameService`에 `validateGuessAllowed()` 메서드 추가하여 CLEARED 상태에서 추가 추측 허용
- IN_PROGRESS일 때만 `attemptCount` 증가 및 `markCleared()` 수행, CLEARED 시 동결
- `attemptNumber`를 `countBySession + 1` 기반 연속 번호로 변경하여 post-clear 추측도 순번 보장
- CLEARED 후 포기는 기존대로 차단 (`validateInProgress` 유지)

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- 랭킹 시스템에서 `attemptCount`를 "N번째 시도에 클리어"로 사용할 예정
- `bestSimilarity`만 갱신되므로 클리어 후 더 높은 유사도에 도전 가능
