### PR TITLE
chore: GIVE_UP(포기) 기능 제거

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
@@ -20,7 +20,6 @@ public enum ErrorCode {
   SENTENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "오늘의 문제를 찾을 수 없습니다"),
   SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "게임 세션을 찾을 수 없습니다"),
   GAME_ALREADY_CLEARED(HttpStatus.CONFLICT, "이미 정답을 맞춘 게임입니다"),
-  GAME_ALREADY_GIVEN_UP(HttpStatus.CONFLICT, "이미 포기한 게임입니다"),
   GAME_EXPIRED(HttpStatus.CONFLICT, "만료된 게임입니다"),
   CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "동시 수정 충돌이 발생했습니다");
 

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -84,10 +84,6 @@ public class GameSession {
     this.clearedAt = Instant.now();
   }
 
-  public void markGivenUp() {
-    this.status = GameSessionStatus.GIVEN_UP;
-  }
-
   public boolean isInProgress() {
     return this.status == GameSessionStatus.IN_PROGRESS;
   }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSessionStatus.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSessionStatus.java
@@ -3,6 +3,5 @@ package com.gakkaweo.backend.domain.game.entity;
 public enum GameSessionStatus {
   IN_PROGRESS,
   CLEARED,
-  GIVEN_UP,
   EXPIRED
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/controller/DailyGameController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/controller/DailyGameController.java
@@ -2,7 +2,6 @@ package com.gakkaweo.backend.game.controller;
 
 import com.gakkaweo.backend.auth.security.CustomUserDetails;
 import com.gakkaweo.backend.game.dto.GameStatusResponse;
-import com.gakkaweo.backend.game.dto.GiveUpResponse;
 import com.gakkaweo.backend.game.dto.GuessHistoryResponse;
 import com.gakkaweo.backend.game.dto.GuessRequest;
 import com.gakkaweo.backend.game.dto.GuessResponse;
@@ -42,12 +41,6 @@ public class DailyGameController {
       return ResponseEntity.ok(dailyGameService.guessAnonymous(request));
     }
     return ResponseEntity.ok(dailyGameService.guessAuthenticated(request, userDetails.publicId()));
-  }
-
-  @PostMapping("/give-up")
-  public ResponseEntity<GiveUpResponse> giveUp(
-      @RequestParam UUID sentenceId, @AuthenticationPrincipal CustomUserDetails userDetails) {
-    return ResponseEntity.ok(dailyGameService.giveUp(sentenceId, userDetails.publicId()));
   }
 
   @GetMapping("/history")

--- a/backend/src/main/java/com/gakkaweo/backend/game/dto/GiveUpResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/dto/GiveUpResponse.java
@@ -1,5 +1,0 @@
-package com.gakkaweo.backend.game.dto;
-
-import java.math.BigDecimal;
-
-public record GiveUpResponse(int attemptCount, BigDecimal bestSimilarity, String gameStatus) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -12,7 +12,6 @@ import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import com.gakkaweo.backend.game.config.GameProperties;
 import com.gakkaweo.backend.game.dto.GameStatusResponse;
-import com.gakkaweo.backend.game.dto.GiveUpResponse;
 import com.gakkaweo.backend.game.dto.GuessHistoryResponse;
 import com.gakkaweo.backend.game.dto.GuessRequest;
 import com.gakkaweo.backend.game.dto.GuessResponse;
@@ -155,27 +154,6 @@ public class DailyGameService {
     return new GuessResponse(similarity, null, isCorrect, null, Instant.now());
   }
 
-  @Transactional
-  public GiveUpResponse giveUp(UUID sentenceId, UUID memberPublicId) {
-    DailySentence sentence = findTodaySentenceByPublicId(sentenceId);
-    Member member = findMember(memberPublicId);
-
-    GameSession session =
-        gameSessionRepository
-            .findByMemberAndSentence(member, sentence)
-            .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
-
-    validateInProgress(session);
-
-    session.markGivenUp();
-    gameSessionRepository.save(session);
-
-    log.info("게임 포기: memberId={}, sentenceId={}", memberPublicId, sentenceId);
-
-    return new GiveUpResponse(
-        session.getAttemptCount(), session.getBestSimilarity(), session.getStatus().name());
-  }
-
   @Transactional(readOnly = true)
   public GuessHistoryResponse getHistory(UUID sentenceId, UUID memberPublicId) {
     DailySentence sentence = findTodaySentenceByPublicId(sentenceId);
@@ -277,20 +255,8 @@ public class DailyGameService {
       return;
     }
     throw switch (session.getStatus()) {
-      case GIVEN_UP -> new BusinessException(ErrorCode.GAME_ALREADY_GIVEN_UP);
       case EXPIRED -> new BusinessException(ErrorCode.GAME_EXPIRED);
       default -> new IllegalStateException("도달할 수 없는 상태: " + session.getStatus());
     };
-  }
-
-  private void validateInProgress(GameSession session) {
-    if (!session.isInProgress()) {
-      throw switch (session.getStatus()) {
-        case CLEARED -> new BusinessException(ErrorCode.GAME_ALREADY_CLEARED);
-        case GIVEN_UP -> new BusinessException(ErrorCode.GAME_ALREADY_GIVEN_UP);
-        case EXPIRED -> new BusinessException(ErrorCode.GAME_EXPIRED);
-        default -> new IllegalStateException("도달할 수 없는 상태: " + session.getStatus());
-      };
-    }
   }
 }


### PR DESCRIPTION
## 관련 이슈

Closes #33 

## 변경 사항

- `GameSessionStatus`에서 `GIVEN_UP` 제거 → IN_PROGRESS, CLEARED, EXPIRED 3개로 단순화
- `GameSession.markGivenUp()` 메서드 삭제
- `ErrorCode.GAME_ALREADY_GIVEN_UP` 삭제
- `GiveUpResponse` DTO 파일 삭제
- `DailyGameService`에서 `giveUp()`, `validateInProgress()` 삭제, `validateGuessAllowed()`의 GIVEN_UP 분기 제거
- `DailyGameController`에서 `POST /daily/give-up` 엔드포인트 삭제

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- 기존 DB의 GIVEN_UP 데이터는 수동 처리 (개발 중이라 Flyway 불필요)
- SecurityConfig 변경 불필요 (`/daily/**` 와일드카드가 나머지 엔드포인트 커버)

