### PR TITLE
refactor: 백엔드 코드 품질 개선

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.gakkaweo.backend.auth.security.CustomUserDetails;
 import com.gakkaweo.backend.auth.service.AccountService;
 import com.gakkaweo.backend.auth.service.AuthService;
 import com.gakkaweo.backend.auth.util.CookieUtils;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,18 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
   private final AuthService authService;
   private final AccountService accountService;
   private final CookieUtils cookieUtils;
-
-  public AuthController(
-      AuthService authService, AccountService accountService, CookieUtils cookieUtils) {
-    this.authService = authService;
-    this.accountService = accountService;
-    this.cookieUtils = cookieUtils;
-  }
 
   @PostMapping("/refresh")
   public ResponseEntity<Void> refresh(@CookieValue("refresh_token") String refreshToken) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package com.gakkaweo.backend.auth.jwt;
 
-import static com.gakkaweo.backend.auth.service.AuthService.BLACKLIST_PREFIX;
+import static com.gakkaweo.backend.common.redis.RedisKeyConstants.BLACKLIST_PREFIX;
 
 import com.gakkaweo.backend.auth.security.CustomUserDetails;
 import io.jsonwebtoken.Claims;
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -18,15 +19,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtProvider jwtProvider;
   private final StringRedisTemplate redisTemplate;
-
-  public JwtAuthenticationFilter(JwtProvider jwtProvider, StringRedisTemplate redisTemplate) {
-    this.jwtProvider = jwtProvider;
-    this.redisTemplate = redisTemplate;
-  }
 
   @Override
   protected void doFilterInternal(

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -9,6 +9,7 @@ import com.gakkaweo.backend.auth.util.CookieUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
@@ -17,23 +18,13 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
   private final AuthService authService;
   private final CookieUtils cookieUtils;
   private final OAuth2Properties oAuth2Properties;
   private final CookieAuthorizationRequestRepository authorizationRequestRepository;
-
-  public OAuth2LoginSuccessHandler(
-      AuthService authService,
-      CookieUtils cookieUtils,
-      OAuth2Properties oAuth2Properties,
-      CookieAuthorizationRequestRepository authorizationRequestRepository) {
-    this.authService = authService;
-    this.cookieUtils = cookieUtils;
-    this.oAuth2Properties = oAuth2Properties;
-    this.authorizationRequestRepository = authorizationRequestRepository;
-  }
 
   @Override
   public void onAuthenticationSuccess(

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/CustomOAuth2UserService.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.auth.oauth2.service;
 import com.gakkaweo.backend.auth.oauth2.CustomOAuth2User;
 import com.gakkaweo.backend.auth.oauth2.dto.OAuthAttributes;
 import com.gakkaweo.backend.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -12,13 +13,10 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
   private final OAuthMemberService oAuthMemberService;
-
-  public CustomOAuth2UserService(OAuthMemberService oAuthMemberService) {
-    this.oAuthMemberService = oAuthMemberService;
-  }
 
   @Override
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/OAuthMemberService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/OAuthMemberService.java
@@ -7,26 +7,19 @@ import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
 import com.gakkaweo.backend.domain.member.service.NicknameGenerator;
 import java.util.Objects;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class OAuthMemberService {
 
   private final SocialAccountRepository socialAccountRepository;
   private final MemberRepository memberRepository;
   private final NicknameGenerator nicknameGenerator;
-
-  public OAuthMemberService(
-      SocialAccountRepository socialAccountRepository,
-      MemberRepository memberRepository,
-      NicknameGenerator nicknameGenerator) {
-    this.socialAccountRepository = socialAccountRepository;
-    this.memberRepository = memberRepository;
-    this.nicknameGenerator = nicknameGenerator;
-  }
 
   @Transactional
   public Member findOrCreateMember(OAuthAttributes attributes) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
@@ -1,5 +1,9 @@
 package com.gakkaweo.backend.auth.service;
 
+import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
+import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
+import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
+
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.domain.admin.repository.SentenceUploadRepository;
@@ -11,6 +15,7 @@ import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -18,12 +23,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class AccountService {
 
   private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-  private static final String RANKING_KEY_PREFIX = "ranking:";
-  private static final String DETAIL_KEY_PREFIX = "ranking_detail:";
-  private static final String MEMBER_PREFIX = "member:";
 
   private final MemberRepository memberRepository;
   private final GameSessionRepository gameSessionRepository;
@@ -32,23 +35,6 @@ public class AccountService {
   private final RefreshTokenRepository refreshTokenRepository;
   private final AuthService authService;
   private final StringRedisTemplate redisTemplate;
-
-  public AccountService(
-      MemberRepository memberRepository,
-      GameSessionRepository gameSessionRepository,
-      SentenceUploadRepository sentenceUploadRepository,
-      SocialAccountRepository socialAccountRepository,
-      RefreshTokenRepository refreshTokenRepository,
-      AuthService authService,
-      StringRedisTemplate redisTemplate) {
-    this.memberRepository = memberRepository;
-    this.gameSessionRepository = gameSessionRepository;
-    this.sentenceUploadRepository = sentenceUploadRepository;
-    this.socialAccountRepository = socialAccountRepository;
-    this.refreshTokenRepository = refreshTokenRepository;
-    this.authService = authService;
-    this.redisTemplate = redisTemplate;
-  }
 
   @Transactional
   public void deleteAccount(UUID publicId) {
@@ -79,15 +65,15 @@ public class AccountService {
 
       LocalDate today = LocalDate.now(KST);
       String rankingKey = RANKING_KEY_PREFIX + today;
-      String memberKey = MEMBER_PREFIX + publicId;
-      String detailKey = DETAIL_KEY_PREFIX + today + ":" + MEMBER_PREFIX + publicId;
+      String memberKey = RANKING_MEMBER_PREFIX + publicId;
+      String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
 
       redisTemplate.opsForZSet().remove(rankingKey, memberKey);
       redisTemplate.delete(detailKey);
 
       log.info("탈퇴 회원 Redis 정리 완료: publicId={}", publicId);
     } catch (Exception e) {
-      log.warn("탈퇴 회원 Redis 정리 실패: publicId={}, {}", publicId, e.getMessage());
+      log.warn("탈퇴 회원 Redis 정리 실패: publicId={}", publicId, e);
     }
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.gakkaweo.backend.auth.service;
 
+import static com.gakkaweo.backend.common.redis.RedisKeyConstants.BLACKLIST_PREFIX;
+
 import com.gakkaweo.backend.auth.dto.AuthResponse;
 import com.gakkaweo.backend.auth.dto.TokenPair;
 import com.gakkaweo.backend.auth.jwt.JwtProvider;
@@ -11,6 +13,7 @@ import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import io.jsonwebtoken.Claims;
 import java.time.Duration;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -18,25 +21,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class AuthService {
-
-  public static final String BLACKLIST_PREFIX = "blacklist:jti:";
 
   private final JwtProvider jwtProvider;
   private final RefreshTokenService refreshTokenService;
   private final MemberRepository memberRepository;
   private final StringRedisTemplate redisTemplate;
-
-  public AuthService(
-      JwtProvider jwtProvider,
-      RefreshTokenService refreshTokenService,
-      MemberRepository memberRepository,
-      StringRedisTemplate redisTemplate) {
-    this.jwtProvider = jwtProvider;
-    this.refreshTokenService = refreshTokenService;
-    this.memberRepository = memberRepository;
-    this.redisTemplate = redisTemplate;
-  }
 
   @Transactional
   public TokenPair issueTokens(Member member) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
@@ -13,22 +13,18 @@ import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class RefreshTokenService {
 
   private final RefreshTokenRepository refreshTokenRepository;
   private final JwtProperties jwtProperties;
-
-  public RefreshTokenService(
-      RefreshTokenRepository refreshTokenRepository, JwtProperties jwtProperties) {
-    this.refreshTokenRepository = refreshTokenRepository;
-    this.jwtProperties = jwtProperties;
-  }
 
   @Transactional
   public String createRefreshToken(Member member) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/util/CookieUtils.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/util/CookieUtils.java
@@ -2,19 +2,16 @@ package com.gakkaweo.backend.auth.util;
 
 import com.gakkaweo.backend.auth.config.CookieProperties;
 import com.gakkaweo.backend.auth.config.JwtProperties;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class CookieUtils {
 
   private final JwtProperties jwtProperties;
   private final CookieProperties cookieProperties;
-
-  public CookieUtils(JwtProperties jwtProperties, CookieProperties cookieProperties) {
-    this.jwtProperties = jwtProperties;
-    this.cookieProperties = cookieProperties;
-  }
 
   public ResponseCookie createAccessTokenCookie(String token) {
     return ResponseCookie.from("access_token", token)

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorBody.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorBody.java
@@ -1,0 +1,3 @@
+package com.gakkaweo.backend.common.exception;
+
+public record ErrorBody(int status, String code, String message, String timestamp) {}

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
@@ -19,10 +19,11 @@ public enum ErrorCode {
 
   SENTENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "오늘의 문제를 찾을 수 없습니다"),
   SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "게임 세션을 찾을 수 없습니다"),
-  GAME_ALREADY_CLEARED(HttpStatus.CONFLICT, "이미 정답을 맞춘 게임입니다"),
   GAME_EXPIRED(HttpStatus.CONFLICT, "만료된 게임입니다"),
   CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "동시 수정 충돌이 발생했습니다"),
-  RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요");
+  RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요"),
+  SSE_MAX_CONNECTIONS(HttpStatus.SERVICE_UNAVAILABLE, "SSE 최대 연결 수를 초과했습니다"),
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");
 
   private final HttpStatus status;
   private final String message;

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
@@ -3,19 +3,23 @@ package com.gakkaweo.backend.common.exception;
 import java.time.Instant;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
 @SuppressWarnings("unused")
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<?> handleBusinessException(BusinessException e) {
@@ -28,43 +32,6 @@ public class GlobalExceptionHandler {
             errorCode.getMessage(),
             Instant.now().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
-  }
-
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<?> handleValidationException(MethodArgumentNotValidException e) {
-    String message =
-        e.getBindingResult().getFieldErrors().stream()
-            .map(error -> error.getField() + ": " + error.getDefaultMessage())
-            .collect(Collectors.joining(", "));
-    log.warn("유효성 검증 실패: {}", message);
-    ErrorBody body =
-        new ErrorBody(
-            HttpStatus.BAD_REQUEST.value(), "VALIDATION_FAILED", message, Instant.now().toString());
-    return ResponseEntity.badRequest().body(body);
-  }
-
-  @ExceptionHandler(MissingServletRequestParameterException.class)
-  public ResponseEntity<?> handleMissingParameter(MissingServletRequestParameterException e) {
-    log.warn("필수 파라미터 누락: {}", e.getMessage());
-    ErrorBody body =
-        new ErrorBody(
-            HttpStatus.BAD_REQUEST.value(),
-            "MISSING_PARAMETER",
-            e.getMessage(),
-            Instant.now().toString());
-    return ResponseEntity.badRequest().body(body);
-  }
-
-  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-  public ResponseEntity<?> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
-    log.warn("지원하지 않는 HTTP 메서드: {}", e.getMessage());
-    ErrorBody body =
-        new ErrorBody(
-            HttpStatus.METHOD_NOT_ALLOWED.value(),
-            "METHOD_NOT_ALLOWED",
-            e.getMessage(),
-            Instant.now().toString());
-    return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(body);
   }
 
   @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
@@ -81,7 +48,7 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<?> handleException(Exception e) {
+  public ResponseEntity<?> handleUnexpectedException(Exception e) {
     log.error("예상하지 못한 서버 오류 발생", e);
     ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
     ErrorBody body =
@@ -91,5 +58,64 @@ public class GlobalExceptionHandler {
             errorCode.getMessage(),
             Instant.now().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(
+      MethodArgumentNotValidException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
+    String message =
+        ex.getBindingResult().getFieldErrors().stream()
+            .map(error -> error.getField() + ": " + error.getDefaultMessage())
+            .collect(Collectors.joining(", "));
+    log.warn("유효성 검증 실패: {}", message);
+    ErrorBody body =
+        new ErrorBody(status.value(), "VALIDATION_FAILED", message, Instant.now().toString());
+    return ResponseEntity.status(status).body(body);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleMissingServletRequestParameter(
+      MissingServletRequestParameterException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
+    log.warn("필수 파라미터 누락: {}", ex.getMessage());
+    ErrorBody body =
+        new ErrorBody(
+            status.value(), "MISSING_PARAMETER", ex.getMessage(), Instant.now().toString());
+    return ResponseEntity.status(status).body(body);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+      HttpRequestMethodNotSupportedException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
+    log.warn("지원하지 않는 HTTP 메서드: {}", ex.getMessage());
+    ErrorBody body =
+        new ErrorBody(
+            status.value(), "METHOD_NOT_ALLOWED", ex.getMessage(), Instant.now().toString());
+    return ResponseEntity.status(status).body(body);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleExceptionInternal(
+      Exception ex,
+      @Nullable Object body,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
+    log.warn("{}: {}", ex.getClass().getSimpleName(), ex.getMessage());
+    ErrorBody errorBody =
+        new ErrorBody(
+            status.value(),
+            ex.getClass().getSimpleName(),
+            ex.getMessage(),
+            Instant.now().toString());
+    return ResponseEntity.status(status).headers(headers).body(errorBody);
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
@@ -80,5 +80,16 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
-  record ErrorBody(int status, String code, String message, String timestamp) {}
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<?> handleException(Exception e) {
+    log.error("예상하지 못한 서버 오류 발생", e);
+    ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+    ErrorBody body =
+        new ErrorBody(
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            errorCode.getMessage(),
+            Instant.now().toString());
+    return ResponseEntity.status(errorCode.getStatus()).body(body);
+  }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/common/redis/RedisKeyConstants.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/redis/RedisKeyConstants.java
@@ -1,0 +1,12 @@
+package com.gakkaweo.backend.common.redis;
+
+public final class RedisKeyConstants {
+
+  public static final String BLACKLIST_PREFIX = "blacklist:jti:";
+  public static final String RANKING_KEY_PREFIX = "ranking:";
+  public static final String RANKING_DETAIL_PREFIX = "ranking_detail:";
+  public static final String RANKING_MEMBER_PREFIX = "member:";
+  public static final String SIMILARITY_CACHE_PREFIX = "similarity:";
+
+  private RedisKeyConstants() {}
+}

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginSuccessHandler;
 import com.gakkaweo.backend.auth.oauth2.service.CustomOAuth2UserService;
 import com.gakkaweo.backend.ratelimit.filter.RateLimitFilter;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -24,6 +25,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -33,23 +35,6 @@ public class SecurityConfig {
   private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
   private final CookieAuthorizationRequestRepository authorizationRequestRepository;
   private final OAuth2Properties oAuth2Properties;
-
-  public SecurityConfig(
-      JwtAuthenticationFilter jwtAuthenticationFilter,
-      RateLimitFilter rateLimitFilter,
-      CustomOAuth2UserService customOAuth2UserService,
-      OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler,
-      OAuth2LoginFailureHandler oAuth2LoginFailureHandler,
-      CookieAuthorizationRequestRepository authorizationRequestRepository,
-      OAuth2Properties oAuth2Properties) {
-    this.jwtAuthenticationFilter = jwtAuthenticationFilter;
-    this.rateLimitFilter = rateLimitFilter;
-    this.customOAuth2UserService = customOAuth2UserService;
-    this.oAuth2LoginSuccessHandler = oAuth2LoginSuccessHandler;
-    this.oAuth2LoginFailureHandler = oAuth2LoginFailureHandler;
-    this.authorizationRequestRepository = authorizationRequestRepository;
-    this.oAuth2Properties = oAuth2Properties;
-  }
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/SentenceUpload.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/SentenceUpload.java
@@ -28,7 +28,7 @@ public class SentenceUpload {
   private Long id;
 
   @ManyToOne(fetch = LAZY)
-  @JoinColumn(name = "admin_id")
+  @JoinColumn(name = "admin_id", nullable = true)
   private Member admin;
 
   @Column(nullable = false, length = 255)

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/repository/SentenceUploadRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/repository/SentenceUploadRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface SentenceUploadRepository extends JpaRepository<SentenceUpload, Long> {
 
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query("UPDATE SentenceUpload s SET s.admin = null WHERE s.admin = :admin")
   int anonymizeByAdmin(@Param("admin") Member admin);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/auth/repository/RefreshTokenRepository.java
@@ -17,7 +17,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
   List<RefreshToken> findByMemberId(Long memberId);
 
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query("DELETE FROM RefreshToken r WHERE r.member.id = :memberId")
   int deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
@@ -43,6 +43,7 @@ public class DailySentence {
   @Column(length = 20)
   private DailySentenceStatus status = DailySentenceStatus.ACTIVE;
 
+  @Column(nullable = true)
   private Integer totalPlayers;
 
   private Instant createdAt;

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -40,7 +40,7 @@ public class GameSession {
   private Long id;
 
   @ManyToOne(fetch = LAZY)
-  @JoinColumn(name = "member_id")
+  @JoinColumn(name = "member_id", nullable = true)
   private Member member;
 
   @ManyToOne(fetch = LAZY)
@@ -58,6 +58,7 @@ public class GameSession {
 
   private Instant clearedAt;
 
+  @Column(nullable = true)
   private Integer finalRank;
 
   @Version private Integer version;

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GameSessionRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GameSessionRepository.java
@@ -14,7 +14,7 @@ public interface GameSessionRepository extends JpaRepository<GameSession, Long> 
 
   Optional<GameSession> findByMemberAndSentence(Member member, DailySentence sentence);
 
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query(
       "UPDATE GameSession g SET g.status ="
           + " com.gakkaweo.backend.domain.game.entity.GameSessionStatus.EXPIRED"
@@ -26,7 +26,7 @@ public interface GameSessionRepository extends JpaRepository<GameSession, Long> 
   @Query("SELECT g FROM GameSession g JOIN FETCH g.member WHERE g.sentence = :sentence")
   List<GameSession> findAllBySentenceWithMember(@Param("sentence") DailySentence sentence);
 
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query("UPDATE GameSession g SET g.member = null WHERE g.member = :member")
   int anonymizeByMember(@Param("member") Member member);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/repository/SocialAccountRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/repository/SocialAccountRepository.java
@@ -15,7 +15,7 @@ public interface SocialAccountRepository extends JpaRepository<SocialAccount, Lo
   @EntityGraph(attributePaths = "member")
   Optional<SocialAccount> findByProviderAndProviderId(SocialProvider provider, String providerId);
 
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query("DELETE FROM SocialAccount s WHERE s.member = :member")
   int deleteByMember(@Param("member") Member member);
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/controller/DailyGameController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/controller/DailyGameController.java
@@ -9,6 +9,7 @@ import com.gakkaweo.backend.game.dto.TodayResponse;
 import com.gakkaweo.backend.game.service.DailyGameService;
 import jakarta.validation.Valid;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,13 +21,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/daily")
+@RequiredArgsConstructor
 public class DailyGameController {
 
   private final DailyGameService dailyGameService;
-
-  public DailyGameController(DailyGameService dailyGameService) {
-    this.dailyGameService = dailyGameService;
-  }
 
   @GetMapping("/today")
   public ResponseEntity<TodayResponse> getToday() {

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -25,6 +26,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class DailySentenceScheduler {
 
   private static final ZoneId KST = ZoneId.of("Asia/Seoul");
@@ -34,19 +36,6 @@ public class DailySentenceScheduler {
   private final RankingService rankingService;
   private final TransactionTemplate transactionTemplate;
   private final ApplicationEventPublisher eventPublisher;
-
-  public DailySentenceScheduler(
-      DailySentenceRepository dailySentenceRepository,
-      GameSessionRepository gameSessionRepository,
-      RankingService rankingService,
-      TransactionTemplate transactionTemplate,
-      ApplicationEventPublisher eventPublisher) {
-    this.dailySentenceRepository = dailySentenceRepository;
-    this.gameSessionRepository = gameSessionRepository;
-    this.rankingService = rankingService;
-    this.transactionTemplate = transactionTemplate;
-    this.eventPublisher = eventPublisher;
-  }
 
   @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
   public void executeMidnightJob() {

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -28,6 +28,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -36,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class DailyGameService {
 
   private static final ZoneId KST = ZoneId.of("Asia/Seoul");
@@ -49,27 +51,6 @@ public class DailyGameService {
   private final HintMaskGenerator hintMaskGenerator;
   private final GameProperties gameProperties;
   private final ApplicationEventPublisher eventPublisher;
-
-  public DailyGameService(
-      DailySentenceRepository dailySentenceRepository,
-      GameSessionRepository gameSessionRepository,
-      GuessHistoryRepository guessHistoryRepository,
-      MemberRepository memberRepository,
-      SimilarityService similarityService,
-      RankingService rankingService,
-      HintMaskGenerator hintMaskGenerator,
-      GameProperties gameProperties,
-      ApplicationEventPublisher eventPublisher) {
-    this.dailySentenceRepository = dailySentenceRepository;
-    this.gameSessionRepository = gameSessionRepository;
-    this.guessHistoryRepository = guessHistoryRepository;
-    this.memberRepository = memberRepository;
-    this.similarityService = similarityService;
-    this.rankingService = rankingService;
-    this.hintMaskGenerator = hintMaskGenerator;
-    this.gameProperties = gameProperties;
-    this.eventPublisher = eventPublisher;
-  }
 
   @Transactional(readOnly = true)
   public TodayResponse getToday() {

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/SimilarityService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/SimilarityService.java
@@ -1,5 +1,7 @@
 package com.gakkaweo.backend.infra.ai.service;
 
+import static com.gakkaweo.backend.common.redis.RedisKeyConstants.SIMILARITY_CACHE_PREFIX;
+
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.infra.ai.client.AiServiceClient;
@@ -12,14 +14,13 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
 public class SimilarityService {
-
-  private static final String CACHE_KEY_PREFIX = "similarity:";
 
   private final AiServiceClient aiServiceClient;
   private final TextNormalizer textNormalizer;
@@ -64,17 +65,17 @@ public class SimilarityService {
             return BigDecimal.valueOf(response.score()).setScale(1, RoundingMode.HALF_UP);
           });
     } catch (CallNotPermittedException e) {
-      log.warn("서킷 브레이커 OPEN 상태: {}", e.getMessage());
+      log.warn("서킷 브레이커 OPEN 상태: {}", e.getMessage(), e);
       throw new BusinessException(ErrorCode.AI_SERVICE_UNAVAILABLE);
     } catch (AiServiceException e) {
-      log.warn("AI 서비스 호출 실패: {}", e.getMessage());
+      log.warn("AI 서비스 호출 실패: {}", e.getMessage(), e);
       throw new BusinessException(ErrorCode.AI_SERVICE_UNAVAILABLE);
     }
   }
 
   private String buildCacheKey(Long sentenceId, String normalizedText) {
     String hash = textNormalizer.hashForCache(normalizedText);
-    return CACHE_KEY_PREFIX + sentenceId + ":" + hash;
+    return SIMILARITY_CACHE_PREFIX + sentenceId + ":" + hash;
   }
 
   private BigDecimal getFromCache(String cacheKey) {
@@ -83,8 +84,8 @@ public class SimilarityService {
       if (value != null) {
         return new BigDecimal(value);
       }
-    } catch (Exception e) {
-      log.warn("Redis 캐시 조회 실패: {}", e.getMessage());
+    } catch (DataAccessException e) {
+      log.warn("Redis 캐시 조회 실패: {}", e.getMessage(), e);
     }
     return null;
   }
@@ -92,8 +93,8 @@ public class SimilarityService {
   private void saveToCache(String cacheKey, BigDecimal score, Duration ttl) {
     try {
       redisTemplate.opsForValue().set(cacheKey, score.toPlainString(), ttl);
-    } catch (Exception e) {
-      log.warn("Redis 캐시 저장 실패: {}", e.getMessage());
+    } catch (DataAccessException e) {
+      log.warn("Redis 캐시 저장 실패: {}", e.getMessage(), e);
     }
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/controller/RankingController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/controller/RankingController.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.ranking.controller;
 import com.gakkaweo.backend.ranking.dto.RankingResponse;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import com.gakkaweo.backend.ranking.sse.SseConnectionManager;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,16 +13,11 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/ranking")
+@RequiredArgsConstructor
 public class RankingController {
 
   private final RankingService rankingService;
   private final SseConnectionManager sseConnectionManager;
-
-  public RankingController(
-      RankingService rankingService, SseConnectionManager sseConnectionManager) {
-    this.rankingService = rankingService;
-    this.sseConnectionManager = sseConnectionManager;
-  }
 
   @GetMapping("/today")
   public ResponseEntity<RankingResponse> getTodayRanking() {

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -1,5 +1,9 @@
 package com.gakkaweo.backend.ranking.service;
 
+import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
+import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
+import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
+
 import com.gakkaweo.backend.domain.game.entity.GameSession;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.ranking.dto.RankingResponse;
@@ -15,32 +19,28 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class RankingService {
 
   private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-  private static final String RANKING_KEY_PREFIX = "ranking:";
-  private static final String DETAIL_KEY_PREFIX = "ranking_detail:";
-  private static final String MEMBER_PREFIX = "member:";
   private static final int TOP_RANKING_SIZE = 10;
   private static final Duration EXPIRE_TTL = Duration.ofHours(1);
 
   private final StringRedisTemplate redisTemplate;
 
-  public RankingService(StringRedisTemplate redisTemplate) {
-    this.redisTemplate = redisTemplate;
-  }
-
   public Integer updateRanking(GameSession session, Member member) {
     try {
       LocalDate today = LocalDate.now(KST);
       String rankingKey = buildRankingKey(today);
-      String memberKey = MEMBER_PREFIX + member.getPublicId();
+      String memberKey = RANKING_MEMBER_PREFIX + member.getPublicId();
       String detailKey = buildDetailKey(today, member.getPublicId());
 
       long elapsedSeconds = calculateElapsedSeconds();
@@ -63,8 +63,8 @@ public class RankingService {
         return rank.intValue() + 1;
       }
       return null;
-    } catch (Exception e) {
-      log.warn("랭킹 갱신 실패: memberId={}, {}", member.getPublicId(), e.getMessage());
+    } catch (DataAccessException e) {
+      log.warn("랭킹 갱신 실패: memberId={}", member.getPublicId(), e);
       return null;
     }
   }
@@ -89,7 +89,7 @@ public class RankingService {
       List<RankingEntry> entries = new ArrayList<>();
       long rank = 1;
       for (String memberKey : topMembers) {
-        String publicIdStr = memberKey.substring(MEMBER_PREFIX.length());
+        String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
         String detailKey = buildDetailKey(today, UUID.fromString(publicIdStr));
 
         Map<Object, Object> detail = redisTemplate.opsForHash().entries(detailKey);
@@ -108,8 +108,8 @@ public class RankingService {
       }
 
       return new RankingResponse(entries, totalPlayers);
-    } catch (Exception e) {
-      log.warn("랭킹 목록 조회 실패: {}", e.getMessage());
+    } catch (DataAccessException e) {
+      log.warn("랭킹 목록 조회 실패: {}", e.getMessage(), e);
       return new RankingResponse(List.of(), 0);
     }
   }
@@ -130,13 +130,13 @@ public class RankingService {
       List<RankingSnapshot.MemberRank> memberRanks = new ArrayList<>();
       int rank = 1;
       for (String memberKey : allMembers) {
-        UUID publicId = UUID.fromString(memberKey.substring(MEMBER_PREFIX.length()));
+        UUID publicId = UUID.fromString(memberKey.substring(RANKING_MEMBER_PREFIX.length()));
         memberRanks.add(new RankingSnapshot.MemberRank(publicId, rank++));
       }
 
       return new RankingSnapshot(memberRanks, totalPlayers.intValue());
-    } catch (Exception e) {
-      log.warn("랭킹 스냅샷 조회 실패: date={}, {}", date, e.getMessage());
+    } catch (DataAccessException e) {
+      log.warn("랭킹 스냅샷 조회 실패: date={}", date, e);
       return new RankingSnapshot(List.of(), 0);
     }
   }
@@ -148,7 +148,7 @@ public class RankingService {
     int detailCount = 0;
     if (members != null) {
       for (String memberKey : members) {
-        String publicIdStr = memberKey.substring(MEMBER_PREFIX.length());
+        String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
         String detailKey = buildDetailKey(date, UUID.fromString(publicIdStr));
         redisTemplate.expire(detailKey, EXPIRE_TTL);
         detailCount++;
@@ -177,6 +177,6 @@ public class RankingService {
   }
 
   private String buildDetailKey(LocalDate date, UUID memberPublicId) {
-    return DETAIL_KEY_PREFIX + date + ":" + MEMBER_PREFIX + memberPublicId;
+    return RANKING_DETAIL_PREFIX + date + ":" + RANKING_MEMBER_PREFIX + memberPublicId;
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -108,7 +108,7 @@ public class RankingService {
       }
 
       return new RankingResponse(entries, totalPlayers);
-    } catch (DataAccessException e) {
+    } catch (Exception e) {
       log.warn("랭킹 목록 조회 실패: {}", e.getMessage(), e);
       return new RankingResponse(List.of(), 0);
     }
@@ -135,7 +135,7 @@ public class RankingService {
       }
 
       return new RankingSnapshot(memberRanks, totalPlayers.intValue());
-    } catch (DataAccessException e) {
+    } catch (Exception e) {
       log.warn("랭킹 스냅샷 조회 실패: date={}", date, e);
       return new RankingSnapshot(List.of(), 0);
     }

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
@@ -1,5 +1,7 @@
 package com.gakkaweo.backend.ranking.sse;
 
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.ranking.dto.RankingResponse;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import jakarta.annotation.PostConstruct;
@@ -10,14 +12,14 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class SseConnectionManager {
 
   private static final int MAX_CONNECTIONS = 500;
@@ -32,10 +34,6 @@ public class SseConnectionManager {
             t.setDaemon(true);
             return t;
           });
-
-  public SseConnectionManager(RankingService rankingService) {
-    this.rankingService = rankingService;
-  }
 
   @PostConstruct
   void startHeartbeat() {
@@ -55,7 +53,7 @@ public class SseConnectionManager {
 
   public SseEmitter register() {
     if (emitters.size() >= MAX_CONNECTIONS) {
-      throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "SSE 최대 연결 수 초과");
+      throw new BusinessException(ErrorCode.SSE_MAX_CONNECTIONS);
     }
 
     SseEmitter emitter = new SseEmitter(0L);
@@ -83,7 +81,7 @@ public class SseConnectionManager {
       sendToAll(
           emitter -> emitter.send(SseEmitter.event().name(SseEventType.HEARTBEAT.name()).data("")));
     } catch (Exception e) {
-      log.error("SSE heartbeat 처리 중 예외: {}", e.getMessage());
+      log.error("SSE heartbeat 처리 중 예외", e);
     }
   }
 
@@ -93,7 +91,7 @@ public class SseConnectionManager {
       emitter.send(SseEmitter.event().name(SseEventType.RANKING_UPDATE.name()).data(ranking));
     } catch (Exception e) {
       removeAndComplete(emitter);
-      log.debug("SSE 초기 데이터 전송 실패: {}", e.getMessage());
+      log.debug("SSE 초기 데이터 전송 실패: {}", e.getMessage(), e);
     }
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
@@ -51,7 +51,7 @@ public class SseConnectionManager {
     emitters.clear();
   }
 
-  public SseEmitter register() {
+  public synchronized SseEmitter register() {
     if (emitters.size() >= MAX_CONNECTIONS) {
       throw new BusinessException(ErrorCode.SSE_MAX_CONNECTIONS);
     }

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseEventListener.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseEventListener.java
@@ -10,12 +10,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class SseEventListener {
 
   private static final long DEBOUNCE_MILLIS = 100;
@@ -30,12 +32,6 @@ public class SseEventListener {
             return t;
           });
   private volatile ScheduledFuture<?> pendingBroadcast;
-
-  public SseEventListener(
-      RankingService rankingService, SseConnectionManager sseConnectionManager) {
-    this.rankingService = rankingService;
-    this.sseConnectionManager = sseConnectionManager;
-  }
 
   @PreDestroy
   void shutdown() {
@@ -64,7 +60,7 @@ public class SseEventListener {
       sseConnectionManager.broadcast(SseEventType.RANKING_UPDATE, ranking);
       log.debug("RANKING_UPDATE 브로드캐스트: totalPlayers={}", ranking.totalPlayers());
     } catch (Exception e) {
-      log.error("RANKING_UPDATE 브로드캐스트 실패: {}", e.getMessage());
+      log.error("RANKING_UPDATE 브로드캐스트 실패", e);
     }
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/BucketStore.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/BucketStore.java
@@ -7,20 +7,18 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class BucketStore {
 
   private final RateLimitProperties properties;
   private final Map<String, BucketEntry> buckets = new ConcurrentHashMap<>();
-
-  public BucketStore(RateLimitProperties properties) {
-    this.properties = properties;
-  }
 
   public Bucket resolveBucket(EndpointGroup group, String key) {
     String bucketKey = group.name() + ":" + key;

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/RateLimitFilter.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/RateLimitFilter.java
@@ -2,6 +2,7 @@ package com.gakkaweo.backend.ratelimit.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gakkaweo.backend.auth.security.CustomUserDetails;
+import com.gakkaweo.backend.common.exception.ErrorBody;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.ConsumptionProbe;
@@ -11,8 +12,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -22,20 +23,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class RateLimitFilter extends OncePerRequestFilter {
 
   private final EndpointGroupResolver endpointGroupResolver;
   private final BucketStore bucketStore;
   private final ObjectMapper objectMapper;
-
-  public RateLimitFilter(
-      EndpointGroupResolver endpointGroupResolver,
-      BucketStore bucketStore,
-      ObjectMapper objectMapper) {
-    this.endpointGroupResolver = endpointGroupResolver;
-    this.bucketStore = bucketStore;
-    this.objectMapper = objectMapper;
-  }
 
   @Override
   protected void doFilterInternal(
@@ -64,12 +57,12 @@ public class RateLimitFilter extends OncePerRequestFilter {
     log.warn("Rate limit 초과: group={}, key={}, retryAfter={}s", group, key, retryAfterSeconds);
 
     ErrorCode errorCode = ErrorCode.RATE_LIMIT_EXCEEDED;
-    Map<String, Object> body =
-        Map.of(
-            "status", errorCode.getStatus().value(),
-            "code", errorCode.name(),
-            "message", errorCode.getMessage(),
-            "timestamp", Instant.now().toString());
+    ErrorBody body =
+        new ErrorBody(
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            errorCode.getMessage(),
+            Instant.now().toString());
 
     response.setStatus(errorCode.getStatus().value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);


### PR DESCRIPTION
## 관련 이슈

Closes #46 

## 변경 사항

- `@Modifying(clearAutomatically = true)` 일괄 적용 — 벌크 JPQL 5개
- Redis 키 prefix를 `RedisKeyConstants` 공유 클래스로 통합
- `ErrorBody` 공용 record 추출 + catch-all 500 핸들러 추가
- `INTERNAL_SERVER_ERROR`, `SSE_MAX_CONNECTIONS` ErrorCode 추가
- 미사용 `GAME_ALREADY_CLEARED` ErrorCode 제거
- `ResponseStatusException` → `BusinessException` 교체 (SSE)
- 수동 생성자 → `@RequiredArgsConstructor` 통일 (19개 파일)
- `log.warn/error`에 exception 객체 전달하여 스택트레이스 출력
- Redis 관련 `catch(Exception)` → `catch(DataAccessException)` 구체화
- Entity JPA 매핑 nullable 명시화 (V4, V6 반영)

## 코드리뷰 이후
- `GlobalExceptionHandler`에 `ResponseEntityExceptionHandler` 상속 적용 — 프레임워크 예외(`HttpMessageNotReadableException` 등)가 올바른 상태 코드로 반환
- `getRankings`/`getAllRankingsForDate` catch를 `Exception`으로 복원 — 파싱 예외 혼재 고려
- `SseConnectionManager.register()`에 `synchronized` 추가 — 최대 연결 수 check-then-act race condition 해소

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
