### PR TITLE
feat: 랭킹 SSE 실시간 업데이트

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -64,6 +64,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/ranking/today")
                     .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/ranking/stream")
+                    .permitAll()
                     .requestMatchers("/daily/**")
                     .authenticated()
                     .anyRequest()

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -5,6 +5,7 @@ import com.gakkaweo.backend.domain.game.entity.GameSession;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
 import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
 import com.gakkaweo.backend.ranking.dto.RankingSnapshot;
+import com.gakkaweo.backend.ranking.event.DayChangeEvent;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -16,6 +17,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -31,28 +33,33 @@ public class DailySentenceScheduler {
   private final GameSessionRepository gameSessionRepository;
   private final RankingService rankingService;
   private final TransactionTemplate transactionTemplate;
+  private final ApplicationEventPublisher eventPublisher;
 
   public DailySentenceScheduler(
       DailySentenceRepository dailySentenceRepository,
       GameSessionRepository gameSessionRepository,
       RankingService rankingService,
-      TransactionTemplate transactionTemplate) {
+      TransactionTemplate transactionTemplate,
+      ApplicationEventPublisher eventPublisher) {
     this.dailySentenceRepository = dailySentenceRepository;
     this.gameSessionRepository = gameSessionRepository;
     this.rankingService = rankingService;
     this.transactionTemplate = transactionTemplate;
+    this.eventPublisher = eventPublisher;
   }
 
   @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-  public void selectDailySentence() {
+  public void executeMidnightJob() {
     log.info("일일 스케줄러 시작");
+    LocalDate today = LocalDate.now(KST);
+    LocalDate yesterday = today.minusDays(1);
+
     try {
-      transactionTemplate.executeWithoutResult(status -> expireYesterdaySessions());
+      transactionTemplate.executeWithoutResult(status -> expireYesterdaySessions(yesterday));
     } catch (Exception e) {
       log.error("전날 세션 만료 처리 실패: {}", e.getMessage(), e);
     }
 
-    LocalDate yesterday = LocalDate.now(KST).minusDays(1);
     boolean snapshotSuccess = false;
     try {
       RankingSnapshot snapshot = rankingService.getAllRankingsForDate(yesterday);
@@ -71,10 +78,15 @@ public class DailySentenceScheduler {
     }
 
     try {
-      transactionTemplate.executeWithoutResult(status -> selectTodaySentence());
+      transactionTemplate.executeWithoutResult(status -> selectTodaySentence(today));
     } catch (Exception e) {
       log.error("오늘의 문장 선정 실패: {}", e.getMessage(), e);
     }
+
+    dailySentenceRepository
+        .findByUsedAt(today)
+        .ifPresent(s -> eventPublisher.publishEvent(new DayChangeEvent(s.getPublicId())));
+
     log.info("일일 스케줄러 완료");
   }
 
@@ -83,12 +95,11 @@ public class DailySentenceScheduler {
     LocalDate today = LocalDate.now(KST);
     if (dailySentenceRepository.findByUsedAt(today).isEmpty()) {
       log.info("오늘 날짜 기준으로 선택된 문장이 없어 즉시 선정을 진행합니다.");
-      selectDailySentence();
+      executeMidnightJob();
     }
   }
 
-  private void expireYesterdaySessions() {
-    LocalDate yesterday = LocalDate.now(KST).minusDays(1);
+  private void expireYesterdaySessions(LocalDate yesterday) {
     dailySentenceRepository
         .findByUsedAt(yesterday)
         .ifPresent(
@@ -137,9 +148,7 @@ public class DailySentenceScheduler {
         snapshot.totalPlayers());
   }
 
-  private void selectTodaySentence() {
-    LocalDate today = LocalDate.now(KST);
-
+  private void selectTodaySentence(LocalDate today) {
     if (dailySentenceRepository.findByUsedAt(today).isPresent()) {
       log.info("오늘의 문장이 이미 선정됨: date={}", today);
       return;

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -18,6 +18,7 @@ import com.gakkaweo.backend.game.dto.GuessResponse;
 import com.gakkaweo.backend.game.dto.TodayResponse;
 import com.gakkaweo.backend.game.util.HintMaskGenerator;
 import com.gakkaweo.backend.infra.ai.service.SimilarityService;
+import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -28,6 +29,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +48,7 @@ public class DailyGameService {
   private final RankingService rankingService;
   private final HintMaskGenerator hintMaskGenerator;
   private final GameProperties gameProperties;
+  private final ApplicationEventPublisher eventPublisher;
 
   public DailyGameService(
       DailySentenceRepository dailySentenceRepository,
@@ -55,7 +58,8 @@ public class DailyGameService {
       SimilarityService similarityService,
       RankingService rankingService,
       HintMaskGenerator hintMaskGenerator,
-      GameProperties gameProperties) {
+      GameProperties gameProperties,
+      ApplicationEventPublisher eventPublisher) {
     this.dailySentenceRepository = dailySentenceRepository;
     this.gameSessionRepository = gameSessionRepository;
     this.guessHistoryRepository = guessHistoryRepository;
@@ -64,6 +68,7 @@ public class DailyGameService {
     this.rankingService = rankingService;
     this.hintMaskGenerator = hintMaskGenerator;
     this.gameProperties = gameProperties;
+    this.eventPublisher = eventPublisher;
   }
 
   @Transactional(readOnly = true)
@@ -124,6 +129,7 @@ public class DailyGameService {
 
     if (similarity.compareTo(previousBest) > 0) {
       rankingService.updateRanking(session, member);
+      eventPublisher.publishEvent(new RankingUpdateEvent());
     }
 
     log.info(

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/controller/RankingController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/controller/RankingController.java
@@ -2,23 +2,34 @@ package com.gakkaweo.backend.ranking.controller;
 
 import com.gakkaweo.backend.ranking.dto.RankingResponse;
 import com.gakkaweo.backend.ranking.service.RankingService;
+import com.gakkaweo.backend.ranking.sse.SseConnectionManager;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/ranking")
 public class RankingController {
 
   private final RankingService rankingService;
+  private final SseConnectionManager sseConnectionManager;
 
-  public RankingController(RankingService rankingService) {
+  public RankingController(
+      RankingService rankingService, SseConnectionManager sseConnectionManager) {
     this.rankingService = rankingService;
+    this.sseConnectionManager = sseConnectionManager;
   }
 
   @GetMapping("/today")
   public ResponseEntity<RankingResponse> getTodayRanking() {
     return ResponseEntity.ok(rankingService.getRankings());
+  }
+
+  @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter streamRanking() {
+    return sseConnectionManager.register();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/dto/SseEventType.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/dto/SseEventType.java
@@ -1,0 +1,7 @@
+package com.gakkaweo.backend.ranking.dto;
+
+public enum SseEventType {
+  RANKING_UPDATE,
+  DAY_CHANGE,
+  HEARTBEAT
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/event/DayChangeEvent.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/event/DayChangeEvent.java
@@ -1,0 +1,5 @@
+package com.gakkaweo.backend.ranking.event;
+
+import java.util.UUID;
+
+public record DayChangeEvent(UUID newSentenceId) {}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/event/RankingUpdateEvent.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/event/RankingUpdateEvent.java
@@ -1,0 +1,3 @@
+package com.gakkaweo.backend.ranking.event;
+
+public record RankingUpdateEvent() {}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
@@ -1,11 +1,9 @@
 package com.gakkaweo.backend.ranking.sse;
 
 import com.gakkaweo.backend.ranking.dto.RankingResponse;
-import com.gakkaweo.backend.ranking.dto.SseEventType;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -85,7 +83,7 @@ public class SseConnectionManager {
       sendToAll(
           emitter -> emitter.send(SseEmitter.event().name(SseEventType.HEARTBEAT.name()).data("")));
     } catch (Exception e) {
-      log.warn("SSE heartbeat 처리 중 예외: {}", e.getMessage());
+      log.error("SSE heartbeat 처리 중 예외: {}", e.getMessage());
     }
   }
 
@@ -93,9 +91,9 @@ public class SseConnectionManager {
     try {
       RankingResponse ranking = rankingService.getRankings();
       emitter.send(SseEmitter.event().name(SseEventType.RANKING_UPDATE.name()).data(ranking));
-    } catch (IOException e) {
+    } catch (Exception e) {
       removeAndComplete(emitter);
-      log.warn("SSE 초기 데이터 전송 실패: {}", e.getMessage());
+      log.debug("SSE 초기 데이터 전송 실패: {}", e.getMessage());
     }
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
@@ -1,0 +1,134 @@
+package com.gakkaweo.backend.ranking.sse;
+
+import com.gakkaweo.backend.ranking.dto.RankingResponse;
+import com.gakkaweo.backend.ranking.dto.SseEventType;
+import com.gakkaweo.backend.ranking.service.RankingService;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+@Slf4j
+public class SseConnectionManager {
+
+  private static final int MAX_CONNECTIONS = 500;
+  private static final long HEARTBEAT_INTERVAL_SECONDS = 10;
+
+  private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+  private final RankingService rankingService;
+  private final ScheduledExecutorService heartbeatExecutor =
+      Executors.newSingleThreadScheduledExecutor(
+          r -> {
+            Thread t = new Thread(r, "sse-heartbeat");
+            t.setDaemon(true);
+            return t;
+          });
+
+  public SseConnectionManager(RankingService rankingService) {
+    this.rankingService = rankingService;
+  }
+
+  @PostConstruct
+  void startHeartbeat() {
+    heartbeatExecutor.scheduleAtFixedRate(
+        this::sendHeartbeat,
+        HEARTBEAT_INTERVAL_SECONDS,
+        HEARTBEAT_INTERVAL_SECONDS,
+        TimeUnit.SECONDS);
+  }
+
+  @PreDestroy
+  void shutdown() {
+    heartbeatExecutor.shutdownNow();
+    emitters.forEach(this::completeQuietly);
+    emitters.clear();
+  }
+
+  public SseEmitter register() {
+    if (emitters.size() >= MAX_CONNECTIONS) {
+      throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "SSE 최대 연결 수 초과");
+    }
+
+    SseEmitter emitter = new SseEmitter(0L);
+
+    emitter.onCompletion(() -> emitters.remove(emitter));
+    emitter.onTimeout(() -> removeAndComplete(emitter));
+    emitter.onError(e -> removeAndComplete(emitter));
+
+    emitters.add(emitter);
+    sendInitialRanking(emitter);
+
+    log.debug("SSE 연결 등록: 현재 연결 수={}", emitters.size());
+    return emitter;
+  }
+
+  public void broadcast(SseEventType type, Object data) {
+    sendToAll(emitter -> emitter.send(SseEmitter.event().name(type.name()).data(data)));
+  }
+
+  private void sendHeartbeat() {
+    try {
+      if (emitters.isEmpty()) {
+        return;
+      }
+      sendToAll(
+          emitter -> emitter.send(SseEmitter.event().name(SseEventType.HEARTBEAT.name()).data("")));
+    } catch (Exception e) {
+      log.warn("SSE heartbeat 처리 중 예외: {}", e.getMessage());
+    }
+  }
+
+  private void sendInitialRanking(SseEmitter emitter) {
+    try {
+      RankingResponse ranking = rankingService.getRankings();
+      emitter.send(SseEmitter.event().name(SseEventType.RANKING_UPDATE.name()).data(ranking));
+    } catch (IOException e) {
+      removeAndComplete(emitter);
+      log.warn("SSE 초기 데이터 전송 실패: {}", e.getMessage());
+    }
+  }
+
+  private void sendToAll(EmitterAction action) {
+    List<SseEmitter> dead = new ArrayList<>();
+    for (SseEmitter emitter : emitters) {
+      try {
+        action.execute(emitter);
+      } catch (Exception e) {
+        dead.add(emitter);
+        completeQuietly(emitter);
+      }
+    }
+    if (!dead.isEmpty()) {
+      emitters.removeAll(dead);
+      log.debug("SSE 실패 연결 제거: removed={}, remaining={}", dead.size(), emitters.size());
+    }
+  }
+
+  private void removeAndComplete(SseEmitter emitter) {
+    emitters.remove(emitter);
+    completeQuietly(emitter);
+  }
+
+  private void completeQuietly(SseEmitter emitter) {
+    try {
+      emitter.complete();
+    } catch (Exception ignored) {
+    }
+  }
+
+  @FunctionalInterface
+  private interface EmitterAction {
+    void execute(SseEmitter emitter) throws Exception;
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseEventListener.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseEventListener.java
@@ -1,0 +1,72 @@
+package com.gakkaweo.backend.ranking.sse;
+
+import com.gakkaweo.backend.ranking.dto.RankingResponse;
+import com.gakkaweo.backend.ranking.dto.SseEventType;
+import com.gakkaweo.backend.ranking.event.DayChangeEvent;
+import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
+import com.gakkaweo.backend.ranking.service.RankingService;
+import jakarta.annotation.PreDestroy;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class SseEventListener {
+
+  private static final long DEBOUNCE_MILLIS = 100;
+
+  private final RankingService rankingService;
+  private final SseConnectionManager sseConnectionManager;
+  private final ScheduledExecutorService debounceExecutor =
+      Executors.newSingleThreadScheduledExecutor(
+          r -> {
+            Thread t = new Thread(r, "sse-debounce");
+            t.setDaemon(true);
+            return t;
+          });
+  private volatile ScheduledFuture<?> pendingBroadcast;
+
+  public SseEventListener(
+      RankingService rankingService, SseConnectionManager sseConnectionManager) {
+    this.rankingService = rankingService;
+    this.sseConnectionManager = sseConnectionManager;
+  }
+
+  @PreDestroy
+  void shutdown() {
+    debounceExecutor.shutdownNow();
+  }
+
+  @EventListener
+  public void onRankingUpdate(RankingUpdateEvent event) {
+    ScheduledFuture<?> existing = pendingBroadcast;
+    if (existing != null) {
+      existing.cancel(false);
+    }
+    pendingBroadcast =
+        debounceExecutor.schedule(this::broadcastRanking, DEBOUNCE_MILLIS, TimeUnit.MILLISECONDS);
+  }
+
+  @EventListener
+  public void onDayChange(DayChangeEvent event) {
+    sseConnectionManager.broadcast(
+        SseEventType.DAY_CHANGE, Map.of("newSentenceId", event.newSentenceId()));
+    log.info("DAY_CHANGE 이벤트 브로드캐스트: newSentenceId={}", event.newSentenceId());
+  }
+
+  private void broadcastRanking() {
+    try {
+      RankingResponse ranking = rankingService.getRankings();
+      sseConnectionManager.broadcast(SseEventType.RANKING_UPDATE, ranking);
+      log.debug("RANKING_UPDATE 브로드캐스트: totalPlayers={}", ranking.totalPlayers());
+    } catch (Exception e) {
+      log.warn("RANKING_UPDATE 브로드캐스트 실패: {}", e.getMessage());
+    }
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseEventListener.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseEventListener.java
@@ -1,7 +1,6 @@
 package com.gakkaweo.backend.ranking.sse;
 
 import com.gakkaweo.backend.ranking.dto.RankingResponse;
-import com.gakkaweo.backend.ranking.dto.SseEventType;
 import com.gakkaweo.backend.ranking.event.DayChangeEvent;
 import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
 import com.gakkaweo.backend.ranking.service.RankingService;
@@ -44,10 +43,9 @@ public class SseEventListener {
   }
 
   @EventListener
-  public void onRankingUpdate(RankingUpdateEvent event) {
-    ScheduledFuture<?> existing = pendingBroadcast;
-    if (existing != null) {
-      existing.cancel(false);
+  public synchronized void onRankingUpdate(RankingUpdateEvent event) {
+    if (pendingBroadcast != null) {
+      pendingBroadcast.cancel(false);
     }
     pendingBroadcast =
         debounceExecutor.schedule(this::broadcastRanking, DEBOUNCE_MILLIS, TimeUnit.MILLISECONDS);
@@ -66,7 +64,7 @@ public class SseEventListener {
       sseConnectionManager.broadcast(SseEventType.RANKING_UPDATE, ranking);
       log.debug("RANKING_UPDATE 브로드캐스트: totalPlayers={}", ranking.totalPlayers());
     } catch (Exception e) {
-      log.warn("RANKING_UPDATE 브로드캐스트 실패: {}", e.getMessage());
+      log.error("RANKING_UPDATE 브로드캐스트 실패: {}", e.getMessage());
     }
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseEventType.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseEventType.java
@@ -1,4 +1,4 @@
-package com.gakkaweo.backend.ranking.dto;
+package com.gakkaweo.backend.ranking.sse;
 
 public enum SseEventType {
   RANKING_UPDATE,

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -92,5 +92,9 @@ resilience4j:
         wait-duration-in-open-state: 30s
         permitted-number-of-calls-in-half-open-state: 3
 
+logging:
+  level:
+    com.gakkaweo.backend: DEBUG
+
 server:
   port: 8080


### PR DESCRIPTION
## 관련 이슈

Closes #37 

## 변경 사항

- SSE(Server-Sent Events)를 통해 랭킹 변동을 실시간으로 클라이언트에 푸시
- `SseConnectionManager`: emitter 연결 관리 + 10초 heartbeat + 초기 랭킹 즉시 전송 + 최대 500 연결
- `SseEventListener`: ApplicationEvent 수신 + 100ms 디바운스 후 브로드캐스트
- `GET /ranking/stream` SSE 엔드포인트 추가 (permitAll)
- 추측 시 유사도 개선되면 `RankingUpdateEvent` 발행 → SSE 브로드캐스트
- 자정 스케줄러 완료 시 `DayChangeEvent` 발행 → 프론트엔드 새로고침 유도
- 이벤트 3종: `RANKING_UPDATE`, `DAY_CHANGE`, `HEARTBEAT`
- 스케줄러 메서드명 `selectDailySentence` → `executeMidnightJob` 변경
- 스케줄러 날짜 계산을 진입점에서 1회만 수행하도록 리팩토링
- 디버그 로깅 설정 추가
- 코드리뷰 반영: 디바운스 race condition 수정 (`synchronized`), `sendInitialRanking` catch 범위 확대, `SseEventType` 패키지 `dto/` → `sse/` 이동, 로깅 레벨 CLAUDE.md 규칙 준수

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- 설계: SseEmitter(Spring MVC) + ApplicationEventPublisher(단일 서버, Redis Pub/Sub 대신)
