### PR TITLE
feat: 자정 랭킹 DB 스냅샷 구현

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
@@ -49,6 +49,8 @@ public class DailySentence {
   @Column(length = 20)
   private DailySentenceStatus status = DailySentenceStatus.ACTIVE;
 
+  @Setter private Integer totalPlayers;
+
   private Instant createdAt;
 
   public DailySentence(String sentence) {

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
@@ -49,12 +49,16 @@ public class DailySentence {
   @Column(length = 20)
   private DailySentenceStatus status = DailySentenceStatus.ACTIVE;
 
-  @Setter private Integer totalPlayers;
+  private Integer totalPlayers;
 
   private Instant createdAt;
 
   public DailySentence(String sentence) {
     this.sentence = sentence;
+  }
+
+  public void recordTotalPlayers(int totalPlayers) {
+    this.totalPlayers = totalPlayers;
   }
 
   @PrePersist

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -58,6 +58,8 @@ public class GameSession {
 
   private Instant clearedAt;
 
+  private Integer finalRank;
+
   @Version private Integer version;
 
   private Instant createdAt;
@@ -90,6 +92,10 @@ public class GameSession {
 
   public boolean isCleared() {
     return this.status == GameSessionStatus.CLEARED;
+  }
+
+  public void recordFinalRank(int finalRank) {
+    this.finalRank = finalRank;
   }
 
   @PrePersist

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GameSessionRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GameSessionRepository.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.domain.game.repository;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.entity.GameSession;
 import com.gakkaweo.backend.domain.member.entity.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -21,4 +22,7 @@ public interface GameSessionRepository extends JpaRepository<GameSession, Long> 
           + " AND g.status ="
           + " com.gakkaweo.backend.domain.game.entity.GameSessionStatus.IN_PROGRESS")
   int expireInProgressSessions(@Param("sentence") DailySentence sentence);
+
+  @Query("SELECT g FROM GameSession g JOIN FETCH g.member WHERE g.sentence = :sentence")
+  List<GameSession> findAllBySentenceWithMember(@Param("sentence") DailySentence sentence);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -52,17 +52,22 @@ public class DailySentenceScheduler {
       log.error("전날 세션 만료 처리 실패: {}", e.getMessage(), e);
     }
 
+    LocalDate yesterday = LocalDate.now(KST).minusDays(1);
+    boolean snapshotSuccess = false;
     try {
-      transactionTemplate.executeWithoutResult(status -> snapshotYesterdayRankings());
+      RankingSnapshot snapshot = rankingService.getAllRankingsForDate(yesterday);
+      transactionTemplate.executeWithoutResult(status -> saveRankingSnapshot(yesterday, snapshot));
+      snapshotSuccess = true;
     } catch (Exception e) {
       log.error("전날 랭킹 스냅샷 저장 실패: {}", e.getMessage(), e);
     }
 
-    try {
-      LocalDate yesterday = LocalDate.now(KST).minusDays(1);
-      rankingService.expirePreviousDayRankingKeys(yesterday);
-    } catch (Exception e) {
-      log.error("전날 랭킹 키 만료 처리 실패: {}", e.getMessage(), e);
+    if (snapshotSuccess) {
+      try {
+        rankingService.expirePreviousDayRankingKeys(yesterday);
+      } catch (Exception e) {
+        log.error("전날 랭킹 키 만료 처리 실패: {}", e.getMessage(), e);
+      }
     }
 
     try {
@@ -95,10 +100,7 @@ public class DailySentenceScheduler {
             });
   }
 
-  private void snapshotYesterdayRankings() {
-    LocalDate yesterday = LocalDate.now(KST).minusDays(1);
-
-    RankingSnapshot snapshot = rankingService.getAllRankingsForDate(yesterday);
+  private void saveRankingSnapshot(LocalDate yesterday, RankingSnapshot snapshot) {
     if (snapshot.memberRanks().isEmpty()) {
       log.info("전날 랭킹 스냅샷: 데이터 없음, date={}", yesterday);
       return;
@@ -110,7 +112,7 @@ public class DailySentenceScheduler {
       return;
     }
 
-    sentence.setTotalPlayers(snapshot.totalPlayers());
+    sentence.recordTotalPlayers(snapshot.totalPlayers());
     dailySentenceRepository.save(sentence);
 
     List<GameSession> sessions = gameSessionRepository.findAllBySentenceWithMember(sentence);

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -1,11 +1,19 @@
 package com.gakkaweo.backend.game.scheduler;
 
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.GameSession;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
 import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import com.gakkaweo.backend.ranking.dto.RankingSnapshot;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
@@ -45,6 +53,12 @@ public class DailySentenceScheduler {
     }
 
     try {
+      transactionTemplate.executeWithoutResult(status -> snapshotYesterdayRankings());
+    } catch (Exception e) {
+      log.error("전날 랭킹 스냅샷 저장 실패: {}", e.getMessage(), e);
+    }
+
+    try {
       LocalDate yesterday = LocalDate.now(KST).minusDays(1);
       rankingService.expirePreviousDayRankingKeys(yesterday);
     } catch (Exception e) {
@@ -79,6 +93,46 @@ public class DailySentenceScheduler {
                 log.info("전날 세션 만료 처리: date={}, count={}", yesterday, count);
               }
             });
+  }
+
+  private void snapshotYesterdayRankings() {
+    LocalDate yesterday = LocalDate.now(KST).minusDays(1);
+
+    RankingSnapshot snapshot = rankingService.getAllRankingsForDate(yesterday);
+    if (snapshot.memberRanks().isEmpty()) {
+      log.info("전날 랭킹 스냅샷: 데이터 없음, date={}", yesterday);
+      return;
+    }
+
+    DailySentence sentence = dailySentenceRepository.findByUsedAt(yesterday).orElse(null);
+    if (sentence == null) {
+      log.warn("전날 문장 미발견, 랭킹 스냅샷 건너뜀: date={}", yesterday);
+      return;
+    }
+
+    sentence.setTotalPlayers(snapshot.totalPlayers());
+    dailySentenceRepository.save(sentence);
+
+    List<GameSession> sessions = gameSessionRepository.findAllBySentenceWithMember(sentence);
+    Map<UUID, GameSession> sessionByPublicId =
+        sessions.stream()
+            .collect(Collectors.toMap(s -> s.getMember().getPublicId(), Function.identity()));
+
+    List<GameSession> updatedSessions = new ArrayList<>();
+    for (RankingSnapshot.MemberRank mr : snapshot.memberRanks()) {
+      GameSession session = sessionByPublicId.get(mr.publicId());
+      if (session != null) {
+        session.recordFinalRank(mr.rank());
+        updatedSessions.add(session);
+      }
+    }
+
+    gameSessionRepository.saveAll(updatedSessions);
+    log.info(
+        "전날 랭킹 스냅샷 저장: date={}, updated={}, totalPlayers={}",
+        yesterday,
+        updatedSessions.size(),
+        snapshot.totalPlayers());
   }
 
   private void selectTodaySentence() {

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/dto/RankingSnapshot.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/dto/RankingSnapshot.java
@@ -1,0 +1,9 @@
+package com.gakkaweo.backend.ranking.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record RankingSnapshot(List<MemberRank> memberRanks, int totalPlayers) {
+
+  public record MemberRank(UUID publicId, int rank) {}
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -4,6 +4,7 @@ import com.gakkaweo.backend.domain.game.entity.GameSession;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.ranking.dto.RankingResponse;
 import com.gakkaweo.backend.ranking.dto.RankingResponse.RankingEntry;
+import com.gakkaweo.backend.ranking.dto.RankingSnapshot;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -110,6 +111,33 @@ public class RankingService {
     } catch (Exception e) {
       log.warn("랭킹 목록 조회 실패: {}", e.getMessage());
       return new RankingResponse(List.of(), 0);
+    }
+  }
+
+  public RankingSnapshot getAllRankingsForDate(LocalDate date) {
+    try {
+      String rankingKey = buildRankingKey(date);
+      Long totalPlayers = redisTemplate.opsForZSet().zCard(rankingKey);
+      if (totalPlayers == null || totalPlayers == 0) {
+        return new RankingSnapshot(List.of(), 0);
+      }
+
+      Set<String> allMembers = redisTemplate.opsForZSet().reverseRange(rankingKey, 0, -1);
+      if (allMembers == null || allMembers.isEmpty()) {
+        return new RankingSnapshot(List.of(), 0);
+      }
+
+      List<RankingSnapshot.MemberRank> memberRanks = new ArrayList<>();
+      int rank = 1;
+      for (String memberKey : allMembers) {
+        UUID publicId = UUID.fromString(memberKey.substring(MEMBER_PREFIX.length()));
+        memberRanks.add(new RankingSnapshot.MemberRank(publicId, rank++));
+      }
+
+      return new RankingSnapshot(memberRanks, totalPlayers.intValue());
+    } catch (Exception e) {
+      log.warn("랭킹 스냅샷 조회 실패: date={}, {}", date, e.getMessage());
+      return new RankingSnapshot(List.of(), 0);
     }
   }
 

--- a/backend/src/main/resources/db/migration/V4__add_ranking_snapshot_columns.sql
+++ b/backend/src/main/resources/db/migration/V4__add_ranking_snapshot_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE game_sessions
+    ADD COLUMN final_rank INTEGER;
+
+ALTER TABLE daily_sentences
+    ADD COLUMN total_players INTEGER;


### PR DESCRIPTION
## 관련 이슈

Closes #35 

## 변경 사항

- Flyway V4 — `game_sessions`에 `final_rank`, `daily_sentences`에 `total_players` 컬럼 추가
- `DailySentence`에 `totalPlayers` 필드, `GameSession`에 `finalRank` 필드 + `recordFinalRank()` 도메인 메서드 추가
- `GameSessionRepository`에 `findAllBySentenceWithMember()` JOIN FETCH 쿼리 추가 (N+1 방지)
- `RankingSnapshot` record DTO 생성 (Redis→스케줄러 데이터 전달용)
- `RankingService.getAllRankingsForDate()` 추가 — Redis 전체 랭킹 조회
- `DailySentenceScheduler`에 `snapshotYesterdayRankings()` 스텝 삽입
- 스케줄러 실행 순서 변경: 세션 만료 → **스냅샷 저장** → TTL 설정 → 문장 선정
- (PR 작성 이후) Redis I/O를 트랜잭션 밖으로 분리 (DB 커넥션 불필요 점유 방지)
- (PR 작성 이후) 스냅샷 실패 시 TTL 설정 건너뛰기 (Redis 데이터 보존)
- (PR 작성 이후) DailySentence.setTotalPlayers() → recordTotalPlayers() 도메인 메서드로 변경

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- 마이페이지 히스토리 API는 별도 이슈로 진행
