### PR TITLE
fix: /auth/me Rate Limit 그룹 불일치 수정

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/EndpointGroupResolver.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/EndpointGroupResolver.java
@@ -12,6 +12,10 @@ public class EndpointGroupResolver {
       return EndpointGroup.NONE;
     }
 
+    if ("GET".equals(method) && uri.equals("/auth/me")) {
+      return EndpointGroup.READ;
+    }
+
     if (uri.startsWith("/auth")) {
       return EndpointGroup.AUTH;
     }


### PR DESCRIPTION
## 관련 이슈

Closes #60 

## 변경 사항

- `EndpointGroupResolver`에서 `GET /auth/me`를 `/auth` 접두사 매칭 전에 READ 그룹으로 분기

## 셀프 리뷰 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했다
- [ ] 불필요한 코드나 주석을 제거했다
- [ ] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다