### PR TITLE
fix: 기술부채 해소 - 탈퇴 SSE 랭킹 이벤트 + Rate Limit 타이머 정리

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
@@ -12,11 +12,13 @@ import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
+import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +37,7 @@ public class AccountService {
   private final RefreshTokenRepository refreshTokenRepository;
   private final AuthService authService;
   private final StringRedisTemplate redisTemplate;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public void deleteAccount(UUID publicId) {
@@ -68,8 +71,12 @@ public class AccountService {
       String memberKey = RANKING_MEMBER_PREFIX + publicId;
       String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
 
-      redisTemplate.opsForZSet().remove(rankingKey, memberKey);
+      Long removed = redisTemplate.opsForZSet().remove(rankingKey, memberKey);
       redisTemplate.delete(detailKey);
+
+      if (removed != null && removed > 0) {
+        eventPublisher.publishEvent(new RankingUpdateEvent());
+      }
 
       log.info("탈퇴 회원 Redis 정리 완료: publicId={}", publicId);
     } catch (Exception e) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
@@ -72,9 +72,9 @@ public class AccountService {
       String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
 
       Long removed = redisTemplate.opsForZSet().remove(rankingKey, memberKey);
-      redisTemplate.delete(detailKey);
 
       if (removed != null && removed > 0) {
+        redisTemplate.delete(detailKey);
         eventPublisher.publishEvent(new RankingUpdateEvent());
       }
 

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -63,9 +63,7 @@ export function GamePage() {
 
   useEffect(
     () => () => {
-      if (rateLimitTimerRef.current) {
-        clearTimeout(rateLimitTimerRef.current);
-      }
+      clearTimeout(rateLimitTimerRef.current ?? undefined);
     },
     [],
   );
@@ -96,9 +94,7 @@ export function GamePage() {
       case "RATE_LIMIT_EXCEEDED": {
         const seconds = err.retryAfter ?? 5;
         setRateLimited(true);
-        if (rateLimitTimerRef.current) {
-          clearTimeout(rateLimitTimerRef.current);
-        }
+        clearTimeout(rateLimitTimerRef.current ?? undefined);
         rateLimitTimerRef.current = setTimeout(() => {
           setRateLimited(false);
           rateLimitTimerRef.current = null;

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -34,6 +34,7 @@ export function GamePage() {
   const [rateLimited, setRateLimited] = useState(false);
   const [localCleared, setLocalCleared] = useState(false);
   const retryRef = useRef(false);
+  const rateLimitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const isCleared = isAuthenticated
     ? status?.gameStatus === "CLEARED" || localCleared
@@ -59,6 +60,15 @@ export function GamePage() {
     confetti({ particleCount: 80, spread: 70, origin: { x: 0.3, y: 0.5 } });
     confetti({ particleCount: 80, spread: 70, origin: { x: 0.7, y: 0.5 } });
   }, [localCleared]);
+
+  useEffect(
+    () => () => {
+      if (rateLimitTimerRef.current) {
+        clearTimeout(rateLimitTimerRef.current);
+      }
+    },
+    [],
+  );
 
   function appendGuessToCache(guessText: string, res: GuessResponse) {
     queryClient.setQueryData<HistoryResponse>(["game", "history", sentenceId], (old) => ({
@@ -86,7 +96,13 @@ export function GamePage() {
       case "RATE_LIMIT_EXCEEDED": {
         const seconds = err.retryAfter ?? 5;
         setRateLimited(true);
-        setTimeout(() => setRateLimited(false), seconds * 1000);
+        if (rateLimitTimerRef.current) {
+          clearTimeout(rateLimitTimerRef.current);
+        }
+        rateLimitTimerRef.current = setTimeout(() => {
+          setRateLimited(false);
+          rateLimitTimerRef.current = null;
+        }, seconds * 1000);
         addToast(`요청이 너무 많습니다. ${seconds}초 후 다시 시도해주세요.`, "error");
         break;
       }


### PR DESCRIPTION
## 관련 이슈

Closes #64 

## 변경 사항

- 회원탈퇴 시 랭킹 참여자인 경우 RankingUpdateEvent 발행하여 SSE 즉시 갱신
- GamePage rate limit 타이머를 useRef로 관리하여 연속 429 대응 + unmount cleanup 추가

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
