### PR TITLE
feat: Rate Limiting — Bucket4j 인메모리 요청 제한

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     // Resilience4j
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
 
+    // Rate Limiting
+    implementation 'com.bucket4j:bucket4j_jdk17-core:8.17.0'
+
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
     compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
   SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "게임 세션을 찾을 수 없습니다"),
   GAME_ALREADY_CLEARED(HttpStatus.CONFLICT, "이미 정답을 맞춘 게임입니다"),
   GAME_EXPIRED(HttpStatus.CONFLICT, "만료된 게임입니다"),
-  CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "동시 수정 충돌이 발생했습니다");
+  CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "동시 수정 충돌이 발생했습니다"),
+  RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요");
 
   private final HttpStatus status;
   private final String message;

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.gakkaweo.backend.auth.oauth2.CookieAuthorizationRequestRepository;
 import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginFailureHandler;
 import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginSuccessHandler;
 import com.gakkaweo.backend.auth.oauth2.service.CustomOAuth2UserService;
+import com.gakkaweo.backend.ratelimit.filter.RateLimitFilter;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,6 +27,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final RateLimitFilter rateLimitFilter;
   private final CustomOAuth2UserService customOAuth2UserService;
   private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
   private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
@@ -34,12 +36,14 @@ public class SecurityConfig {
 
   public SecurityConfig(
       JwtAuthenticationFilter jwtAuthenticationFilter,
+      RateLimitFilter rateLimitFilter,
       CustomOAuth2UserService customOAuth2UserService,
       OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler,
       OAuth2LoginFailureHandler oAuth2LoginFailureHandler,
       CookieAuthorizationRequestRepository authorizationRequestRepository,
       OAuth2Properties oAuth2Properties) {
     this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    this.rateLimitFilter = rateLimitFilter;
     this.customOAuth2UserService = customOAuth2UserService;
     this.oAuth2LoginSuccessHandler = oAuth2LoginSuccessHandler;
     this.oAuth2LoginFailureHandler = oAuth2LoginFailureHandler;
@@ -79,7 +83,8 @@ public class SecurityConfig {
                     .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
                     .successHandler(oAuth2LoginSuccessHandler)
                     .failureHandler(oAuth2LoginFailureHandler))
-        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterAfter(rateLimitFilter, JwtAuthenticationFilter.class);
     return http.build();
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/config/RateLimitProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/config/RateLimitProperties.java
@@ -14,5 +14,4 @@ public class RateLimitProperties {
   private final int ssePerMinute;
   private final int authPerMinute;
   private final int bucketExpiryMinutes;
-  private final long cleanupIntervalMs;
 }

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/config/RateLimitProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/config/RateLimitProperties.java
@@ -1,0 +1,18 @@
+package com.gakkaweo.backend.ratelimit.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.rate-limit")
+@Getter
+@RequiredArgsConstructor
+public class RateLimitProperties {
+
+  private final int guessPerMinute;
+  private final int readPerMinute;
+  private final int ssePerMinute;
+  private final int authPerMinute;
+  private final int bucketExpiryMinutes;
+  private final long cleanupIntervalMs;
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/BucketStore.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/BucketStore.java
@@ -1,0 +1,73 @@
+package com.gakkaweo.backend.ratelimit.filter;
+
+import com.gakkaweo.backend.ratelimit.config.RateLimitProperties;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class BucketStore {
+
+  private final RateLimitProperties properties;
+  private final Map<String, BucketEntry> buckets = new ConcurrentHashMap<>();
+
+  public BucketStore(RateLimitProperties properties) {
+    this.properties = properties;
+  }
+
+  public Bucket resolveBucket(EndpointGroup group, String key) {
+    String bucketKey = group.name() + ":" + key;
+    return buckets
+        .compute(
+            bucketKey,
+            (k, existing) -> {
+              if (existing != null) {
+                return new BucketEntry(existing.bucket(), Instant.now());
+              }
+              Bucket bucket = createBucket(group);
+              return new BucketEntry(bucket, Instant.now());
+            })
+        .bucket();
+  }
+
+  @Scheduled(fixedDelayString = "${app.rate-limit.cleanup-interval-ms:300000}")
+  public void cleanup() {
+    Instant expiry = Instant.now().minusSeconds(properties.getBucketExpiryMinutes() * 60L);
+    int before = buckets.size();
+    buckets.entrySet().removeIf(entry -> entry.getValue().lastAccessed().isBefore(expiry));
+    int removed = before - buckets.size();
+    if (removed > 0) {
+      log.debug("Rate limit 버킷 정리: {}개 제거, 남은 버킷 {}개", removed, buckets.size());
+    }
+  }
+
+  private Bucket createBucket(EndpointGroup group) {
+    int capacity = getCapacity(group);
+    return Bucket.builder()
+        .addLimit(
+            Bandwidth.builder()
+                .capacity(capacity)
+                .refillGreedy(capacity, Duration.ofMinutes(1))
+                .build())
+        .build();
+  }
+
+  private int getCapacity(EndpointGroup group) {
+    return switch (group) {
+      case GUESS -> properties.getGuessPerMinute();
+      case READ -> properties.getReadPerMinute();
+      case SSE -> properties.getSsePerMinute();
+      case AUTH -> properties.getAuthPerMinute();
+      case NONE -> throw new IllegalArgumentException("NONE 그룹은 버킷을 생성하지 않습니다");
+    };
+  }
+
+  private record BucketEntry(Bucket bucket, Instant lastAccessed) {}
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/EndpointGroup.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/EndpointGroup.java
@@ -1,0 +1,9 @@
+package com.gakkaweo.backend.ratelimit.filter;
+
+public enum EndpointGroup {
+  GUESS,
+  READ,
+  SSE,
+  AUTH,
+  NONE
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/EndpointGroupResolver.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/EndpointGroupResolver.java
@@ -1,0 +1,33 @@
+package com.gakkaweo.backend.ratelimit.filter;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class EndpointGroupResolver {
+
+  public EndpointGroup resolve(String method, String uri) {
+    if (uri.equals("/health")
+        || uri.startsWith("/login/oauth2/")
+        || uri.startsWith("/oauth2/authorization/")) {
+      return EndpointGroup.NONE;
+    }
+
+    if (uri.startsWith("/auth")) {
+      return EndpointGroup.AUTH;
+    }
+
+    if ("POST".equals(method) && uri.equals("/daily/guess")) {
+      return EndpointGroup.GUESS;
+    }
+
+    if ("GET".equals(method) && uri.equals("/ranking/stream")) {
+      return EndpointGroup.SSE;
+    }
+
+    if ("GET".equals(method)) {
+      return EndpointGroup.READ;
+    }
+
+    return EndpointGroup.NONE;
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/RateLimitFilter.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/RateLimitFilter.java
@@ -1,0 +1,93 @@
+package com.gakkaweo.backend.ratelimit.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gakkaweo.backend.auth.security.CustomUserDetails;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+  private final EndpointGroupResolver endpointGroupResolver;
+  private final BucketStore bucketStore;
+  private final ObjectMapper objectMapper;
+
+  public RateLimitFilter(
+      EndpointGroupResolver endpointGroupResolver,
+      BucketStore bucketStore,
+      ObjectMapper objectMapper) {
+    this.endpointGroupResolver = endpointGroupResolver;
+    this.bucketStore = bucketStore;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    EndpointGroup group =
+        endpointGroupResolver.resolve(request.getMethod(), request.getRequestURI());
+
+    if (group == EndpointGroup.NONE) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    String key = resolveKey(group, request);
+    Bucket bucket = bucketStore.resolveBucket(group, key);
+    ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+
+    if (probe.isConsumed()) {
+      response.setHeader("X-Rate-Limit-Remaining", String.valueOf(probe.getRemainingTokens()));
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    long retryAfterSeconds = TimeUnit.NANOSECONDS.toSeconds(probe.getNanosToWaitForRefill()) + 1;
+    log.warn("Rate limit 초과: group={}, key={}, retryAfter={}s", group, key, retryAfterSeconds);
+
+    ErrorCode errorCode = ErrorCode.RATE_LIMIT_EXCEEDED;
+    Map<String, Object> body =
+        Map.of(
+            "status", errorCode.getStatus().value(),
+            "code", errorCode.name(),
+            "message", errorCode.getMessage(),
+            "timestamp", Instant.now().toString());
+
+    response.setStatus(errorCode.getStatus().value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+    response.setHeader("Retry-After", String.valueOf(retryAfterSeconds));
+    objectMapper.writeValue(response.getWriter(), body);
+  }
+
+  private String resolveKey(EndpointGroup group, HttpServletRequest request) {
+    if (group == EndpointGroup.AUTH) {
+      return request.getRemoteAddr();
+    }
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails user) {
+      return user.publicId().toString();
+    }
+
+    return request.getRemoteAddr();
+  }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -82,6 +82,13 @@ app:
     timeout: ${AI_SERVICE_TIMEOUT:3s}
   game:
     similarity-threshold: ${SIMILARITY_THRESHOLD:95.0}
+  rate-limit:
+    guess-per-minute: ${RATE_LIMIT_GUESS:40}
+    read-per-minute: ${RATE_LIMIT_READ:60}
+    sse-per-minute: ${RATE_LIMIT_SSE:10}
+    auth-per-minute: ${RATE_LIMIT_AUTH:10}
+    bucket-expiry-minutes: ${RATE_LIMIT_BUCKET_EXPIRY:10}
+    cleanup-interval-ms: ${RATE_LIMIT_CLEANUP_INTERVAL_MS:300000}
 
 resilience4j:
   circuitbreaker:


### PR DESCRIPTION
## 관련 이슈

Closes #41 

## 변경 사항

- Bucket4j 인메모리 Rate Limiting 필터 구현 (OncePerRequestFilter)
- 엔드포인트 그룹별 차등 제한: GUESS 40/min, READ 60/min, SSE 10/min, AUTH 10/min
- 식별 기준: 익명은 IP, 로그인 유저는 memberId, AUTH는 항상 IP (credential stuffing 방어)
- OAuth 콜백 경로(`/login/oauth2/**`, `/oauth2/authorization/**`) Rate Limiting 미적용
- 429 응답에 `Retry-After` 헤더 + ErrorCode 일관된 JSON 포맷
- ConcurrentHashMap 버킷 저장소 + 5분 주기 만료 정리 (기본 10분 미접근 시 제거)
- `app.rate-limit.*` 환경변수로 제한값 오버라이드 가능

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- [Bucket4j GitHub](https://github.com/bucket4j/bucket4j)
