### PR TITLE
feat: 회원 탈퇴 API

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/controller/AuthController.java
@@ -3,12 +3,14 @@ package com.gakkaweo.backend.auth.controller;
 import com.gakkaweo.backend.auth.dto.AuthResponse;
 import com.gakkaweo.backend.auth.dto.TokenPair;
 import com.gakkaweo.backend.auth.security.CustomUserDetails;
+import com.gakkaweo.backend.auth.service.AccountService;
 import com.gakkaweo.backend.auth.service.AuthService;
 import com.gakkaweo.backend.auth.util.CookieUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,10 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
   private final AuthService authService;
+  private final AccountService accountService;
   private final CookieUtils cookieUtils;
 
-  public AuthController(AuthService authService, CookieUtils cookieUtils) {
+  public AuthController(
+      AuthService authService, AccountService accountService, CookieUtils cookieUtils) {
     this.authService = authService;
+    this.accountService = accountService;
     this.cookieUtils = cookieUtils;
   }
 
@@ -57,5 +62,18 @@ public class AuthController {
   public ResponseEntity<AuthResponse> me(@AuthenticationPrincipal CustomUserDetails userDetails) {
     AuthResponse response = authService.getCurrentUser(userDetails.publicId());
     return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/account")
+  public ResponseEntity<Void> deleteAccount(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @CookieValue(value = "access_token", required = false) String accessToken) {
+    accountService.deleteAccount(userDetails.publicId());
+    accountService.cleanupRedis(userDetails.publicId(), accessToken);
+
+    return ResponseEntity.ok()
+        .header(HttpHeaders.SET_COOKIE, cookieUtils.deleteAccessTokenCookie().toString())
+        .header(HttpHeaders.SET_COOKIE, cookieUtils.deleteRefreshTokenCookie().toString())
+        .build();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
@@ -1,0 +1,93 @@
+package com.gakkaweo.backend.auth.service;
+
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.admin.repository.SentenceUploadRepository;
+import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
+import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+public class AccountService {
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+  private static final String RANKING_KEY_PREFIX = "ranking:";
+  private static final String DETAIL_KEY_PREFIX = "ranking_detail:";
+  private static final String MEMBER_PREFIX = "member:";
+
+  private final MemberRepository memberRepository;
+  private final GameSessionRepository gameSessionRepository;
+  private final SentenceUploadRepository sentenceUploadRepository;
+  private final SocialAccountRepository socialAccountRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final AuthService authService;
+  private final StringRedisTemplate redisTemplate;
+
+  public AccountService(
+      MemberRepository memberRepository,
+      GameSessionRepository gameSessionRepository,
+      SentenceUploadRepository sentenceUploadRepository,
+      SocialAccountRepository socialAccountRepository,
+      RefreshTokenRepository refreshTokenRepository,
+      AuthService authService,
+      StringRedisTemplate redisTemplate) {
+    this.memberRepository = memberRepository;
+    this.gameSessionRepository = gameSessionRepository;
+    this.sentenceUploadRepository = sentenceUploadRepository;
+    this.socialAccountRepository = socialAccountRepository;
+    this.refreshTokenRepository = refreshTokenRepository;
+    this.authService = authService;
+    this.redisTemplate = redisTemplate;
+  }
+
+  @Transactional
+  public void deleteAccount(UUID publicId) {
+    Member member =
+        memberRepository
+            .findByPublicId(publicId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+    int anonymizedSessions = gameSessionRepository.anonymizeByMember(member);
+    int anonymizedUploads = sentenceUploadRepository.anonymizeByAdmin(member);
+
+    socialAccountRepository.deleteByMember(member);
+    refreshTokenRepository.deleteByMemberId(member.getId());
+    memberRepository.delete(member);
+
+    log.info(
+        "회원 탈퇴 완료: publicId={}, anonymizedSessions={}, anonymizedUploads={}",
+        publicId,
+        anonymizedSessions,
+        anonymizedUploads);
+  }
+
+  public void cleanupRedis(UUID publicId, String accessToken) {
+    try {
+      if (accessToken != null) {
+        authService.logout(accessToken);
+      }
+
+      LocalDate today = LocalDate.now(KST);
+      String rankingKey = RANKING_KEY_PREFIX + today;
+      String memberKey = MEMBER_PREFIX + publicId;
+      String detailKey = DETAIL_KEY_PREFIX + today + ":" + MEMBER_PREFIX + publicId;
+
+      redisTemplate.opsForZSet().remove(rankingKey, memberKey);
+      redisTemplate.delete(detailKey);
+
+      log.info("탈퇴 회원 Redis 정리 완료: publicId={}", publicId);
+    } catch (Exception e) {
+      log.warn("탈퇴 회원 Redis 정리 실패: publicId={}, {}", publicId, e.getMessage());
+    }
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/SentenceUpload.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/SentenceUpload.java
@@ -28,7 +28,7 @@ public class SentenceUpload {
   private Long id;
 
   @ManyToOne(fetch = LAZY)
-  @JoinColumn(name = "admin_id", nullable = false)
+  @JoinColumn(name = "admin_id")
   private Member admin;
 
   @Column(nullable = false, length = 255)

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/repository/SentenceUploadRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/repository/SentenceUploadRepository.java
@@ -1,6 +1,15 @@
 package com.gakkaweo.backend.domain.admin.repository;
 
 import com.gakkaweo.backend.domain.admin.entity.SentenceUpload;
+import com.gakkaweo.backend.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface SentenceUploadRepository extends JpaRepository<SentenceUpload, Long> {}
+public interface SentenceUploadRepository extends JpaRepository<SentenceUpload, Long> {
+
+  @Modifying
+  @Query("UPDATE SentenceUpload s SET s.admin = null WHERE s.admin = :admin")
+  int anonymizeByAdmin(@Param("admin") Member admin);
+}

--- a/backend/src/main/java/com/gakkaweo/backend/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/auth/repository/RefreshTokenRepository.java
@@ -13,4 +13,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
   List<RefreshToken> findByFamilyId(UUID familyId);
 
   List<RefreshToken> findByMemberId(Long memberId);
+
+  void deleteByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/auth/repository/RefreshTokenRepository.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
@@ -14,5 +17,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
   List<RefreshToken> findByMemberId(Long memberId);
 
-  void deleteByMemberId(Long memberId);
+  @Modifying
+  @Query("DELETE FROM RefreshToken r WHERE r.member.id = :memberId")
+  int deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -40,7 +40,7 @@ public class GameSession {
   private Long id;
 
   @ManyToOne(fetch = LAZY)
-  @JoinColumn(name = "member_id", nullable = false)
+  @JoinColumn(name = "member_id")
   private Member member;
 
   @ManyToOne(fetch = LAZY)

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GameSessionRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GameSessionRepository.java
@@ -25,4 +25,8 @@ public interface GameSessionRepository extends JpaRepository<GameSession, Long> 
 
   @Query("SELECT g FROM GameSession g JOIN FETCH g.member WHERE g.sentence = :sentence")
   List<GameSession> findAllBySentenceWithMember(@Param("sentence") DailySentence sentence);
+
+  @Modifying
+  @Query("UPDATE GameSession g SET g.member = null WHERE g.member = :member")
+  int anonymizeByMember(@Param("member") Member member);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/repository/SocialAccountRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/repository/SocialAccountRepository.java
@@ -6,11 +6,16 @@ import com.gakkaweo.backend.domain.member.entity.SocialProvider;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
 
   @EntityGraph(attributePaths = "member")
   Optional<SocialAccount> findByProviderAndProviderId(SocialProvider provider, String providerId);
 
-  void deleteByMember(Member member);
+  @Modifying
+  @Query("DELETE FROM SocialAccount s WHERE s.member = :member")
+  int deleteByMember(@Param("member") Member member);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/repository/SocialAccountRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/repository/SocialAccountRepository.java
@@ -1,5 +1,6 @@
 package com.gakkaweo.backend.domain.member.repository;
 
+import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.domain.member.entity.SocialAccount;
 import com.gakkaweo.backend.domain.member.entity.SocialProvider;
 import java.util.Optional;
@@ -10,4 +11,6 @@ public interface SocialAccountRepository extends JpaRepository<SocialAccount, Lo
 
   @EntityGraph(attributePaths = "member")
   Optional<SocialAccount> findByProviderAndProviderId(SocialProvider provider, String providerId);
+
+  void deleteByMember(Member member);
 }

--- a/backend/src/main/resources/db/migration/V6__allow_nullable_member_id.sql
+++ b/backend/src/main/resources/db/migration/V6__allow_nullable_member_id.sql
@@ -1,0 +1,6 @@
+-- 회원 탈퇴 시 게임 기록 익명화를 위해 member_id nullable 변경
+ALTER TABLE game_sessions
+    ALTER COLUMN member_id DROP NOT NULL;
+
+ALTER TABLE sentence_uploads
+    ALTER COLUMN admin_id DROP NOT NULL;


### PR DESCRIPTION
## 관련 이슈

Closes #44 

## 변경 사항

- Flyway V6: `game_sessions.member_id`, `sentence_uploads.admin_id` nullable 변경
- `DELETE /auth/account`: 회원 탈퇴 엔드포인트 추가
- AccountService: 게임 기록 익명화(`member_id = NULL`) + 인증 데이터 삭제(소셜 계정, 리프레시 토큰, 회원)
- 탈퇴 후 Redis 정리: Access Token 블랙리스트 등록, 오늘 랭킹 Sorted Set/Hash 제거
- 탈퇴 후 쿠키(access_token, refresh_token) 삭제

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
