### PR TITLE
feat: 랭킹 REST API 구현

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -62,6 +62,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/daily/guess")
                     .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/ranking/today")
+                    .permitAll()
                     .requestMatchers("/daily/**")
                     .authenticated()
                     .anyRequest()

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.game.scheduler;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
 import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import com.gakkaweo.backend.ranking.service.RankingService;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import lombok.extern.slf4j.Slf4j;
@@ -20,14 +21,17 @@ public class DailySentenceScheduler {
 
   private final DailySentenceRepository dailySentenceRepository;
   private final GameSessionRepository gameSessionRepository;
+  private final RankingService rankingService;
   private final TransactionTemplate transactionTemplate;
 
   public DailySentenceScheduler(
       DailySentenceRepository dailySentenceRepository,
       GameSessionRepository gameSessionRepository,
+      RankingService rankingService,
       TransactionTemplate transactionTemplate) {
     this.dailySentenceRepository = dailySentenceRepository;
     this.gameSessionRepository = gameSessionRepository;
+    this.rankingService = rankingService;
     this.transactionTemplate = transactionTemplate;
   }
 
@@ -38,6 +42,13 @@ public class DailySentenceScheduler {
       transactionTemplate.executeWithoutResult(status -> expireYesterdaySessions());
     } catch (Exception e) {
       log.error("전날 세션 만료 처리 실패: {}", e.getMessage(), e);
+    }
+
+    try {
+      LocalDate yesterday = LocalDate.now(KST).minusDays(1);
+      rankingService.expirePreviousDayRankingKeys(yesterday);
+    } catch (Exception e) {
+      log.error("전날 랭킹 키 만료 처리 실패: {}", e.getMessage(), e);
     }
 
     try {

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -19,6 +19,7 @@ import com.gakkaweo.backend.game.dto.GuessResponse;
 import com.gakkaweo.backend.game.dto.TodayResponse;
 import com.gakkaweo.backend.game.util.HintMaskGenerator;
 import com.gakkaweo.backend.infra.ai.service.SimilarityService;
+import com.gakkaweo.backend.ranking.service.RankingService;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
@@ -43,6 +44,7 @@ public class DailyGameService {
   private final GuessHistoryRepository guessHistoryRepository;
   private final MemberRepository memberRepository;
   private final SimilarityService similarityService;
+  private final RankingService rankingService;
   private final HintMaskGenerator hintMaskGenerator;
   private final GameProperties gameProperties;
 
@@ -52,6 +54,7 @@ public class DailyGameService {
       GuessHistoryRepository guessHistoryRepository,
       MemberRepository memberRepository,
       SimilarityService similarityService,
+      RankingService rankingService,
       HintMaskGenerator hintMaskGenerator,
       GameProperties gameProperties) {
     this.dailySentenceRepository = dailySentenceRepository;
@@ -59,6 +62,7 @@ public class DailyGameService {
     this.guessHistoryRepository = guessHistoryRepository;
     this.memberRepository = memberRepository;
     this.similarityService = similarityService;
+    this.rankingService = rankingService;
     this.hintMaskGenerator = hintMaskGenerator;
     this.gameProperties = gameProperties;
   }
@@ -102,6 +106,8 @@ public class DailyGameService {
 
     boolean isCorrect = similarity.compareTo(gameProperties.getSimilarityThreshold()) >= 0;
 
+    BigDecimal previousBest = session.getBestSimilarity();
+
     if (session.isInProgress()) {
       session.incrementAttempt();
       if (isCorrect) {
@@ -116,6 +122,10 @@ public class DailyGameService {
         new GuessHistory(session, request.guessText(), similarity, guessSequence));
 
     gameSessionRepository.save(session);
+
+    if (similarity.compareTo(previousBest) > 0) {
+      rankingService.updateRanking(session, member);
+    }
 
     log.info(
         "추측 제출: memberId={}, sentenceId={}, similarity={}, isCorrect={}",

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/controller/RankingController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/controller/RankingController.java
@@ -1,0 +1,24 @@
+package com.gakkaweo.backend.ranking.controller;
+
+import com.gakkaweo.backend.ranking.dto.RankingResponse;
+import com.gakkaweo.backend.ranking.service.RankingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ranking")
+public class RankingController {
+
+  private final RankingService rankingService;
+
+  public RankingController(RankingService rankingService) {
+    this.rankingService = rankingService;
+  }
+
+  @GetMapping("/today")
+  public ResponseEntity<RankingResponse> getTodayRanking() {
+    return ResponseEntity.ok(rankingService.getRankings());
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/dto/RankingResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/dto/RankingResponse.java
@@ -1,0 +1,11 @@
+package com.gakkaweo.backend.ranking.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public record RankingResponse(List<RankingEntry> rankings, long totalPlayers) {
+
+  public record RankingEntry(
+      long rank, UUID publicId, String nickname, BigDecimal similarity, int attemptCount) {}
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -1,0 +1,176 @@
+package com.gakkaweo.backend.ranking.service;
+
+import com.gakkaweo.backend.domain.game.entity.GameSession;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.ranking.dto.RankingResponse;
+import com.gakkaweo.backend.ranking.dto.RankingResponse.RankingEntry;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class RankingService {
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+  private static final String RANKING_KEY_PREFIX = "ranking:";
+  private static final String DETAIL_KEY_PREFIX = "ranking_detail:";
+  private static final String MEMBER_PREFIX = "member:";
+  private static final int TOP_RANKING_SIZE = 10;
+  private static final Duration EXPIRE_TTL = Duration.ofHours(1);
+
+  private final StringRedisTemplate redisTemplate;
+
+  public RankingService(StringRedisTemplate redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  public Integer updateRanking(GameSession session, Member member) {
+    try {
+      LocalDate today = LocalDate.now(KST);
+      String rankingKey = buildRankingKey(today);
+      String memberKey = MEMBER_PREFIX + member.getPublicId();
+      String detailKey = buildDetailKey(today, member.getPublicId());
+
+      long elapsedSeconds = calculateElapsedSeconds();
+      double score =
+          encodeScore(session.getBestSimilarity(), session.getAttemptCount(), elapsedSeconds);
+
+      redisTemplate.opsForZSet().add(rankingKey, memberKey, score);
+
+      Map<String, String> detail =
+          Map.of(
+              "publicId", member.getPublicId().toString(),
+              "nickname", member.getNickname(),
+              "similarity", session.getBestSimilarity().toPlainString(),
+              "attemptCount", String.valueOf(session.getAttemptCount()),
+              "elapsedSeconds", String.valueOf(elapsedSeconds));
+      redisTemplate.opsForHash().putAll(detailKey, detail);
+
+      Long rank = redisTemplate.opsForZSet().reverseRank(rankingKey, memberKey);
+      if (rank != null) {
+        return rank.intValue() + 1;
+      }
+      return null;
+    } catch (Exception e) {
+      log.warn("랭킹 갱신 실패: memberId={}, {}", member.getPublicId(), e.getMessage());
+      return null;
+    }
+  }
+
+  public Integer getMemberRank(UUID memberPublicId) {
+    try {
+      LocalDate today = LocalDate.now(KST);
+      String rankingKey = buildRankingKey(today);
+      String memberKey = MEMBER_PREFIX + memberPublicId;
+
+      Long rank = redisTemplate.opsForZSet().reverseRank(rankingKey, memberKey);
+      if (rank != null) {
+        return rank.intValue() + 1;
+      }
+      return null;
+    } catch (Exception e) {
+      log.warn("랭킹 조회 실패: memberId={}, {}", memberPublicId, e.getMessage());
+      return null;
+    }
+  }
+
+  public RankingResponse getRankings() {
+    try {
+      LocalDate today = LocalDate.now(KST);
+      String rankingKey = buildRankingKey(today);
+
+      Set<String> topMembers =
+          redisTemplate.opsForZSet().reverseRange(rankingKey, 0, TOP_RANKING_SIZE - 1);
+
+      Long totalPlayers = redisTemplate.opsForZSet().zCard(rankingKey);
+      if (totalPlayers == null) {
+        totalPlayers = 0L;
+      }
+
+      if (topMembers == null || topMembers.isEmpty()) {
+        return new RankingResponse(List.of(), totalPlayers);
+      }
+
+      List<RankingEntry> entries = new ArrayList<>();
+      long rank = 1;
+      for (String memberKey : topMembers) {
+        String publicIdStr = memberKey.replace(MEMBER_PREFIX, "");
+        String detailKey = buildDetailKey(today, UUID.fromString(publicIdStr));
+
+        Map<Object, Object> detail = redisTemplate.opsForHash().entries(detailKey);
+        if (detail.isEmpty()) {
+          rank++;
+          continue;
+        }
+
+        entries.add(
+            new RankingEntry(
+                rank,
+                UUID.fromString((String) detail.get("publicId")),
+                (String) detail.get("nickname"),
+                new BigDecimal((String) detail.get("similarity")),
+                Integer.parseInt((String) detail.get("attemptCount"))));
+        rank++;
+      }
+
+      return new RankingResponse(entries, totalPlayers);
+    } catch (Exception e) {
+      log.warn("랭킹 목록 조회 실패: {}", e.getMessage());
+      return new RankingResponse(List.of(), 0);
+    }
+  }
+
+  public void expirePreviousDayRankingKeys(LocalDate date) {
+    try {
+      String rankingKey = buildRankingKey(date);
+      redisTemplate.expire(rankingKey, EXPIRE_TTL);
+
+      String detailPattern = DETAIL_KEY_PREFIX + date + ":*";
+      Set<String> detailKeys = redisTemplate.keys(detailPattern);
+      if (detailKeys != null && !detailKeys.isEmpty()) {
+        for (String key : detailKeys) {
+          redisTemplate.expire(key, EXPIRE_TTL);
+        }
+      }
+
+      log.info(
+          "전날 랭킹 키 TTL 설정: date={}, detailKeys={}",
+          date,
+          detailKeys != null ? detailKeys.size() : 0);
+    } catch (Exception e) {
+      log.warn("전날 랭킹 키 만료 처리 실패: {}", e.getMessage());
+      throw e;
+    }
+  }
+
+  private double encodeScore(BigDecimal similarity, int attemptCount, long elapsedSeconds) {
+    long similarityComponent = similarity.multiply(BigDecimal.TEN).longValue() * 1_000_000_000L;
+    long attemptComponent = (long) attemptCount * 100_000L;
+    return similarityComponent - attemptComponent - elapsedSeconds;
+  }
+
+  private long calculateElapsedSeconds() {
+    ZonedDateTime now = ZonedDateTime.now(KST);
+    ZonedDateTime startOfDay = now.toLocalDate().atStartOfDay(KST);
+    return Duration.between(startOfDay, now).getSeconds();
+  }
+
+  private String buildRankingKey(LocalDate date) {
+    return RANKING_KEY_PREFIX + date;
+  }
+
+  private String buildDetailKey(LocalDate date, UUID memberPublicId) {
+    return DETAIL_KEY_PREFIX + date + ":" + MEMBER_PREFIX + memberPublicId;
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -68,23 +68,6 @@ public class RankingService {
     }
   }
 
-  public Integer getMemberRank(UUID memberPublicId) {
-    try {
-      LocalDate today = LocalDate.now(KST);
-      String rankingKey = buildRankingKey(today);
-      String memberKey = MEMBER_PREFIX + memberPublicId;
-
-      Long rank = redisTemplate.opsForZSet().reverseRank(rankingKey, memberKey);
-      if (rank != null) {
-        return rank.intValue() + 1;
-      }
-      return null;
-    } catch (Exception e) {
-      log.warn("랭킹 조회 실패: memberId={}, {}", memberPublicId, e.getMessage());
-      return null;
-    }
-  }
-
   public RankingResponse getRankings() {
     try {
       LocalDate today = LocalDate.now(KST);
@@ -105,12 +88,11 @@ public class RankingService {
       List<RankingEntry> entries = new ArrayList<>();
       long rank = 1;
       for (String memberKey : topMembers) {
-        String publicIdStr = memberKey.replace(MEMBER_PREFIX, "");
+        String publicIdStr = memberKey.substring(MEMBER_PREFIX.length());
         String detailKey = buildDetailKey(today, UUID.fromString(publicIdStr));
 
         Map<Object, Object> detail = redisTemplate.opsForHash().entries(detailKey);
         if (detail.isEmpty()) {
-          rank++;
           continue;
         }
 
@@ -132,26 +114,22 @@ public class RankingService {
   }
 
   public void expirePreviousDayRankingKeys(LocalDate date) {
-    try {
-      String rankingKey = buildRankingKey(date);
-      redisTemplate.expire(rankingKey, EXPIRE_TTL);
+    String rankingKey = buildRankingKey(date);
 
-      String detailPattern = DETAIL_KEY_PREFIX + date + ":*";
-      Set<String> detailKeys = redisTemplate.keys(detailPattern);
-      if (detailKeys != null && !detailKeys.isEmpty()) {
-        for (String key : detailKeys) {
-          redisTemplate.expire(key, EXPIRE_TTL);
-        }
+    Set<String> members = redisTemplate.opsForZSet().range(rankingKey, 0, -1);
+    int detailCount = 0;
+    if (members != null) {
+      for (String memberKey : members) {
+        String publicIdStr = memberKey.substring(MEMBER_PREFIX.length());
+        String detailKey = buildDetailKey(date, UUID.fromString(publicIdStr));
+        redisTemplate.expire(detailKey, EXPIRE_TTL);
+        detailCount++;
       }
-
-      log.info(
-          "전날 랭킹 키 TTL 설정: date={}, detailKeys={}",
-          date,
-          detailKeys != null ? detailKeys.size() : 0);
-    } catch (Exception e) {
-      log.warn("전날 랭킹 키 만료 처리 실패: {}", e.getMessage());
-      throw e;
     }
+
+    redisTemplate.expire(rankingKey, EXPIRE_TTL);
+
+    log.info("전날 랭킹 키 TTL 설정: date={}, detailKeys={}", date, detailCount);
   }
 
   private double encodeScore(BigDecimal similarity, int attemptCount, long elapsedSeconds) {


### PR DESCRIPTION
## 관련 이슈

Closes #31 

## 변경 사항

- `ranking/` 패키지 신규 생성 (controller, service, dto)
- Redis Sorted Set(`ranking:{날짜}`) + Hash(`ranking_detail:{날짜}:member:{publicId}`)로 랭킹 데이터 저장
- 스코어 인코딩: `similarity×10 × 1,000,000,000 - attemptCount × 100,000 - elapsedSeconds`
- `GET /ranking/today` — 상위 10명 조회 (닉네임 원본 노출, permitAll)
- `DailyGameService` — 추측 시 유사도 개선되면 `RankingService.updateRanking()` 호출
- `DailySentenceScheduler` — 자정에 전날 랭킹 키 TTL 1시간 설정
- Redis 실패 시 경고 로그 + 계속 (SimilarityService와 동일 패턴)
- GuessResponse에 rank 미포함 — 순위 정보는 SSE(별도 이슈)에서 전담
- (코드리뷰 반영) `KEYS` 명령어 → Sorted Set 멤버 기반 detail 키 유도로 교체
- (코드리뷰 반영) 랭크 번호 건너뛰기 수정, `replace` → `substring`, 이중 로깅 제거, 미사용 메서드 삭제

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
