### PR TITLE
feat: 게임 페이지 구현

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -80,6 +80,7 @@ public class SecurityConfig {
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setAllowCredentials(true);
+    configuration.setExposedHeaders(List.of("Retry-After", "X-Rate-Limit-Remaining"));
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.95.0",
+    "canvas-confetti": "^1.9.4",
     "pretendard": "^1.3.9",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.2.2",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
       "@tanstack/react-query":
         specifier: ^5.95.0
         version: 5.95.0(react@19.2.4)
+      canvas-confetti:
+        specifier: ^1.9.4
+        version: 1.9.4
       pretendard:
         specifier: ^1.3.9
         version: 1.3.9
@@ -32,6 +35,9 @@ importers:
       "@tailwindcss/vite":
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+      "@types/canvas-confetti":
+        specifier: ^1.9.0
+        version: 1.9.0
       "@types/node":
         specifier: ^25.5.0
         version: 25.5.0
@@ -508,6 +514,10 @@ packages:
     resolution:
       { integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg== }
 
+  "@types/canvas-confetti@1.9.0":
+    resolution:
+      { integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg== }
+
   "@types/estree@1.0.8":
     resolution:
       { integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w== }
@@ -676,6 +686,10 @@ packages:
   caniuse-lite@1.0.30001781:
     resolution:
       { integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw== }
+
+  canvas-confetti@1.9.4:
+    resolution:
+      { integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw== }
 
   chalk@4.1.2:
     resolution:
@@ -1757,6 +1771,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  "@types/canvas-confetti@1.9.0": {}
+
   "@types/estree@1.0.8": {}
 
   "@types/json-schema@7.0.15": {}
@@ -1914,6 +1930,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001781: {}
+
+  canvas-confetti@1.9.4: {}
 
   chalk@4.1.2:
     dependencies:

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -31,9 +31,10 @@ export function GamePage() {
 
   const [inputError, setInputError] = useState<string | null>(null);
   const [rateLimited, setRateLimited] = useState(false);
+  const [localCleared, setLocalCleared] = useState(false);
   const retryRef = useRef(false);
 
-  const isCleared = isAuthenticated ? status?.gameStatus === "CLEARED" : anonState.isCleared;
+  const isCleared = status?.gameStatus === "CLEARED" || anonState.isCleared || localCleared;
 
   const displayGuesses = isAuthenticated ? (history?.guesses ?? []) : anonState.guesses;
 
@@ -89,6 +90,9 @@ export function GamePage() {
                 } else {
                   addAnonGuess(guessText, res.similarity, res.isCorrect);
                 }
+                if (res.isCorrect) {
+                  setLocalCleared(true);
+                }
               },
               onError: () => {
                 retryRef.current = false;
@@ -126,6 +130,9 @@ export function GamePage() {
             appendGuessToCache(text, res);
           } else {
             addAnonGuess(text, res.similarity, res.isCorrect);
+          }
+          if (res.isCorrect) {
+            setLocalCleared(true);
           }
         },
         onError: (err) => handleGuessError(err, sentenceId, text),

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -55,7 +55,7 @@ export function GamePage() {
         },
       ],
     }));
-    queryClient.invalidateQueries({ queryKey: ["game", "status"] });
+    queryClient.invalidateQueries({ queryKey: ["game", "status", sentenceId] });
   }
 
   function handleGuessError(err: unknown, sentenceId: string, guessText: string) {

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -1,12 +1,194 @@
+import { useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "@/shared/api/client";
+import type { GuessResponse, HistoryResponse } from "@/shared/api/types";
 import { Card } from "@/shared/ui/Card";
+import { useAuthStore } from "@/shared/stores/useAuthStore";
+import { useToastStore } from "@/shared/stores/useToastStore";
+import { useToday, useGameStatus, useGameHistory, useGuess } from "@/features/game/hooks/useGameQueries";
+import { useCountdown } from "@/features/game/hooks/useCountdown";
+import { useAnonymousGame } from "@/features/game/hooks/useAnonymousGame";
+import { HintMask } from "@/features/game/components/HintMask";
+import { GuessInput } from "@/features/game/components/GuessInput";
+import { GuessHistory } from "@/features/game/components/GuessHistory";
+import { GameClearedCard } from "@/features/game/components/GameClearedCard";
+import { YesterdayAnswer } from "@/features/game/components/YesterdayAnswer";
 
 export function GamePage() {
+  const queryClient = useQueryClient();
+  const addToast = useToastStore((s) => s.addToast);
+  const { isAuthenticated, isLoading: authLoading } = useAuthStore();
+
+  const { data: today, isLoading: todayLoading, error: todayError } = useToday();
+  const sentenceId = today?.sentenceId;
+
+  const { data: status } = useGameStatus(sentenceId);
+  const { data: history } = useGameHistory(sentenceId);
+  const { state: anonState, addGuess: addAnonGuess } = useAnonymousGame(sentenceId);
+
+  const guessMutation = useGuess();
+  const { formatted: countdown } = useCountdown(today?.expiresAt);
+
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [rateLimited, setRateLimited] = useState(false);
+  const retryRef = useRef(false);
+
+  const isCleared = isAuthenticated ? status?.gameStatus === "CLEARED" : anonState.isCleared;
+
+  const displayGuesses = isAuthenticated ? (history?.guesses ?? []) : anonState.guesses;
+
+  const attemptCount = isAuthenticated ? (status?.attemptCount ?? 0) : anonState.attemptCount;
+
+  const bestSimilarity = isAuthenticated ? (status?.bestSimilarity ?? 0) : anonState.bestSimilarity;
+
+  const similarities = displayGuesses.map((g) => g.similarity);
+
+  function appendGuessToCache(guessText: string, res: GuessResponse) {
+    queryClient.setQueryData<HistoryResponse>(["game", "history", sentenceId], (old) => ({
+      guesses: [
+        ...(old?.guesses ?? []),
+        {
+          guessText,
+          similarity: res.similarity,
+          attemptNumber: res.attemptNumber ?? (old?.guesses?.length ?? 0) + 1,
+          createdAt: res.timestamp,
+        },
+      ],
+    }));
+    queryClient.invalidateQueries({ queryKey: ["game", "status"] });
+  }
+
+  function handleGuessError(err: unknown, sentenceId: string, guessText: string) {
+    if (!(err instanceof ApiError)) {
+      addToast("알 수 없는 오류가 발생했습니다.", "error");
+      return;
+    }
+
+    switch (err.code) {
+      case "RATE_LIMIT_EXCEEDED": {
+        const seconds = err.retryAfter ?? 5;
+        setRateLimited(true);
+        setTimeout(() => setRateLimited(false), seconds * 1000);
+        addToast(`요청이 너무 많습니다. ${seconds}초 후 다시 시도해주세요.`, "error");
+        break;
+      }
+      case "GAME_EXPIRED":
+        addToast("게임이 만료되었습니다. 새로운 문제를 불러옵니다.", "info");
+        queryClient.invalidateQueries({ queryKey: ["game", "today"] });
+        break;
+      case "CONCURRENT_MODIFICATION":
+        if (!retryRef.current) {
+          retryRef.current = true;
+          guessMutation.mutate(
+            { sentenceId, guessText },
+            {
+              onSuccess: (res) => {
+                retryRef.current = false;
+                if (isAuthenticated) {
+                  appendGuessToCache(guessText, res);
+                } else {
+                  addAnonGuess(guessText, res.similarity, res.isCorrect);
+                }
+              },
+              onError: () => {
+                retryRef.current = false;
+                addToast("다시 시도해주세요.", "error");
+              },
+            },
+          );
+        } else {
+          retryRef.current = false;
+          addToast("다시 시도해주세요.", "error");
+        }
+        break;
+      case "AI_SERVICE_UNAVAILABLE":
+        addToast("AI 서버 점검 중입니다. 잠시 후 다시 시도해주세요.", "error");
+        break;
+      case "INVALID_GUESS_TEXT":
+        setInputError(err.message);
+        break;
+      default:
+        addToast(err.message, "error");
+    }
+  }
+
+  function handleSubmit(text: string) {
+    if (!sentenceId) {
+      return;
+    }
+    setInputError(null);
+
+    guessMutation.mutate(
+      { sentenceId, guessText: text },
+      {
+        onSuccess: (res) => {
+          if (isAuthenticated) {
+            appendGuessToCache(text, res);
+          } else {
+            addAnonGuess(text, res.similarity, res.isCorrect);
+          }
+        },
+        onError: (err) => handleGuessError(err, sentenceId, text),
+      },
+    );
+  }
+
+  if (todayLoading || authLoading) {
+    return (
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div className="h-10 w-48 bg-gray-200 dark:bg-gray-800 animate-pulse" />
+        <div className="border-4 border-gray-200 dark:border-gray-800 p-6">
+          <div className="h-8 w-full bg-gray-200 dark:bg-gray-800 animate-pulse" />
+        </div>
+      </div>
+    );
+  }
+
+  if (todayError) {
+    const message = todayError instanceof ApiError ? todayError.message : "문제를 불러올 수 없습니다.";
+    return (
+      <div className="max-w-2xl mx-auto space-y-6">
+        <h1 className="text-4xl font-black">오늘의 문장</h1>
+        <Card>
+          <p className="text-lg font-bold text-red-500">{message}</p>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!today) {
+    return null;
+  }
+
   return (
     <div className="max-w-2xl mx-auto space-y-6">
-      <h1 className="text-4xl font-black">오늘의 문장</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-4xl font-black">오늘의 문장</h1>
+        <span className="text-sm font-bold text-gray-600 dark:text-gray-400">
+          다음 문장까지: <span className="tabular-nums">{countdown}</span>
+        </span>
+      </div>
+
+      {today.yesterdaySentence && today.yesterdayDate && (
+        <YesterdayAnswer sentence={today.yesterdaySentence} date={today.yesterdayDate} />
+      )}
+
       <Card>
-        <p className="text-lg font-medium text-gray-600 dark:text-gray-400">게임 페이지 — Issue B에서 구현 예정</p>
+        <HintMask hintMask={today.hintMask} charCounts={today.charCounts} />
       </Card>
+
+      {isCleared && (
+        <GameClearedCard attemptCount={attemptCount} bestSimilarity={bestSimilarity} similarities={similarities} />
+      )}
+
+      <GuessInput
+        onSubmit={handleSubmit}
+        isLoading={guessMutation.isPending}
+        disabled={rateLimited}
+        error={inputError}
+      />
+
+      <GuessHistory guesses={displayGuesses} />
     </div>
   );
 }

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -1,5 +1,6 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import confetti from "canvas-confetti";
 import { ApiError } from "@/shared/api/client";
 import type { GuessResponse, HistoryResponse } from "@/shared/api/types";
 import { Card } from "@/shared/ui/Card";
@@ -42,7 +43,13 @@ export function GamePage() {
 
   const bestSimilarity = isAuthenticated ? (status?.bestSimilarity ?? 0) : anonState.bestSimilarity;
 
-  const similarities = displayGuesses.map((g) => g.similarity);
+  useEffect(() => {
+    if (!localCleared) {
+      return;
+    }
+    confetti({ particleCount: 80, spread: 70, origin: { x: 0.3, y: 0.5 } });
+    confetti({ particleCount: 80, spread: 70, origin: { x: 0.7, y: 0.5 } });
+  }, [localCleared]);
 
   function appendGuessToCache(guessText: string, res: GuessResponse) {
     queryClient.setQueryData<HistoryResponse>(["game", "history", sentenceId], (old) => ({
@@ -90,7 +97,7 @@ export function GamePage() {
                 } else {
                   addAnonGuess(guessText, res.similarity, res.isCorrect);
                 }
-                if (res.isCorrect) {
+                if (res.isCorrect && !isCleared) {
                   setLocalCleared(true);
                 }
               },
@@ -131,7 +138,7 @@ export function GamePage() {
           } else {
             addAnonGuess(text, res.similarity, res.isCorrect);
           }
-          if (res.isCorrect) {
+          if (res.isCorrect && !isCleared) {
             setLocalCleared(true);
           }
         },
@@ -185,7 +192,7 @@ export function GamePage() {
       </Card>
 
       {isCleared && (
-        <GameClearedCard attemptCount={attemptCount} bestSimilarity={bestSimilarity} similarities={similarities} />
+        <GameClearedCard attemptCount={attemptCount} bestSimilarity={bestSimilarity} />
       )}
 
       <GuessInput

--- a/frontend/src/features/game/api.ts
+++ b/frontend/src/features/game/api.ts
@@ -8,7 +8,7 @@ export function getToday() {
 export function submitGuess(body: GuessRequest) {
   return apiFetch<GuessResponse>("/daily/guess", {
     method: "POST",
-    body: body as unknown as BodyInit,
+    body: body,
   });
 }
 

--- a/frontend/src/features/game/api.ts
+++ b/frontend/src/features/game/api.ts
@@ -1,0 +1,21 @@
+import { apiFetch } from "@/shared/api/client";
+import type { GuessRequest, GuessResponse, HistoryResponse, StatusResponse, TodayResponse } from "@/shared/api/types";
+
+export function getToday() {
+  return apiFetch<TodayResponse>("/daily/today");
+}
+
+export function submitGuess(body: GuessRequest) {
+  return apiFetch<GuessResponse>("/daily/guess", {
+    method: "POST",
+    body: body as unknown as BodyInit,
+  });
+}
+
+export function getHistory(sentenceId: string) {
+  return apiFetch<HistoryResponse>(`/daily/history?sentenceId=${sentenceId}`);
+}
+
+export function getStatus() {
+  return apiFetch<StatusResponse>("/daily/status");
+}

--- a/frontend/src/features/game/components/GameClearedCard.tsx
+++ b/frontend/src/features/game/components/GameClearedCard.tsx
@@ -24,7 +24,7 @@ export function GameClearedCard({ attemptCount, bestSimilarity, similarities }: 
   }
 
   return (
-    <Card className="bg-green-50 dark:bg-green-950 border-green-500 dark:border-green-400">
+    <Card className="bg-green-50 dark:bg-green-950">
       <div className="space-y-4 text-center">
         <p className="text-3xl font-black">🎉 정답!</p>
         <p className="text-lg font-bold">{attemptCount}회 만에 맞추셨습니다!</p>

--- a/frontend/src/features/game/components/GameClearedCard.tsx
+++ b/frontend/src/features/game/components/GameClearedCard.tsx
@@ -1,39 +1,19 @@
 import { Card } from "@/shared/ui/Card";
-import { Button } from "@/shared/ui/Button";
-import { useToastStore } from "@/shared/stores/useToastStore";
 
 interface GameClearedCardProps {
   attemptCount: number;
   bestSimilarity: number;
-  similarities: number[];
 }
 
-export function GameClearedCard({ attemptCount, bestSimilarity, similarities }: GameClearedCardProps) {
-  const addToast = useToastStore((s) => s.addToast);
-
-  async function handleCopy() {
-    const path = similarities.map((s) => s.toFixed(1)).join(" → ");
-    const text = `가까워 🎉 ${attemptCount}회 만에 성공!\n최고 유사도: ${path}`;
-
-    try {
-      await navigator.clipboard.writeText(text);
-      addToast("결과가 복사되었습니다!", "success");
-    } catch {
-      addToast("복사에 실패했습니다.", "error");
-    }
-  }
-
+export function GameClearedCard({ attemptCount, bestSimilarity }: GameClearedCardProps) {
   return (
-    <Card className="bg-green-50 dark:bg-green-950">
-      <div className="space-y-4 text-center">
+    <Card className="!bg-green-50 dark:!bg-green-950">
+      <div className="space-y-2 text-center">
         <p className="text-3xl font-black">🎉 정답!</p>
         <p className="text-lg font-bold">{attemptCount}회 만에 맞추셨습니다!</p>
         <p className="text-base font-medium text-gray-600 dark:text-gray-400">
           최고 유사도: {bestSimilarity.toFixed(1)}%
         </p>
-        <Button onClick={handleCopy} variant="secondary" size="sm">
-          결과 복사
-        </Button>
       </div>
     </Card>
   );

--- a/frontend/src/features/game/components/GameClearedCard.tsx
+++ b/frontend/src/features/game/components/GameClearedCard.tsx
@@ -1,0 +1,40 @@
+import { Card } from "@/shared/ui/Card";
+import { Button } from "@/shared/ui/Button";
+import { useToastStore } from "@/shared/stores/useToastStore";
+
+interface GameClearedCardProps {
+  attemptCount: number;
+  bestSimilarity: number;
+  similarities: number[];
+}
+
+export function GameClearedCard({ attemptCount, bestSimilarity, similarities }: GameClearedCardProps) {
+  const addToast = useToastStore((s) => s.addToast);
+
+  async function handleCopy() {
+    const path = similarities.map((s) => s.toFixed(1)).join(" → ");
+    const text = `가까워 🎉 ${attemptCount}회 만에 성공!\n최고 유사도: ${path}`;
+
+    try {
+      await navigator.clipboard.writeText(text);
+      addToast("결과가 복사되었습니다!", "success");
+    } catch {
+      addToast("복사에 실패했습니다.", "error");
+    }
+  }
+
+  return (
+    <Card className="bg-green-50 dark:bg-green-950 border-green-500 dark:border-green-400">
+      <div className="space-y-4 text-center">
+        <p className="text-3xl font-black">🎉 정답!</p>
+        <p className="text-lg font-bold">{attemptCount}회 만에 맞추셨습니다!</p>
+        <p className="text-base font-medium text-gray-600 dark:text-gray-400">
+          최고 유사도: {bestSimilarity.toFixed(1)}%
+        </p>
+        <Button onClick={handleCopy} variant="secondary" size="sm">
+          결과 복사
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/features/game/components/GuessHistory.tsx
+++ b/frontend/src/features/game/components/GuessHistory.tsx
@@ -24,7 +24,7 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
       <div className="space-y-3">
         {sorted.map((guess, i) => (
           <div
-            key={i}
+            key={`${guess.attemptNumber ?? total - i}-${guess.guessText}`}
             className="flex items-center justify-between border-4 border-black dark:border-white shadow-brutal bg-white dark:bg-gray-900 p-3"
           >
             <div className="flex items-center gap-3">

--- a/frontend/src/features/game/components/GuessHistory.tsx
+++ b/frontend/src/features/game/components/GuessHistory.tsx
@@ -1,0 +1,42 @@
+import { SimilarityBadge } from "@/features/game/components/SimilarityBadge";
+
+interface GuessItem {
+  guessText: string;
+  similarity: number;
+  attemptNumber: number | null;
+}
+
+interface GuessHistoryProps {
+  guesses: GuessItem[];
+}
+
+export function GuessHistory({ guesses }: GuessHistoryProps) {
+  if (guesses.length === 0) {
+    return null;
+  }
+
+  const sorted = [...guesses].reverse();
+  const total = guesses.length;
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-2xl font-extrabold">추측 기록</h2>
+      <div className="space-y-3">
+        {sorted.map((guess, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between border-4 border-black dark:border-white shadow-brutal bg-white dark:bg-gray-900 p-3"
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-sm font-bold text-gray-500 dark:text-gray-400 tabular-nums shrink-0">
+                #{guess.attemptNumber ?? total - i}
+              </span>
+              <span className="font-medium">{guess.guessText}</span>
+            </div>
+            <SimilarityBadge similarity={guess.similarity} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/game/components/GuessInput.tsx
+++ b/frontend/src/features/game/components/GuessInput.tsx
@@ -1,0 +1,74 @@
+import { useRef, useState } from "react";
+import { Button } from "@/shared/ui/Button";
+import { Input } from "@/shared/ui/Input";
+
+interface GuessInputProps {
+  onSubmit: (text: string) => void;
+  isLoading: boolean;
+  disabled?: boolean;
+  error?: string | null;
+}
+
+export function GuessInput({ onSubmit, isLoading, disabled = false, error = null }: GuessInputProps) {
+  const [text, setText] = useState("");
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const isComposingRef = useRef(false);
+
+  function focusInput() {
+    setTimeout(() => wrapperRef.current?.querySelector<HTMLInputElement>("input")?.focus(), 0);
+  }
+
+  function handleSubmit() {
+    if (isLoading || disabled) {
+      return;
+    }
+    const trimmed = text.trim();
+    if (!trimmed || trimmed.length < 2 || trimmed.length > 200) {
+      return;
+    }
+    onSubmit(trimmed);
+    setText("");
+    focusInput();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key !== "Enter") {
+      return;
+    }
+    if (isComposingRef.current) {
+      return;
+    }
+    e.preventDefault();
+    handleSubmit();
+  }
+
+  return (
+    <div ref={wrapperRef} className="space-y-2">
+      <div className="flex gap-3">
+        <Input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onCompositionStart={() => {
+            isComposingRef.current = true;
+          }}
+          onCompositionEnd={() => {
+            isComposingRef.current = false;
+          }}
+          placeholder="문장을 추측해보세요..."
+          disabled={disabled}
+          maxLength={200}
+        />
+        <Button
+          onClick={handleSubmit}
+          isLoading={isLoading}
+          disabled={disabled || isLoading || text.trim().length < 2}
+          className="shrink-0"
+        >
+          제출
+        </Button>
+      </div>
+      {error && <p className="text-sm font-bold text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/features/game/components/HintMask.tsx
+++ b/frontend/src/features/game/components/HintMask.tsx
@@ -1,0 +1,19 @@
+interface HintMaskProps {
+  hintMask: string;
+  charCounts: number[];
+}
+
+export function HintMask({ hintMask, charCounts }: HintMaskProps) {
+  const words = hintMask.split(" ");
+
+  return (
+    <div className="flex flex-wrap gap-4 items-end">
+      {words.map((word, i) => (
+        <div key={i} className="flex flex-col items-center gap-1">
+          <span className="text-2xl font-black tracking-widest">{word}</span>
+          <span className="text-xs font-medium text-gray-500 dark:text-gray-400">{charCounts[i]}글자</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/game/components/SimilarityBadge.tsx
+++ b/frontend/src/features/game/components/SimilarityBadge.tsx
@@ -1,0 +1,18 @@
+import { getSimilarityColor } from "@/shared/utils/similarity";
+
+interface SimilarityBadgeProps {
+  similarity: number;
+}
+
+export function SimilarityBadge({ similarity }: SimilarityBadgeProps) {
+  const { bg, text } = getSimilarityColor(similarity);
+
+  return (
+    <span
+      className="inline-block border-2 border-black dark:border-white rounded-none px-2 py-0.5 text-sm font-bold tabular-nums"
+      style={{ backgroundColor: bg, color: text }}
+    >
+      {similarity.toFixed(1)}%
+    </span>
+  );
+}

--- a/frontend/src/features/game/components/YesterdayAnswer.tsx
+++ b/frontend/src/features/game/components/YesterdayAnswer.tsx
@@ -1,0 +1,13 @@
+interface YesterdayAnswerProps {
+  sentence: string;
+  date: string;
+}
+
+export function YesterdayAnswer({ sentence, date }: YesterdayAnswerProps) {
+  return (
+    <div className="border-4 border-black dark:border-white shadow-brutal bg-indigo-50 dark:bg-gray-800 p-4">
+      <p className="text-sm font-medium text-gray-600 dark:text-gray-400">어제의 정답 ({date})</p>
+      <p className="text-lg font-extrabold mt-1">{sentence}</p>
+    </div>
+  );
+}

--- a/frontend/src/features/game/hooks/useAnonymousGame.ts
+++ b/frontend/src/features/game/hooks/useAnonymousGame.ts
@@ -1,0 +1,79 @@
+import { useCallback, useState } from "react";
+
+const STORAGE_PREFIX = "gakkaweo-guesses-";
+
+export interface AnonymousGuess {
+  guessText: string;
+  similarity: number;
+  attemptNumber: number;
+  timestamp: string;
+}
+
+interface AnonymousGameState {
+  guesses: AnonymousGuess[];
+  attemptCount: number;
+  bestSimilarity: number;
+  isCleared: boolean;
+}
+
+const EMPTY_STATE: AnonymousGameState = { guesses: [], attemptCount: 0, bestSimilarity: 0, isCleared: false };
+
+function loadState(sentenceId: string): AnonymousGameState {
+  try {
+    const raw = localStorage.getItem(STORAGE_PREFIX + sentenceId);
+    if (raw) {
+      return JSON.parse(raw);
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return EMPTY_STATE;
+}
+
+function saveState(sentenceId: string, state: AnonymousGameState) {
+  localStorage.setItem(STORAGE_PREFIX + sentenceId, JSON.stringify(state));
+}
+
+export function useAnonymousGame(sentenceId: string | undefined) {
+  const [trackedId, setTrackedId] = useState(sentenceId);
+  const [state, setState] = useState<AnonymousGameState>(() => (sentenceId ? loadState(sentenceId) : EMPTY_STATE));
+
+  if (sentenceId !== trackedId) {
+    setTrackedId(sentenceId);
+    setState(sentenceId ? loadState(sentenceId) : EMPTY_STATE);
+  }
+
+  const addGuess = useCallback(
+    (guessText: string, similarity: number, isCorrect: boolean) => {
+      if (!sentenceId) {
+        return;
+      }
+
+      setState((prev) => {
+        const attemptCount = prev.isCleared ? prev.attemptCount : prev.attemptCount + 1;
+        const bestSimilarity = Math.max(prev.bestSimilarity, similarity);
+        const isCleared = prev.isCleared || isCorrect;
+
+        const newGuess: AnonymousGuess = {
+          guessText,
+          similarity,
+          attemptNumber: prev.guesses.length + 1,
+          timestamp: new Date().toISOString(),
+        };
+
+        const next: AnonymousGameState = {
+          guesses: [...prev.guesses, newGuess],
+          attemptCount,
+          bestSimilarity,
+          isCleared,
+        };
+
+        saveState(sentenceId, next);
+        return next;
+      });
+    },
+    [sentenceId],
+  );
+
+  return { state, addGuess };
+}

--- a/frontend/src/features/game/hooks/useCountdown.ts
+++ b/frontend/src/features/game/hooks/useCountdown.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+function getRemaining(expiresAt: string): number {
+  return new Date(expiresAt).getTime() - Date.now();
+}
+
+export function useCountdown(expiresAt: string | undefined) {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!expiresAt) {
+      return;
+    }
+    const id = setInterval(() => {
+      setTick((t) => t + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+
+  const remaining = expiresAt ? getRemaining(expiresAt) : 0;
+  const totalSeconds = Math.max(0, Math.floor(remaining / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const formatted = `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+
+  return { formatted, isExpired: remaining <= 0 };
+}

--- a/frontend/src/features/game/hooks/useGameQueries.ts
+++ b/frontend/src/features/game/hooks/useGameQueries.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { getHistory, getStatus, getToday, submitGuess } from "@/features/game/api";
+import { useAuthStore } from "@/shared/stores/useAuthStore";
+import type { GuessRequest } from "@/shared/api/types";
+
+export function useToday() {
+  return useQuery({
+    queryKey: ["game", "today"],
+    queryFn: getToday,
+    staleTime: Infinity,
+  });
+}
+
+export function useGameStatus(sentenceId: string | undefined) {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  return useQuery({
+    queryKey: ["game", "status"],
+    queryFn: getStatus,
+    staleTime: 30_000,
+    enabled: isAuthenticated && !!sentenceId,
+  });
+}
+
+export function useGameHistory(sentenceId: string | undefined) {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  return useQuery({
+    queryKey: ["game", "history", sentenceId],
+    queryFn: () => getHistory(sentenceId!),
+    staleTime: 0,
+    enabled: isAuthenticated && !!sentenceId,
+  });
+}
+
+export function useGuess() {
+  return useMutation({
+    mutationFn: (body: GuessRequest) => submitGuess(body),
+  });
+}

--- a/frontend/src/features/game/hooks/useGameQueries.ts
+++ b/frontend/src/features/game/hooks/useGameQueries.ts
@@ -15,7 +15,7 @@ export function useGameStatus(sentenceId: string | undefined) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 
   return useQuery({
-    queryKey: ["game", "status"],
+    queryKey: ["game", "status", sentenceId],
     queryFn: getStatus,
     staleTime: 30_000,
     enabled: isAuthenticated && !!sentenceId,

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -58,9 +58,11 @@ async function handleResponse<T>(res: Response): Promise<T> {
   throw new ApiError(res.status, body.code, body, Number.isNaN(retryAfter) ? null : retryAfter);
 }
 
-export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+type ApiFetchOptions = Omit<RequestInit, "body"> & { body?: BodyInit | object | null };
+
+export async function apiFetch<T>(path: string, { body: rawBody, ...restOptions }: ApiFetchOptions = {}): Promise<T> {
   const url = `${API_BASE}${path}`;
-  const method = options.method?.toUpperCase() ?? "GET";
+  const method = restOptions.method?.toUpperCase() ?? "GET";
   const hasBody = method !== "GET" && method !== "HEAD";
 
   const headers: Record<string, string> = {};
@@ -68,18 +70,18 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
     headers["Content-Type"] = "application/json";
   }
 
-  const body =
-    hasBody && options.body && typeof options.body === "object" && !(options.body instanceof FormData)
-      ? JSON.stringify(options.body)
-      : options.body;
+  const body: BodyInit | null | undefined =
+    hasBody && rawBody && typeof rawBody === "object" && !(rawBody instanceof FormData)
+      ? JSON.stringify(rawBody)
+      : (rawBody as BodyInit | null | undefined);
 
   const config: RequestInit = {
-    ...options,
+    ...restOptions,
     body,
     credentials: "include",
     headers: {
       ...headers,
-      ...options.headers,
+      ...restOptions.headers,
     },
   };
 

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -10,13 +10,15 @@ export class ApiError extends Error {
   status: number;
   code: string;
   body: ErrorBody;
+  retryAfter: number | null;
 
-  constructor(status: number, code: string, body: ErrorBody) {
+  constructor(status: number, code: string, body: ErrorBody, retryAfter: number | null = null) {
     super(body.message);
     this.name = "ApiError";
     this.status = status;
     this.code = code;
     this.body = body;
+    this.retryAfter = retryAfter;
   }
 }
 
@@ -50,7 +52,10 @@ async function handleResponse<T>(res: Response): Promise<T> {
     timestamp: new Date().toISOString(),
   }));
 
-  throw new ApiError(res.status, body.code, body);
+  const retryAfterHeader = res.headers.get("Retry-After");
+  const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : null;
+
+  throw new ApiError(res.status, body.code, body, Number.isNaN(retryAfter) ? null : retryAfter);
 }
 
 export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {

--- a/frontend/src/shared/stores/useAuthStore.ts
+++ b/frontend/src/shared/stores/useAuthStore.ts
@@ -17,7 +17,11 @@ export const useAuthStore = create<AuthState>((set) => ({
   fetchUser: async () => {
     try {
       const user = await apiFetch<MeResponse>("/auth/me");
-      set({ user, isAuthenticated: true, isLoading: false });
+      if (user?.publicId) {
+        set({ user, isAuthenticated: true, isLoading: false });
+      } else {
+        set({ user: null, isAuthenticated: false, isLoading: false });
+      }
     } catch {
       set({ user: null, isAuthenticated: false, isLoading: false });
     }

--- a/frontend/src/shared/ui/Button.tsx
+++ b/frontend/src/shared/ui/Button.tsx
@@ -43,7 +43,7 @@ export function Button({
         isLoading
           ? "opacity-70 cursor-wait shadow-brutal animate-pulse"
           : "shadow-brutal hover:shadow-brutal-hover hover:translate-x-1 hover:translate-y-1 active:shadow-none active:translate-x-1.5 active:translate-y-1.5",
-        "disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none disabled:translate-x-0 disabled:translate-y-0",
+        "disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0",
         className,
       ].join(" ")}
       {...rest}

--- a/frontend/src/shared/ui/Input.tsx
+++ b/frontend/src/shared/ui/Input.tsx
@@ -4,7 +4,7 @@ export function Input({ className = "", ...rest }: InputHTMLAttributes<HTMLInput
   return (
     <input
       className={[
-        "border-4 border-black dark:border-white rounded-none bg-white dark:bg-gray-900",
+        "border-4 border-black dark:border-white rounded-none shadow-brutal bg-white dark:bg-gray-900",
         "text-black dark:text-white px-4 py-3 font-medium text-lg w-full",
         "focus:outline-none focus:ring-0 focus:border-black dark:focus:border-white placeholder:text-gray-400",
         className,

--- a/frontend/src/shared/utils/similarity.ts
+++ b/frontend/src/shared/utils/similarity.ts
@@ -1,0 +1,11 @@
+interface SimilarityColor {
+  bg: string;
+  text: string;
+}
+
+export function getSimilarityColor(similarity: number): SimilarityColor {
+  const clamped = Math.max(0, Math.min(100, similarity));
+  const hue = Math.round((clamped / 100) * 120);
+
+  return { bg: `hsl(${hue}, 80%, 45%)`, text: "#ffffff" };
+}


### PR DESCRIPTION
## 관련 이슈

Closes #52 

## 변경 사항

### Frontend — 게임 페이지 (신규 11개 + 수정 4개)

**신규 파일**
- `shared/utils/similarity.ts` — 유사도 HSL 연속 색상 (hue 0°~120°, 빨강→초록)
- `features/game/api.ts` — getToday, submitGuess, getHistory, getStatus
- `features/game/hooks/useGameQueries.ts` — TanStack Query 훅
- `features/game/hooks/useCountdown.ts` — expiresAt 기반 자정 카운트다운
- `features/game/hooks/useAnonymousGame.ts` — 익명 localStorage 상태 관리
- `features/game/components/HintMask.tsx` — 어절별 빈칸 + 글자 수
- `features/game/components/GuessInput.tsx` — 추측 입력 (IME 처리, 포커스 복귀)
- `features/game/components/GuessHistory.tsx` — 추측 히스토리 (최신순, shadow-brutal)
- `features/game/components/SimilarityBadge.tsx` — 퍼센트만 표시, inline 색상
- `features/game/components/YesterdayAnswer.tsx` — 어제 정답 배너
- `features/game/components/GameClearedCard.tsx` — 정답 축하 + 결과 복사

**수정 파일**
- `features/game/GamePage.tsx` — 플레이스홀더 → 실제 게임 페이지
- `shared/api/client.ts` — ApiError에 retryAfter 필드 + Retry-After 헤더 파싱
- `shared/ui/Input.tsx` — shadow-brutal 추가
- `shared/ui/Button.tsx` — disabled 시 그림자 유지 (shadow-none 제거)

### Backend — CORS 설정

- `SecurityConfig.java` — `exposedHeaders`에 Retry-After, X-Rate-Limit-Remaining 추가

### 핵심 설계
- **익명 vs 로그인**: 익명은 localStorage, 로그인은 TanStack Query 캐시(optimistic update)
- **유사도 색상**: HSL hue 0°(빨강)→120°(초록) 선형 보간, 라벨 없이 퍼센트만 표시
- **Rate Limit**: Retry-After 헤더 값으로 정확한 대기 시간 적용 (fallback 5초)
- **포커스**: 로딩 중 Input 비활성화 제거로 포커스 유실 방지

## 테스트

- [x] 익명 추측 제출 → 유사도 뱃지 + 히스토리 표시
- [x] 새로고침 → localStorage에서 히스토리 복원
- [x] 정답(≥95%) → CLEARED 카드 + 결과 복사
- [x] Rate Limit 429 → Retry-After 헤더 기반 대기
- [x] 라이트/다크모드 전체 UI 정상
- [x] ESLint + TypeScript + Prettier 통과

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
