### PR TITLE
fix: 인증 상태 전환 시 데이터 정합성 버그 3건 수정

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/service/NicknameGenerator.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/service/NicknameGenerator.java
@@ -40,7 +40,7 @@ public class NicknameGenerator {
       }
     }
 
-    return createRandomNickname(random) + "_" + random.nextInt(1000, 10000);
+    return createRandomNickname(random) + "_" + random.nextInt(10, 100);
   }
 
   private String createRandomNickname(ThreadLocalRandom random) {

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -146,26 +146,25 @@ public class DailyGameService {
     DailySentence sentence = findTodaySentenceByPublicId(sentenceId);
     Member member = findMember(memberPublicId);
 
-    GameSession session =
-        gameSessionRepository
-            .findByMemberAndSentence(member, sentence)
-            .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
-
-    List<GuessHistory> guesses =
-        guessHistoryRepository.findBySessionOrderByAttemptNumberAsc(session);
-
-    List<GuessHistoryResponse.GuessEntry> entries =
-        guesses.stream()
-            .map(
-                g ->
-                    new GuessHistoryResponse.GuessEntry(
-                        g.getGuessText(),
-                        g.getSimilarity(),
-                        g.getAttemptNumber(),
-                        g.getCreatedAt()))
-            .toList();
-
-    return new GuessHistoryResponse(entries);
+    return gameSessionRepository
+        .findByMemberAndSentence(member, sentence)
+        .map(
+            session -> {
+              List<GuessHistory> guesses =
+                  guessHistoryRepository.findBySessionOrderByAttemptNumberAsc(session);
+              List<GuessHistoryResponse.GuessEntry> entries =
+                  guesses.stream()
+                      .map(
+                          g ->
+                              new GuessHistoryResponse.GuessEntry(
+                                  g.getGuessText(),
+                                  g.getSimilarity(),
+                                  g.getAttemptNumber(),
+                                  g.getCreatedAt()))
+                      .toList();
+              return new GuessHistoryResponse(entries);
+            })
+        .orElse(new GuessHistoryResponse(List.of()));
   }
 
   @Transactional(readOnly = true)

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -235,7 +235,7 @@
 - **인증**: 필수
 - **Rate Limit**: READ (60/min)
 - **쿼리 파라미터**: `sentenceId` (필수, UUID)
-- **응답**:
+- **응답 (세션 존재)**:
 
 ```json
 {
@@ -250,7 +250,15 @@
 }
 ```
 
-- **에러**: `SENTENCE_NOT_FOUND`(404), `SESSION_NOT_FOUND`(404)
+- **응답 (세션 미존재)**: 오늘 게임을 시작하지 않은 경우. 빈 guesses 배열 반환
+
+```json
+{
+  "guesses": []
+}
+```
+
+- **에러**: `SENTENCE_NOT_FOUND`(404)
 
 ### `GET /daily/status` — 게임 상태 조회
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,18 +1,10 @@
 import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { router } from "@/app/router";
+import { queryClient } from "@/shared/api/queryClient";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { useToastStore } from "@/shared/stores/useToastStore";
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-      refetchOnWindowFocus: false,
-    },
-  },
-});
 
 export function App() {
   const fetchUser = useAuthStore((s) => s.fetchUser);

--- a/frontend/src/shared/api/queryClient.ts
+++ b/frontend/src/shared/api/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/frontend/src/shared/stores/useAuthStore.ts
+++ b/frontend/src/shared/stores/useAuthStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { apiFetch } from "@/shared/api/client";
+import { queryClient } from "@/shared/api/queryClient";
 import type { MeResponse } from "@/shared/api/types";
 
 interface AuthState {
@@ -28,6 +29,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     }
   },
   clearUser: () => {
+    queryClient.clear();
     set({ user: null, isAuthenticated: false, isLoading: false });
   },
   updateUser: (patch) => {


### PR DESCRIPTION
## 관련 이슈

Closes #68 

## 변경 사항

- 로그아웃/탈퇴 시 React Query 캐시 초기화하여 이전 유저 데이터 잔존 방지
- `GET /daily/history` 세션 미존재 시 `SESSION_NOT_FOUND` 예외 대신 빈 목록 반환 (`GET /daily/status` 패턴 통일)
- NicknameGenerator fallback suffix를 4자리에서 2자리로 변경하여 닉네임 12자 제한 준수

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
