### PR TITLE
feat: 인증 페이지 구현 (소셜 로그인/로그아웃/마이페이지)

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/auth/security/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.gakkaweo.backend.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException {
+    ErrorBody body =
+        new ErrorBody(
+            HttpStatus.UNAUTHORIZED.value(), "UNAUTHORIZED", "인증이 필요합니다", Instant.now().toString());
+
+    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+    objectMapper.writeValue(response.getWriter(), body);
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/security/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/security/RestAuthenticationEntryPoint.java
@@ -2,12 +2,12 @@ package com.gakkaweo.backend.auth.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.common.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -25,11 +25,15 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
       HttpServletResponse response,
       AuthenticationException authException)
       throws IOException {
+    ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
     ErrorBody body =
         new ErrorBody(
-            HttpStatus.UNAUTHORIZED.value(), "UNAUTHORIZED", "인증이 필요합니다", Instant.now().toString());
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            errorCode.getMessage(),
+            Instant.now().toString());
 
-    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    response.setStatus(errorCode.getStatus().value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setCharacterEncoding("UTF-8");
     objectMapper.writeValue(response.getWriter(), body);

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
   EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
   BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다"),

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.gakkaweo.backend.auth.oauth2.CookieAuthorizationRequestRepository;
 import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginFailureHandler;
 import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginSuccessHandler;
 import com.gakkaweo.backend.auth.oauth2.service.CustomOAuth2UserService;
+import com.gakkaweo.backend.auth.security.RestAuthenticationEntryPoint;
 import com.gakkaweo.backend.ratelimit.filter.RateLimitFilter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,7 @@ public class SecurityConfig {
   private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
   private final CookieAuthorizationRequestRepository authorizationRequestRepository;
   private final OAuth2Properties oAuth2Properties;
+  private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -59,10 +61,10 @@ public class SecurityConfig {
                     .authenticated()
                     .anyRequest()
                     .authenticated())
+        .exceptionHandling(ex -> ex.authenticationEntryPoint(restAuthenticationEntryPoint))
         .oauth2Login(
             oauth2 ->
                 oauth2
-                    // TODO: 프론트엔드 구현 시 .loginPage() 설정하여 기본 로그인 페이지(/login) 비활성화
                     .authorizationEndpoint(
                         e -> e.authorizationRequestRepository(authorizationRequestRepository))
                     .userInfoEndpoint(u -> u.userService(customOAuth2UserService))

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { router } from "@/app/router";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
+import { useToastStore } from "@/shared/stores/useToastStore";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -15,10 +16,20 @@ const queryClient = new QueryClient({
 
 export function App() {
   const fetchUser = useAuthStore((s) => s.fetchUser);
+  const addToast = useToastStore((s) => s.addToast);
 
   useEffect(() => {
     fetchUser();
   }, [fetchUser]);
+
+  useEffect(() => {
+    const error = new URLSearchParams(window.location.search).get("error");
+    if (!error) {
+      return;
+    }
+    addToast(`로그인에 실패했습니다: ${decodeURIComponent(error)}`, "error");
+    window.history.replaceState({}, "", window.location.pathname);
+  }, [addToast]);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -27,7 +27,7 @@ export function App() {
     if (!error) {
       return;
     }
-    addToast(`로그인에 실패했습니다: ${decodeURIComponent(error)}`, "error");
+    addToast(`로그인에 실패했습니다: ${error}`, "error");
     window.history.replaceState({}, "", window.location.pathname);
   }, [addToast]);
 

--- a/frontend/src/app/guards.tsx
+++ b/frontend/src/app/guards.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuthStore } from "@/shared/stores/useAuthStore";
+
+function LoadingFallback() {
+  return <div className="max-w-md mx-auto py-12 text-center text-gray-400 font-bold animate-pulse">로딩 중...</div>;
+}
+
+export function RequireAuth({ children }: { children: ReactNode }) {
+  const { isAuthenticated, isLoading } = useAuthStore();
+
+  if (isLoading) {
+    return <LoadingFallback />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+}
+
+export function RedirectIfAuth({ children }: { children: ReactNode }) {
+  const { isAuthenticated, isLoading } = useAuthStore();
+
+  if (isLoading) {
+    return <LoadingFallback />;
+  }
+
+  if (isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from "react-router-dom";
 import { Layout } from "@/app/layout/Layout";
+import { RequireAuth, RedirectIfAuth } from "@/app/guards";
 import { GamePage } from "@/features/game/GamePage";
 import { RankingPage } from "@/features/ranking/RankingPage";
 import { LoginPage } from "@/features/auth/LoginPage";
@@ -12,8 +13,22 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <GamePage /> },
       { path: "ranking", element: <RankingPage /> },
-      { path: "login", element: <LoginPage /> },
-      { path: "mypage", element: <MyPage /> },
+      {
+        path: "login",
+        element: (
+          <RedirectIfAuth>
+            <LoginPage />
+          </RedirectIfAuth>
+        ),
+      },
+      {
+        path: "mypage",
+        element: (
+          <RequireAuth>
+            <MyPage />
+          </RequireAuth>
+        ),
+      },
       { path: "*", element: <NotFoundPage /> },
     ],
   },

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties, ReactNode } from "react";
 import { Card } from "@/shared/ui/Card";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL;
@@ -12,7 +13,7 @@ interface ProviderConfig {
   bg: string;
   text: string;
   hoverBg: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
 }
 
 const KakaoIcon = () => (
@@ -128,7 +129,7 @@ export function LoginPage() {
             key={id}
             type="button"
             onClick={() => handleLogin(id)}
-            style={{ "--shadow-color": "0, 0, 0" } as React.CSSProperties}
+            style={{ "--shadow-color": "0, 0, 0" } as CSSProperties}
             className={[
               "w-full border-4 border-black rounded-none font-bold text-base px-6 py-4",
               "shadow-brutal transition-all duration-100",

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -1,12 +1,155 @@
 import { Card } from "@/shared/ui/Card";
 
+const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+const STORAGE_KEY = "gakkaweo-last-provider";
+
+type Provider = "kakao" | "google" | "naver";
+
+interface ProviderConfig {
+  id: Provider;
+  label: string;
+  bg: string;
+  text: string;
+  hoverBg: string;
+  icon: React.ReactNode;
+}
+
+const KakaoIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 3C6.48 3 2 6.42 2 10.6c0 2.7 1.74 5.06 4.36 6.4-.14.52-.92 3.36-.95 3.57 0 0-.02.16.08.22.1.06.22.03.22.03.29-.04 3.37-2.2 3.9-2.57.77.11 1.57.17 2.39.17 5.52 0 10-3.42 10-7.63S17.52 3 12 3z" />
+  </svg>
+);
+
+const GoogleIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24">
+    <path
+      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+      fill="#4285F4"
+    />
+    <path
+      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      fill="#34A853"
+    />
+    <path
+      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      fill="#FBBC05"
+    />
+    <path
+      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      fill="#EA4335"
+    />
+  </svg>
+);
+
+const NaverIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M16.27 3v8.86L7.73 3H3v18h4.73v-8.86L16.27 21H21V3h-4.73z" />
+  </svg>
+);
+
+const PROVIDER_LABELS: Record<Provider, string> = {
+  kakao: "카카오",
+  google: "Google",
+  naver: "네이버",
+};
+
+const PROVIDERS: ProviderConfig[] = [
+  {
+    id: "kakao",
+    label: "카카오 로그인",
+    bg: "bg-yellow-300",
+    text: "text-black",
+    hoverBg: "hover:bg-yellow-400",
+    icon: <KakaoIcon />,
+  },
+  {
+    id: "google",
+    label: "Google 로그인",
+    bg: "bg-white",
+    text: "text-black",
+    hoverBg: "hover:bg-gray-100",
+    icon: <GoogleIcon />,
+  },
+  {
+    id: "naver",
+    label: "네이버 로그인",
+    bg: "bg-green-500",
+    text: "text-white",
+    hoverBg: "hover:bg-green-600",
+    icon: <NaverIcon />,
+  },
+];
+
+function getLastProvider(): Provider | null {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY);
+    if (value === "kakao" || value === "google" || value === "naver") {
+      return value;
+    }
+  } catch {
+    /* localStorage 접근 불가 */
+  }
+  return null;
+}
+
+function saveLastProvider(provider: Provider) {
+  try {
+    localStorage.setItem(STORAGE_KEY, provider);
+  } catch {
+    /* localStorage 접근 불가 */
+  }
+}
+
+function handleLogin(provider: Provider) {
+  saveLastProvider(provider);
+  window.location.href = `${API_BASE}/oauth2/authorization/${provider}`;
+}
+
 export function LoginPage() {
+  const lastProvider = getLastProvider();
+
   return (
     <div className="max-w-md mx-auto space-y-6">
-      <h1 className="text-4xl font-black">로그인</h1>
-      <Card>
-        <p className="text-lg font-medium text-gray-600 dark:text-gray-400">로그인 페이지 — Issue C에서 구현 예정</p>
+      <div className="space-y-2">
+        <h1 className="text-4xl font-black">로그인</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">소셜 계정으로 간편하게 시작하세요</p>
+      </div>
+
+      <Card className="space-y-3">
+        {lastProvider && (
+          <p className="text-sm font-bold text-gray-600 dark:text-gray-400 pb-1">
+            최근에 <span className="text-black dark:text-white">{PROVIDER_LABELS[lastProvider]}</span>(으)로
+            로그인했습니다
+          </p>
+        )}
+        {PROVIDERS.map(({ id, label, bg, text, hoverBg, icon }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => handleLogin(id)}
+            style={{ "--shadow-color": "0, 0, 0" } as React.CSSProperties}
+            className={[
+              "w-full border-4 border-black rounded-none font-bold text-base px-6 py-4",
+              "shadow-brutal transition-all duration-100",
+              "hover:shadow-brutal-hover hover:translate-x-1 hover:translate-y-1",
+              "active:shadow-none active:translate-x-1.5 active:translate-y-1.5",
+              bg,
+              text,
+              hoverBg,
+            ].join(" ")}
+          >
+            <span className="inline-flex items-center gap-3 w-44">
+              <span className="w-5 flex items-center justify-center shrink-0">{icon}</span>
+              <span>{label}</span>
+            </span>
+          </button>
+        ))}
       </Card>
+
+      <p className="text-xs text-gray-400 font-medium text-center">
+        로그인 시 게임 기록이 저장되고 랭킹에 참여할 수 있습니다
+      </p>
     </div>
   );
 }

--- a/frontend/src/features/auth/MyPage.tsx
+++ b/frontend/src/features/auth/MyPage.tsx
@@ -1,12 +1,102 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "@/shared/stores/useAuthStore";
+import { useToastStore } from "@/shared/stores/useToastStore";
 import { Card } from "@/shared/ui/Card";
+import { Button } from "@/shared/ui/Button";
+import { logout, deleteAccount } from "@/features/auth/api";
+import { ConfirmDialog } from "@/features/auth/components/ConfirmDialog";
 
 export function MyPage() {
+  const { user, clearUser } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
+  const navigate = useNavigate();
+
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleLogout = async () => {
+    setIsLoggingOut(true);
+    try {
+      await logout();
+      addToast("로그아웃되었습니다", "success");
+    } catch {
+      addToast("로그아웃 중 문제가 발생했습니다", "error");
+    } finally {
+      clearUser();
+      setIsLoggingOut(false);
+      navigate("/");
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteAccount();
+      clearUser();
+      addToast("회원 탈퇴가 완료되었습니다", "success");
+      setIsConfirmOpen(false);
+      navigate("/");
+    } catch {
+      addToast("회원 탈퇴에 실패했습니다. 다시 시도해주세요.", "error");
+      setIsDeleting(false);
+    }
+  };
+
   return (
     <div className="max-w-md mx-auto space-y-6">
       <h1 className="text-4xl font-black">마이페이지</h1>
-      <Card>
-        <p className="text-lg font-medium text-gray-600 dark:text-gray-400">마이페이지 — Issue C에서 구현 예정</p>
+
+      <Card className="flex flex-col items-center space-y-4 py-8">
+        {user?.profileUrl ? (
+          <img
+            src={user.profileUrl}
+            alt="프로필"
+            className="w-24 h-24 border-4 border-black dark:border-white object-cover"
+          />
+        ) : (
+          <div className="w-24 h-24 border-4 border-black dark:border-white bg-gray-200 dark:bg-gray-800 flex items-center justify-center">
+            <svg
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="text-gray-400 dark:text-gray-500"
+            >
+              <circle cx="12" cy="9" r="3.5" />
+              <path d="M12 14c-4.42 0-8 2.24-8 5v1h16v-1c0-2.76-3.58-5-8-5z" />
+            </svg>
+          </div>
+        )}
+
+        <div className="text-center">
+          <p className="text-sm font-extrabold uppercase tracking-wider text-gray-600 dark:text-gray-400 mb-1">
+            닉네임
+          </p>
+          <p className="text-2xl font-black">{user?.nickname}</p>
+        </div>
       </Card>
+
+      <div className="space-y-3">
+        <Button variant="secondary" className="w-full" onClick={handleLogout} isLoading={isLoggingOut}>
+          로그아웃
+        </Button>
+
+        <Button variant="danger" className="w-full" onClick={() => setIsConfirmOpen(true)} disabled={isDeleting}>
+          회원 탈퇴
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={handleDeleteAccount}
+        title="회원 탈퇴"
+        message="탈퇴 시 게임 기록이 익명 처리되며 복구할 수 없습니다. 정말 탈퇴하시겠습니까?"
+        confirmLabel="탈퇴하기"
+        isLoading={isDeleting}
+      />
     </div>
   );
 }

--- a/frontend/src/features/auth/MyPage.tsx
+++ b/frontend/src/features/auth/MyPage.tsx
@@ -34,10 +34,10 @@ export function MyPage() {
     setIsDeleting(true);
     try {
       await deleteAccount();
+      navigate("/");
       clearUser();
       addToast("회원 탈퇴가 완료되었습니다", "success");
       setIsConfirmOpen(false);
-      navigate("/");
     } catch {
       addToast("회원 탈퇴에 실패했습니다. 다시 시도해주세요.", "error");
       setIsDeleting(false);

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -1,0 +1,9 @@
+import { apiFetch } from "@/shared/api/client";
+
+export function logout() {
+  return apiFetch<void>("/auth/logout", { method: "POST" });
+}
+
+export function deleteAccount() {
+  return apiFetch<void>("/auth/account", { method: "DELETE" });
+}

--- a/frontend/src/features/auth/components/ConfirmDialog.tsx
+++ b/frontend/src/features/auth/components/ConfirmDialog.tsx
@@ -28,7 +28,7 @@ export function ConfirmDialog({
     }
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+      if (e.key === "Escape" && !isLoading) {
         onClose();
       }
     };
@@ -37,7 +37,7 @@ export function ConfirmDialog({
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, isLoading, onClose]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -45,7 +45,7 @@ export function ConfirmDialog({
     }
 
     const handleClickOutside = (e: MouseEvent) => {
-      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+      if (!isLoading && dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
         onClose();
       }
     };
@@ -54,7 +54,7 @@ export function ConfirmDialog({
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, isLoading, onClose]);
 
   if (!isOpen) {
     return null;

--- a/frontend/src/features/auth/components/ConfirmDialog.tsx
+++ b/frontend/src/features/auth/components/ConfirmDialog.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from "react";
+import { Button } from "@/shared/ui/Button";
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  isLoading?: boolean;
+}
+
+export function ConfirmDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmLabel,
+  isLoading,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
+      <div
+        ref={dialogRef}
+        className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-sm"
+      >
+        <div className="px-6 py-5 space-y-3">
+          <h2 className="text-xl font-black">{title}</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">{message}</p>
+        </div>
+
+        <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white">
+          <Button variant="secondary" size="sm" className="flex-1" onClick={onClose} disabled={isLoading}>
+            취소
+          </Button>
+          <Button variant="danger" size="sm" className="flex-1" onClick={onConfirm} isLoading={isLoading}>
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -35,7 +35,9 @@ export function GamePage() {
   const [localCleared, setLocalCleared] = useState(false);
   const retryRef = useRef(false);
 
-  const isCleared = status?.gameStatus === "CLEARED" || anonState.isCleared || localCleared;
+  const isCleared = isAuthenticated
+    ? status?.gameStatus === "CLEARED" || localCleared
+    : anonState.isCleared || localCleared;
 
   const displayGuesses = isAuthenticated ? (history?.guesses ?? []) : anonState.guesses;
 
@@ -191,9 +193,7 @@ export function GamePage() {
         <HintMask hintMask={today.hintMask} charCounts={today.charCounts} />
       </Card>
 
-      {isCleared && (
-        <GameClearedCard attemptCount={attemptCount} bestSimilarity={bestSimilarity} />
-      )}
+      {isCleared && <GameClearedCard attemptCount={attemptCount} bestSimilarity={bestSimilarity} />}
 
       <GuessInput
         onSubmit={handleSubmit}


### PR DESCRIPTION
## 관련 이슈

Closes #54 

## 변경 사항

### Backend
- `RestAuthenticationEntryPoint` 추가 — 미인증 요청에 401 JSON(ErrorBody) 응답. Spring 기본 로그인 페이지 리다이렉트 제거
- SecurityConfig에서 `.loginPage()` 대신 `.exceptionHandling()` + EntryPoint 주입

### Frontend
- **LoginPage** (`/login`): 소셜 로그인 버튼 3종, 최근 로그인 프로바이더 localStorage 안내, 다크모드 검정 그림자 유지
- **MyPage** (`/mypage`): 프로필 사진 (기본 아바타 SVG) + 닉네임, 로그아웃, 회원 탈퇴 (ConfirmDialog)
- **라우트 가드**: `RequireAuth` (미인증 → /login), `RedirectIfAuth` (인증 → /)
- **OAuth 에러 처리**: App.tsx에서 `?error=` 파싱 → 토스트
- **게임 상태 버그 수정**: 익명 localStorage 상태가 로그인 시 누출되던 문제 해소

## 테스트

- [x] 미인증 /auth/me → 401 JSON (리다이렉트 없음)
- [x] /login → 소셜 로그인 버튼 3종, 아이콘 정렬, 다크모드 그림자
- [x] /mypage → 프로필 + 닉네임 + 로그아웃/탈퇴
- [x] 미인증 /mypage → /login 리다이렉트
- [x] 인증 /login → / 리다이렉트
- [x] ESLint + TypeScript + Prettier 통과
