### PR TITLE
feat: AI Service 개선

### DIFF
--- a/ai-service/app/main.py
+++ b/ai-service/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from sentence_transformers import util
 
-from app.model import model
+from app.model import encode_text
 from app.normalize import normalize_text
 from app.schemas import SimilarityRequest, SimilarityResponse
 
@@ -17,7 +17,8 @@ def health_check():
 def compute_similarity(request: SimilarityRequest):
     text1 = normalize_text(request.text1)
     text2 = normalize_text(request.text2)
-    embeddings = model.encode([text1, text2])
-    raw_score = util.cos_sim(embeddings[0], embeddings[1]).item()
+    embedding1 = encode_text(text1)
+    embedding2 = encode_text(text2)
+    raw_score = util.cos_sim(embedding1, embedding2).item()
     score = round(max(0.0, raw_score) * 100, 1)
     return SimilarityResponse(score=score, text1=text1, text2=text2)

--- a/ai-service/app/main.py
+++ b/ai-service/app/main.py
@@ -15,10 +15,10 @@ def health_check():
 
 @app.post("/similarity", response_model=SimilarityResponse)
 def compute_similarity(request: SimilarityRequest):
-    text1 = normalize_text(request.text1)
-    text2 = normalize_text(request.text2)
-    embedding1 = encode_text(text1)
-    embedding2 = encode_text(text2)
-    raw_score = util.cos_sim(embedding1, embedding2).item()
+    sentence = normalize_text(request.sentence)
+    guess = normalize_text(request.guess)
+    sentence_embedding = encode_text(sentence)
+    guess_embedding = encode_text(guess)
+    raw_score = util.cos_sim(sentence_embedding, guess_embedding).item()
     score = round(max(0.0, raw_score) * 100, 1)
-    return SimilarityResponse(score=score, text1=text1, text2=text2)
+    return SimilarityResponse(score=score)

--- a/ai-service/app/model.py
+++ b/ai-service/app/model.py
@@ -1,3 +1,11 @@
+from functools import lru_cache
+
+import numpy as np
 from sentence_transformers import SentenceTransformer
 
 model = SentenceTransformer("jhgan/ko-sbert-sts")
+
+
+@lru_cache(maxsize=32)
+def encode_text(text: str) -> np.ndarray:
+    return model.encode(text)

--- a/ai-service/app/normalize.py
+++ b/ai-service/app/normalize.py
@@ -1,7 +1,9 @@
 import re
+import unicodedata
 
 
 def normalize_text(text: str) -> str:
+    text = unicodedata.normalize("NFC", text)
     text = re.sub(r"[^가-힣a-zA-Z0-9\s]", "", text)
     text = re.sub(r"\s+", " ", text)
     return text.strip()

--- a/ai-service/app/schemas.py
+++ b/ai-service/app/schemas.py
@@ -2,11 +2,9 @@ from pydantic import BaseModel, Field
 
 
 class SimilarityRequest(BaseModel):
-    text1: str = Field(..., min_length=2, max_length=200)
-    text2: str = Field(..., min_length=2, max_length=200)
+    sentence: str = Field(..., min_length=2, max_length=200)
+    guess: str = Field(..., min_length=2, max_length=200)
 
 
 class SimilarityResponse(BaseModel):
     score: float
-    text1: str
-    text2: str

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
@@ -38,12 +38,6 @@ public class DailySentence {
   @Column(unique = true)
   private LocalDate usedAt;
 
-  @Setter private byte[] embedding;
-
-  @Setter
-  @Column(length = 100)
-  private String modelVersion;
-
   @Setter
   @Enumerated(EnumType.STRING)
   @Column(length = 20)

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/client/AiServiceClient.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/client/AiServiceClient.java
@@ -15,13 +15,13 @@ public class AiServiceClient {
 
   private final RestClient aiServiceRestClient;
 
-  public SimilarityResponse calculateSimilarity(String text1, String text2) {
+  public SimilarityResponse calculateSimilarity(String sentence, String guess) {
     try {
       return aiServiceRestClient
           .post()
           .uri("/similarity")
           .contentType(MediaType.APPLICATION_JSON)
-          .body(new SimilarityRequest(text1, text2))
+          .body(new SimilarityRequest(sentence, guess))
           .retrieve()
           .body(SimilarityResponse.class);
     } catch (RestClientException e) {

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/client/dto/SimilarityRequest.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/client/dto/SimilarityRequest.java
@@ -1,3 +1,3 @@
 package com.gakkaweo.backend.infra.ai.client.dto;
 
-public record SimilarityRequest(String text1, String text2) {}
+public record SimilarityRequest(String sentence, String guess) {}

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/client/dto/SimilarityResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/client/dto/SimilarityResponse.java
@@ -1,3 +1,3 @@
 package com.gakkaweo.backend.infra.ai.client.dto;
 
-public record SimilarityResponse(double score, String text1, String text2) {}
+public record SimilarityResponse(double score) {}

--- a/backend/src/main/resources/db/migration/V5__drop_embedding_columns.sql
+++ b/backend/src/main/resources/db/migration/V5__drop_embedding_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE daily_sentences
+    DROP COLUMN embedding;
+
+ALTER TABLE daily_sentences
+    DROP COLUMN model_version;


### PR DESCRIPTION
## 관련 이슈

Closes #39 

## 변경 사항

- Python `normalize_text`에 `unicodedata.normalize("NFC")` 추가하여 Java `TextNormalizer`와 이중 검증 일관성 확보
- `model.encode()` 결과를 `@lru_cache(maxsize=32)`로 캐싱하여 정답 문장 재인코딩 제거
- `/similarity` 엔드포인트 배치 인코딩 → 개별 캐시 인코딩으로 리팩토링
- 유사도 API 요청 필드 `text1`/`text2` → `sentence`/`guess`로 도메인 의미 명확화
- 유사도 API 응답에서 `score`만 반환하여 불필요한 에코백 제거
- Flyway V5: `daily_sentences.embedding`, `model_version` 컬럼 DROP
- `DailySentence` JPA 엔티티에서 `embedding`, `modelVersion` 필드 제거

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
