### PR TITLE
chore: 프론트엔드 UI 개선 & 리팩토링

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -143,8 +143,8 @@ hue = (similarity / 100) × 120
 | ---------- | ---------- | --------------------------------------------- |
 | 게임       | `/`        | 추측 입력, 유사도 결과, 히스토리, 힌트 마스크 |
 | 랭킹       | `/ranking` | 실시간 순위 (SSE)                             |
-| 로그인     | `/login`   | 소셜 로그인 + 로컬 로그인 폼 + 회원가입 다이얼로그 |
-| 마이페이지 | `/mypage`  | 닉네임 확인, 회원 탈퇴                        |
+| 로그인     | `/login`   | 소셜 로그인 + 로컬 로그인 2컬럼 + 회원가입 다이얼로그 |
+| 마이페이지 | `/mypage`  | 닉네임 확인 (✏️ 편집), 회원 탈퇴              |
 
 ## 9. 로그인 프로바이더 색상
 
@@ -180,7 +180,7 @@ hue = (similarity / 100) × 120
 ```
 border-4 border-black rounded-none shadow-brutal bg-white dark:bg-gray-900
 px-4 py-3 font-medium text-lg
-focus:outline-none focus:ring-0 focus:border-black
+focus:outline-none focus:ring-0 focus:border-indigo-500 dark:focus:border-indigo-400
 placeholder:text-gray-400
 ```
 

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -63,104 +63,125 @@ export function LoginPage() {
   };
 
   return (
-    <div className="max-w-md mx-auto space-y-6">
+    <div className="max-w-2xl mx-auto space-y-6">
       <div className="space-y-2">
         <h1 className="text-4xl font-black">로그인</h1>
-        <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">소셜 계정으로 간편하게 시작하세요</p>
+        <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">소셜 또는 가까워 계정으로 시작하세요</p>
       </div>
 
-      <Card className="space-y-3">
-        {lastProvider && (
-          <p className="text-sm font-bold text-gray-600 dark:text-gray-400 pb-1">
-            최근에 <span className="text-black dark:text-white">{PROVIDER_COLORS[lastProvider].label}</span>(으)로
-            로그인했습니다
+      <div className="flex gap-6 items-stretch">
+        <Card className="flex-1 space-y-4">
+          <h2 className="text-lg font-extrabold">소셜 로그인</h2>
+          <p
+            className={[
+              "text-sm font-bold text-gray-600 dark:text-gray-400",
+              lastProvider && lastProvider !== "local" ? "" : "invisible",
+            ].join(" ")}
+          >
+            최근에{" "}
+            <span className="text-black dark:text-white">
+              {lastProvider && lastProvider !== "local" ? PROVIDER_COLORS[lastProvider].label : ""}
+            </span>
+            (으)로 로그인했습니다
           </p>
-        )}
-        {PROVIDERS.map(({ id, loginLabel, icon: Icon }) => {
-          const { bg, text } = PROVIDER_COLORS[id];
-          return (
-            <button
-              key={id}
-              type="button"
-              onClick={() => handleOAuthLogin(id)}
-              className={[
-                "w-full border-4 border-black dark:border-white rounded-none font-bold text-base px-6 py-4",
-                "shadow-brutal transition-all duration-100",
-                "hover:shadow-brutal-hover hover:translate-x-1 hover:translate-y-1",
-                "active:shadow-none active:translate-x-1.5 active:translate-y-1.5",
-                bg,
-                text,
-              ].join(" ")}
-            >
-              <span className="inline-flex items-center gap-3 w-44">
-                <span className="w-5 flex items-center justify-center shrink-0">
-                  <Icon />
-                </span>
-                <span>{loginLabel}</span>
-              </span>
-            </button>
-          );
-        })}
-      </Card>
+          <div className="space-y-3">
+            {PROVIDERS.map(({ id, loginLabel, icon: Icon }) => {
+              const { bg, text } = PROVIDER_COLORS[id];
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => handleOAuthLogin(id)}
+                  className={[
+                    "w-full border-4 border-black dark:border-white rounded-none font-bold text-base px-4 py-3",
+                    "shadow-brutal transition-all duration-100",
+                    "hover:shadow-brutal-hover hover:translate-x-1 hover:translate-y-1",
+                    "active:shadow-none active:translate-x-1.5 active:translate-y-1.5",
+                    bg,
+                    text,
+                  ].join(" ")}
+                >
+                  <span className="inline-flex items-center gap-3 w-44">
+                    <span className="w-5 flex items-center justify-center shrink-0">
+                      <Icon />
+                    </span>
+                    <span>{loginLabel}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </Card>
 
-      <div className="flex items-center gap-4">
-        <div className="flex-1 border-t-2 border-gray-300 dark:border-gray-700" />
-        <span className="text-sm font-bold text-gray-400">또는</span>
-        <div className="flex-1 border-t-2 border-gray-300 dark:border-gray-700" />
-      </div>
-
-      <Card className="space-y-4">
-        <div className="space-y-3">
-          <Input
-            value={username}
-            onChange={(e) => {
-              setUsername(e.target.value);
-              setError(null);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && canSubmit) {
-                handleLogin();
-              }
-            }}
-            placeholder="아이디"
-            disabled={isSubmitting}
-            autoComplete="username"
-          />
-          <Input
-            type="password"
-            value={password}
-            onChange={(e) => {
-              setPassword(e.target.value);
-              setError(null);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && canSubmit) {
-                handleLogin();
-              }
-            }}
-            placeholder="비밀번호"
-            disabled={isSubmitting}
-            autoComplete="current-password"
-          />
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex-1 border-l-2 border-gray-300 dark:border-gray-700" />
+          <span className="text-sm font-bold text-gray-400">또는</span>
+          <div className="flex-1 border-l-2 border-gray-300 dark:border-gray-700" />
         </div>
 
-        {error && <p className="text-sm font-medium text-red-500">{error}</p>}
-
-        <Button className="w-full" onClick={handleLogin} isLoading={isSubmitting} disabled={!canSubmit}>
-          로그인
-        </Button>
-
-        <p className="text-sm font-medium text-center text-gray-600 dark:text-gray-400">
-          계정이 없으신가요?{" "}
-          <button
-            type="button"
-            onClick={() => setIsRegisterOpen(true)}
-            className="font-bold text-black dark:text-white underline underline-offset-2"
+        <Card className="flex-1 space-y-4">
+          <h2 className="text-lg font-extrabold">가까워 로그인</h2>
+          <p
+            className={[
+              "text-sm font-bold text-gray-600 dark:text-gray-400",
+              lastProvider === "local" ? "" : "invisible",
+            ].join(" ")}
           >
-            회원가입
-          </button>
-        </p>
-      </Card>
+            최근에 <span className="text-black dark:text-white">{PROVIDER_COLORS.local.label}</span>(으)로
+            로그인했습니다
+          </p>
+          <div className="space-y-3">
+            <Input
+              value={username}
+              onChange={(e) => {
+                setUsername(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canSubmit) {
+                  handleLogin();
+                }
+              }}
+              placeholder="아이디"
+              disabled={isSubmitting}
+              autoComplete="username"
+            />
+            <Input
+              type="password"
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canSubmit) {
+                  handleLogin();
+                }
+              }}
+              placeholder="비밀번호"
+              disabled={isSubmitting}
+              autoComplete="current-password"
+            />
+          </div>
+
+          {error && <p className="text-sm font-medium text-red-500">{error}</p>}
+
+          <Button className="w-full" onClick={handleLogin} isLoading={isSubmitting} disabled={!canSubmit}>
+            로그인
+          </Button>
+
+          <p className="text-sm font-medium text-center text-gray-600 dark:text-gray-400">
+            계정이 없으신가요?{" "}
+            <button
+              type="button"
+              onClick={() => setIsRegisterOpen(true)}
+              className="font-bold text-black dark:text-white underline underline-offset-2 cursor-pointer hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
+            >
+              회원가입
+            </button>
+          </p>
+        </Card>
+      </div>
 
       <p className="text-xs text-gray-400 font-medium text-center">
         로그인 시 게임 기록이 저장되고 랭킹에 참여할 수 있습니다

--- a/frontend/src/features/auth/MyPage.tsx
+++ b/frontend/src/features/auth/MyPage.tsx
@@ -81,12 +81,19 @@ export function MyPage() {
           <p className="text-sm font-extrabold uppercase tracking-wider text-gray-600 dark:text-gray-400 mb-1">
             닉네임
           </p>
-          <div className="flex items-center justify-center gap-2">
-            <p className="text-2xl font-black">{user?.nickname}</p>
-            <Button variant="secondary" size="sm" onClick={() => setIsNicknameEditOpen(true)}>
-              변경
-            </Button>
-          </div>
+          <p className="text-2xl font-black">
+            <span className="relative">
+              {user?.nickname}
+              <button
+                type="button"
+                onClick={() => setIsNicknameEditOpen(true)}
+                className="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 text-base leading-none cursor-pointer hover:scale-110 transition-transform"
+                aria-label="닉네임 변경"
+              >
+                ✏️
+              </button>
+            </span>
+          </p>
         </div>
       </Card>
 

--- a/frontend/src/features/ranking/components/RankingEntryRow.tsx
+++ b/frontend/src/features/ranking/components/RankingEntryRow.tsx
@@ -4,7 +4,6 @@ import { getSimilarityColor } from "@/shared/utils/similarity";
 
 interface RankingEntryRowProps {
   entry: RankingEntry;
-  isMe: boolean;
 }
 
 const RANK_BADGE_COLORS: Record<number, string> = {
@@ -30,7 +29,7 @@ function DefaultAvatar() {
   );
 }
 
-export function RankingEntryRow({ entry, isMe }: RankingEntryRowProps) {
+export function RankingEntryRow({ entry }: RankingEntryRowProps) {
   const [imgError, setImgError] = useState(false);
   const badgeColor = RANK_BADGE_COLORS[entry.rank] ?? "bg-white dark:bg-gray-900";
   const rowColor = RANK_ROW_COLORS[entry.rank] ?? "";
@@ -41,13 +40,12 @@ export function RankingEntryRow({ entry, isMe }: RankingEntryRowProps) {
       className={[
         "px-2.5 py-1.5 border-2 border-black dark:border-white transition-all duration-100 space-y-1",
         rowColor,
-        isMe ? "ring-2 ring-indigo-500 dark:ring-indigo-400" : "",
       ].join(" ")}
     >
       <div className="flex items-center gap-2">
         <span
           className={[
-            "w-6 h-6 border-2 border-black dark:border-white flex items-center justify-center text-xs font-black shrink-0",
+            "min-w-6 h-6 px-1 border-2 border-black dark:border-white flex items-center justify-center text-xs font-black shrink-0",
             badgeColor,
           ].join(" ")}
         >

--- a/frontend/src/features/ranking/components/RankingPanel.tsx
+++ b/frontend/src/features/ranking/components/RankingPanel.tsx
@@ -32,6 +32,7 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
   const [offset, setOffset] = useState(0);
   const [isSliding, setIsSliding] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
   const [itemHeight, setItemHeight] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
   const entriesRef = useRef(entries);
@@ -48,14 +49,14 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
   }, [entries.length, isLoading]);
 
   useEffect(() => {
-    if (!shouldAnimate || isPaused || itemHeight === 0) {
+    if (!shouldAnimate || isPaused || isHovered || itemHeight === 0) {
       return;
     }
     const id = setInterval(() => {
       setIsSliding(true);
     }, ROTATE_MS);
     return () => clearInterval(id);
-  }, [shouldAnimate, isPaused, itemHeight]);
+  }, [shouldAnimate, isPaused, isHovered, itemHeight]);
 
   const handleTransitionEnd = (e: React.TransitionEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) {
@@ -70,8 +71,7 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
   const stride = itemHeight + GAP_PX;
   const containerHeight = shouldAnimate && itemHeight > 0 ? VISIBLE * itemHeight + (VISIBLE - 1) * GAP_PX : undefined;
 
-  const isInTop10 = ranking?.rankings.some((r) => r.publicId === user?.publicId) ?? false;
-  const showMyRank = isAuthenticated && ranking?.myRank && !isInTop10;
+  const showMySection = isAuthenticated && ranking && entries.length > 0;
 
   return (
     <Card className="w-72 shrink-0 self-start sticky top-24 !p-4 space-y-3">
@@ -103,8 +103,8 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
         <div
           className="overflow-hidden"
           style={containerHeight ? { height: containerHeight } : undefined}
-          onMouseEnter={() => setIsPaused(true)}
-          onMouseLeave={() => setIsPaused(false)}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
         >
           <div
             ref={listRef}
@@ -117,26 +117,31 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
             onTransitionEnd={handleTransitionEnd}
           >
             {visibleEntries.map((entry) => (
-              <RankingEntryRow key={entry.publicId} entry={entry} isMe={entry.publicId === user?.publicId} />
+              <RankingEntryRow key={entry.publicId} entry={entry} />
             ))}
           </div>
         </div>
       )}
 
-      {showMyRank && ranking?.myRank && user && (
+      {showMySection && (
         <>
           <div className="border-t-2 border-dashed border-gray-300 dark:border-gray-700" />
-          <RankingEntryRow
-            entry={{
-              rank: ranking.myRank.rank,
-              publicId: user.publicId,
-              nickname: user.nickname,
-              profileUrl: user.profileUrl,
-              similarity: ranking.myRank.similarity,
-              attemptCount: ranking.myRank.attemptCount,
-            }}
-            isMe
-          />
+          {ranking.myRank && user ? (
+            <RankingEntryRow
+              entry={{
+                rank: ranking.myRank.rank,
+                publicId: user.publicId,
+                nickname: user.nickname,
+                profileUrl: user.profileUrl,
+                similarity: ranking.myRank.similarity,
+                attemptCount: ranking.myRank.attemptCount,
+              }}
+            />
+          ) : (
+            <p className="text-sm font-bold text-gray-500 dark:text-gray-400 text-center py-2">
+              추측해서 랭킹에 참여하세요
+            </p>
+          )}
         </>
       )}
 

--- a/frontend/src/shared/ui/Input.tsx
+++ b/frontend/src/shared/ui/Input.tsx
@@ -11,7 +11,7 @@ export function Input({ className = "", ref, ...rest }: InputProps) {
       className={[
         "border-4 border-black dark:border-white rounded-none shadow-brutal bg-white dark:bg-gray-900",
         "text-black dark:text-white px-4 py-3 font-medium text-lg w-full",
-        "focus:outline-none focus:ring-0 focus:border-black dark:focus:border-white placeholder:text-gray-400",
+        "focus:outline-none focus:ring-0 focus:border-indigo-500 dark:focus:border-indigo-400 placeholder:text-gray-400",
         className,
       ].join(" ")}
       {...rest}


### PR DESCRIPTION
## 관련 이슈

Closes #70 

## 변경 사항

### 랭킹
- 3자리+ 등수 배지 깨짐 수정 (`w-6` → `min-w-6 px-1`)
- 호버/일시정지 상태 분리 (`isHovered` + `isPaused` 독립 state)
- 내 등수 상시 표시 (미추측 시 안내 문구, 추측 시 등수 row)
- 자기자신 강조 제거

### 로그인
- 2컬럼 레이아웃 (소셜 | 세로 구분선 | 가까워)
- 소셜 버튼 크기 축소 + 카드 간격 통일
- 최근 로그인 표시 공간 고정 (`invisible` 패턴)
- 회원가입 링크 hover 효과 추가

### 공통
- Input 포커스 시 `border-indigo-500` 강조 스타일
- 마이페이지 닉네임 변경 버튼 → ✏️ 이모지 (중앙 정렬 독립 배치)

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
