### PR TITLE
feat: 프로필 이미지 업로드

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,3 +9,6 @@ REDIS_PORT=6379
 
 # AI Service Settings
 AI_SERVICE_PORT=8000
+
+# Upload Settings
+UPLOAD_PROFILE_DIR=./uploads/profiles

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -304,3 +304,5 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/gradle,java,intellij+all,dotenv,maven,eclipse,windows,linux,visualstudiocode,git
+
+uploads/

--- a/backend/src/main/java/com/gakkaweo/backend/auth/config/ProfileImageProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/config/ProfileImageProperties.java
@@ -1,0 +1,13 @@
+package com.gakkaweo.backend.auth.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.upload")
+@Getter
+@RequiredArgsConstructor
+public class ProfileImageProperties {
+
+  private final String profileDir;
+}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.gakkaweo.backend.auth.security.CustomUserDetails;
 import com.gakkaweo.backend.auth.service.AccountService;
 import com.gakkaweo.backend.auth.service.AuthService;
 import com.gakkaweo.backend.auth.service.LocalAuthService;
+import com.gakkaweo.backend.auth.service.ProfileImageService;
 import com.gakkaweo.backend.auth.util.CookieUtils;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import jakarta.validation.Valid;
@@ -24,7 +25,9 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/auth")
@@ -34,6 +37,7 @@ public class AuthController {
   private final AuthService authService;
   private final LocalAuthService localAuthService;
   private final AccountService accountService;
+  private final ProfileImageService profileImageService;
   private final CookieUtils cookieUtils;
 
   @PostMapping("/register")
@@ -90,11 +94,31 @@ public class AuthController {
     return ResponseEntity.ok(response);
   }
 
+  @PatchMapping("/profile-image")
+  public ResponseEntity<AuthResponse> uploadProfileImage(
+      @RequestParam("file") MultipartFile file,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    String profileUrl = profileImageService.save(userDetails.publicId(), file);
+    AuthResponse response = authService.updateProfileUrl(userDetails.publicId(), profileUrl);
+    authService.syncProfileUrlToRedis(userDetails.publicId(), response.profileUrl());
+    return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/profile-image")
+  public ResponseEntity<AuthResponse> deleteProfileImage(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    AuthResponse response = authService.updateProfileUrl(userDetails.publicId(), null);
+    profileImageService.delete(userDetails.publicId());
+    authService.syncProfileUrlToRedis(userDetails.publicId(), null);
+    return ResponseEntity.ok(response);
+  }
+
   @DeleteMapping("/account")
   public ResponseEntity<Void> deleteAccount(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @CookieValue(value = "access_token", required = false) String accessToken) {
     accountService.deleteAccount(userDetails.publicId());
+    profileImageService.delete(userDetails.publicId());
     accountService.cleanupRedis(userDetails.publicId(), accessToken);
 
     return ResponseEntity.ok()

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -156,6 +157,36 @@ public class AuthService {
         member.getNickname(),
         member.getProfileUrl(),
         member.getRole().name());
+  }
+
+  @Transactional
+  public AuthResponse updateProfileUrl(UUID publicId, String profileUrl) {
+    Member member =
+        memberRepository
+            .findByPublicId(publicId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+    member.setProfileUrl(profileUrl);
+
+    return new AuthResponse(
+        member.getPublicId(),
+        member.getNickname(),
+        member.getProfileUrl(),
+        member.getRole().name());
+  }
+
+  public void syncProfileUrlToRedis(UUID publicId, String profileUrl) {
+    try {
+      LocalDate today = LocalDate.now(KST);
+      String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
+
+      if (redisTemplate.hasKey(detailKey)) {
+        redisTemplate.opsForHash().put(detailKey, "profileUrl", Objects.toString(profileUrl, ""));
+        eventPublisher.publishEvent(new RankingUpdateEvent());
+      }
+    } catch (Exception e) {
+      log.warn("프로필 URL Redis 동기화 실패: publicId={}", publicId, e);
+    }
   }
 
   public void syncNicknameToRedis(UUID publicId, String nickname) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/ProfileImageService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/ProfileImageService.java
@@ -1,0 +1,100 @@
+package com.gakkaweo.backend.auth.service;
+
+import com.gakkaweo.backend.auth.config.ProfileImageProperties;
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ProfileImageService {
+
+  private static final byte[] RIFF_HEADER = {'R', 'I', 'F', 'F'};
+  private static final byte[] WEBP_SIGNATURE = {'W', 'E', 'B', 'P'};
+
+  private final ProfileImageProperties properties;
+  private Path uploadDir;
+
+  @PostConstruct
+  void init() {
+    uploadDir = Path.of(properties.getProfileDir());
+    try {
+      Files.createDirectories(uploadDir);
+      log.info("프로필 이미지 업로드 디렉토리 준비 완료: {}", uploadDir.toAbsolutePath());
+    } catch (IOException e) {
+      throw new IllegalStateException("업로드 디렉토리 생성 실패: " + uploadDir, e);
+    }
+  }
+
+  public String save(UUID publicId, MultipartFile file) {
+    validateFile(file);
+
+    String filename = publicId + ".webp";
+    Path target = uploadDir.resolve(filename);
+
+    try {
+      Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      log.error("프로필 이미지 저장 실패: publicId={}", publicId, e);
+      throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+    }
+
+    String url = "/uploads/profiles/" + filename + "?v=" + System.currentTimeMillis();
+    log.info("프로필 이미지 저장: publicId={}, path={}", publicId, target);
+    return url;
+  }
+
+  public void delete(UUID publicId) {
+    Path target = uploadDir.resolve(publicId + ".webp");
+    try {
+      boolean deleted = Files.deleteIfExists(target);
+      if (deleted) {
+        log.info("프로필 이미지 삭제: publicId={}", publicId);
+      }
+    } catch (IOException e) {
+      log.warn("프로필 이미지 삭제 실패: publicId={}", publicId, e);
+    }
+  }
+
+  private void validateFile(MultipartFile file) {
+    String contentType = file.getContentType();
+    if (contentType == null || !contentType.startsWith("image/")) {
+      throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+    }
+
+    try (InputStream is = file.getInputStream()) {
+      byte[] header = new byte[12];
+      if (is.read(header) < 12) {
+        throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+      }
+
+      if (!startsWith(header, 0, RIFF_HEADER) || !startsWith(header, 8, WEBP_SIGNATURE)) {
+        throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+      }
+    } catch (BusinessException e) {
+      throw e;
+    } catch (IOException e) {
+      throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+    }
+  }
+
+  private boolean startsWith(byte[] data, int offset, byte[] prefix) {
+    for (int i = 0; i < prefix.length; i++) {
+      if (data[offset + i] != prefix[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
@@ -29,6 +29,9 @@ public enum ErrorCode {
   RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요"),
   DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다"),
   INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다"),
+  INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다"),
+  FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "파일 크기가 제한을 초과했습니다"),
+  FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다"),
   SSE_MAX_CONNECTIONS(HttpStatus.SERVICE_UNAVAILABLE, "SSE 최대 연결 수를 초과했습니다"),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");
 

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
@@ -38,6 +39,23 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   public ResponseEntity<?> handleOptimisticLock(ObjectOptimisticLockingFailureException e) {
     log.warn("낙관적 락 충돌 발생: entity={}, id={}", e.getPersistentClassName(), e.getIdentifier());
     ErrorCode errorCode = ErrorCode.CONCURRENT_MODIFICATION;
+    ErrorBody body =
+        new ErrorBody(
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            errorCode.getMessage(),
+            Instant.now().toString());
+    return ResponseEntity.status(errorCode.getStatus()).body(body);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleMaxUploadSizeExceededException(
+      MaxUploadSizeExceededException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
+    log.warn("파일 크기 초과: {}", ex.getMessage());
+    ErrorCode errorCode = ErrorCode.FILE_TOO_LARGE;
     ErrorBody body =
         new ErrorBody(
             errorCode.getStatus().value(),

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -49,6 +49,8 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/health", "/auth/refresh", "/auth/register", "/auth/login")
                     .permitAll()
+                    .requestMatchers("/uploads/**")
+                    .permitAll()
                     .requestMatchers(HttpMethod.GET, "/daily/today")
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/daily/guess")

--- a/backend/src/main/java/com/gakkaweo/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.gakkaweo.backend.config;
+
+import com.gakkaweo.backend.auth.config.ProfileImageProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+  private final ProfileImageProperties profileImageProperties;
+
+  @Override
+  public void addResourceHandlers(ResourceHandlerRegistry registry) {
+    registry
+        .addResourceHandler("/uploads/profiles/**")
+        .addResourceLocations("file:" + profileImageProperties.getProfileDir() + "/")
+        .setCachePeriod(31536000);
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/EndpointGroupResolver.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/EndpointGroupResolver.java
@@ -7,6 +7,7 @@ public class EndpointGroupResolver {
 
   public EndpointGroup resolve(String method, String uri) {
     if (uri.equals("/health")
+        || uri.startsWith("/uploads/")
         || uri.startsWith("/login/oauth2/")
         || uri.startsWith("/oauth2/authorization/")) {
       return EndpointGroup.NONE;

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -23,6 +23,10 @@ spring:
       host: localhost
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
+  servlet:
+    multipart:
+      max-file-size: 1MB
+      max-request-size: 2MB
   security:
     oauth2:
       client:
@@ -82,6 +86,8 @@ app:
     timeout: ${AI_SERVICE_TIMEOUT:3s}
   game:
     similarity-threshold: ${SIMILARITY_THRESHOLD:95.0}
+  upload:
+    profile-dir: ${UPLOAD_PROFILE_DIR:./uploads/profiles}
   rate-limit:
     guess-per-minute: ${RATE_LIMIT_GUESS:40}
     read-per-minute: ${RATE_LIMIT_READ:60}

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -21,6 +21,8 @@
 | POST   | `/auth/logout`               | 필수   | AUTH 10/min  | 로그아웃          |
 | GET    | `/auth/me`                   | 필수   | READ 60/min  | 내 정보 조회      |
 | PATCH  | `/auth/nickname`             | 필수   | AUTH 10/min  | 닉네임 변경       |
+| PATCH  | `/auth/profile-image`        | 필수   | AUTH 10/min  | 프로필 이미지 업로드 |
+| DELETE | `/auth/profile-image`        | 필수   | AUTH 10/min  | 프로필 이미지 삭제   |
 | DELETE | `/auth/account`              | 필수   | AUTH 10/min  | 회원 탈퇴         |
 | GET    | `/oauth2/authorization/{id}` | 불필요 | 없음         | OAuth 로그인 시작 |
 | GET    | `/daily/today`               | 불필요 | READ 60/min  | 오늘 문제 조회    |
@@ -143,12 +145,50 @@
 - **동작**: 닉네임 변경 + 오늘 랭킹 참여자인 경우 Redis Hash 닉네임 갱신 + SSE RANKING_UPDATE 브로드캐스트
 - **에러**: `NICKNAME_DUPLICATED`(409), `NICKNAME_UNCHANGED`(400), `NICKNAME_FORBIDDEN`(400), `VALIDATION_FAILED`(400), `MEMBER_NOT_FOUND`(404)
 
+### `PATCH /auth/profile-image` — 프로필 이미지 업로드
+
+- **인증**: 필수
+- **Rate Limit**: AUTH (10/min, IP 기준)
+- **Content-Type**: `multipart/form-data`
+- **요청**: `file` (필수, 이미지 파일, WebP, 최대 1MB)
+- **응답**: `200 OK`
+
+```json
+{
+  "publicId": "UUID",
+  "nickname": "String",
+  "profileUrl": "/uploads/profiles/{publicId}.webp?v={timestamp}",
+  "role": "ROLE_USER | ROLE_ADMIN"
+}
+```
+
+- **동작**: 파일 검증 (content-type + WebP magic bytes) → `{profileDir}/{publicId}.webp` 덮어쓰기 → DB profileUrl 갱신 → Redis Hash profileUrl 갱신 + SSE RANKING_UPDATE 브로드캐스트
+- **에러**: `INVALID_FILE_TYPE`(400), `FILE_TOO_LARGE`(400), `FILE_UPLOAD_FAILED`(500), `MEMBER_NOT_FOUND`(404)
+
+### `DELETE /auth/profile-image` — 프로필 이미지 삭제
+
+- **인증**: 필수
+- **Rate Limit**: AUTH (10/min, IP 기준)
+- **응답**: `200 OK`
+
+```json
+{
+  "publicId": "UUID",
+  "nickname": "String",
+  "profileUrl": null,
+  "role": "ROLE_USER | ROLE_ADMIN"
+}
+```
+
+- **동작**: DB profileUrl null 설정 → 파일 삭제 → Redis Hash profileUrl 갱신 + SSE RANKING_UPDATE 브로드캐스트
+- **에러**: `MEMBER_NOT_FOUND`(404)
+
 ### `DELETE /auth/account` — 회원 탈퇴
 
 - **인증**: 필수
 - **Rate Limit**: AUTH (10/min)
 - **응답**: `200 OK` (본문 없음, 쿠키 삭제)
-- **동작**: 게임 기록 익명화, 인증 데이터 삭제, Redis 정리
+- **동작**: 게임 기록 익명화, 인증 데이터 삭제, 프로필 이미지 파일 삭제, Redis 정리
 
 ---
 
@@ -387,6 +427,9 @@
 | `NICKNAME_FORBIDDEN`           | 400  | 사용할 수 없는 닉네임 (금칙어)    |
 | `DUPLICATE_USERNAME`           | 409  | 이미 사용 중인 아이디             |
 | `INVALID_CREDENTIALS`          | 401  | 아이디 또는 비밀번호 불일치       |
+| `INVALID_FILE_TYPE`            | 400  | 지원하지 않는 파일 형식           |
+| `FILE_TOO_LARGE`               | 400  | 파일 크기 제한 초과               |
+| `FILE_UPLOAD_FAILED`           | 500  | 파일 업로드 실패                  |
 | `OAUTH_PROVIDER_NOT_SUPPORTED` | 400  | 지원하지 않는 OAuth 프로바이더    |
 | `VALIDATION_FAILED`            | 400  | 요청 검증 실패                    |
 | `MISSING_PARAMETER`            | 400  | 필수 파라미터 누락                |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -144,7 +144,7 @@ hue = (similarity / 100) × 120
 | 게임       | `/`        | 추측 입력, 유사도 결과, 히스토리, 힌트 마스크 |
 | 랭킹       | `/ranking` | 실시간 순위 (SSE)                             |
 | 로그인     | `/login`   | 소셜 로그인 + 로컬 로그인 2컬럼 + 회원가입 다이얼로그 |
-| 마이페이지 | `/mypage`  | 닉네임 확인 (✏️ 편집), 회원 탈퇴              |
+| 마이페이지 | `/mypage`  | 프로필 이미지 업로드/삭제, 닉네임 확인 (✏️ 편집), 회원 탈퇴 |
 
 ## 9. 로그인 프로바이더 색상
 
@@ -190,3 +190,12 @@ placeholder:text-gray-400
 border-4 border-black dark:border-white rounded-none shadow-brutal
 dark:shadow-brutal-dark bg-white dark:bg-gray-900 p-6
 ```
+
+### 프로필 이미지 (마이페이지)
+
+- **프로필 이미지 클릭** → 팝오버(변경/삭제) 표시
+- **변경**: hidden `<input type="file" accept="image/*">` → 크롭 모달 → 256×256 WebP 리사이징 → 서버 업로드
+- **삭제**: ConfirmDialog 확인 후 서버 삭제 → 기본 아바타 복원
+- **크롭 모달**: `react-easy-crop` — `aspect={1}`, `cropShape="rect"` (직각, 네오브루탈리즘). 줌 슬라이더 1.0~3.0
+- **팝오버**: `border-4 shadow-brutal-sm`, click-outside/Escape 닫기
+- **hover 오버레이**: `bg-black/40` + 편집 아이콘 (프로필 이미지 위)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "pretendard": "^1.3.9",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-easy-crop": "^5.5.7",
     "react-router-dom": "^7.13.1",
     "zustand": "^5.0.12"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-easy-crop:
+        specifier: ^5.5.7
+        version: 5.5.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-router-dom:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1136,6 +1139,10 @@ packages:
     resolution:
       { integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA== }
 
+  normalize-wheel@1.0.1:
+    resolution:
+      { integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA== }
+
   optionator@0.9.4:
     resolution:
       { integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g== }
@@ -1205,6 +1212,13 @@ packages:
       { integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ== }
     peerDependencies:
       react: ^19.2.4
+
+  react-easy-crop@5.5.7:
+    resolution:
+      { integrity: sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA== }
+    peerDependencies:
+      react: ">=16.4.0"
+      react-dom: ">=16.4.0"
 
   react-router-dom@7.13.1:
     resolution:
@@ -2240,6 +2254,8 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  normalize-wheel@1.0.1: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2287,6 +2303,13 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-easy-crop@5.5.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
 
   react-router-dom@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -2362,8 +2385,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/shared/ui/Input";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { type Provider, PROVIDER_COLORS, getLastProvider, saveLastProvider } from "@/shared/config/providers";
 import { KakaoIcon, GoogleIcon, NaverIcon } from "@/shared/config/providerIcons";
+import { queryClient } from "@/shared/api/queryClient";
 import { login } from "@/features/auth/api";
 import { RegisterDialog } from "@/features/auth/components/RegisterDialog";
 
@@ -46,6 +47,7 @@ export function LoginPage() {
       await login(username, password);
       saveLastProvider("local");
       await fetchUser();
+      queryClient.invalidateQueries({ queryKey: ["ranking"] });
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message);
@@ -60,6 +62,7 @@ export function LoginPage() {
     setIsRegisterOpen(false);
     saveLastProvider("local");
     await fetchUser();
+    queryClient.invalidateQueries({ queryKey: ["ranking"] });
   };
 
   return (

--- a/frontend/src/features/auth/MyPage.tsx
+++ b/frontend/src/features/auth/MyPage.tsx
@@ -1,12 +1,15 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import type { MeResponse } from "@/shared/api/types";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { useToastStore } from "@/shared/stores/useToastStore";
 import { Card } from "@/shared/ui/Card";
 import { Button } from "@/shared/ui/Button";
-import { logout, deleteAccount } from "@/features/auth/api";
+import { logout, deleteAccount, deleteProfileImage } from "@/features/auth/api";
+import { resolveProfileUrl } from "@/shared/utils/url";
 import { ConfirmDialog } from "@/features/auth/components/ConfirmDialog";
 import { NicknameEditDialog } from "@/features/auth/components/NicknameEditDialog";
+import { ProfileImageCropDialog } from "@/features/auth/components/ProfileImageCropDialog";
+import { ProfileImagePopover } from "@/features/auth/components/ProfileImagePopover";
 
 export function MyPage() {
   const { user, clearUser, updateUser } = useAuthStore();
@@ -17,6 +20,21 @@ export function MyPage() {
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [selectedImageSrc, setSelectedImageSrc] = useState<string | null>(null);
+  const [isDeleteImageConfirmOpen, setIsDeleteImageConfirmOpen] = useState(false);
+  const [isDeletingImage, setIsDeletingImage] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(
+    () => () => {
+      if (selectedImageSrc) {
+        URL.revokeObjectURL(selectedImageSrc);
+      }
+    },
+    [selectedImageSrc],
+  );
 
   const handleNicknameSuccess = (updatedUser: MeResponse) => {
     updateUser({ nickname: updatedUser.nickname });
@@ -51,31 +69,122 @@ export function MyPage() {
     }
   };
 
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (selectedImageSrc) {
+      URL.revokeObjectURL(selectedImageSrc);
+    }
+
+    const blobUrl = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      canvas.getContext("2d")!.drawImage(img, 0, 0);
+      URL.revokeObjectURL(blobUrl);
+      setSelectedImageSrc(canvas.toDataURL("image/png"));
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(blobUrl);
+    };
+    img.src = blobUrl;
+
+    setIsPopoverOpen(false);
+    e.target.value = "";
+  };
+
+  const handleCropSuccess = (response: MeResponse) => {
+    updateUser({ profileUrl: response.profileUrl });
+    addToast("프로필 이미지가 변경되었습니다", "success");
+
+    if (selectedImageSrc) {
+      URL.revokeObjectURL(selectedImageSrc);
+    }
+    setSelectedImageSrc(null);
+  };
+
+  const handleCropClose = () => {
+    if (selectedImageSrc) {
+      URL.revokeObjectURL(selectedImageSrc);
+    }
+    setSelectedImageSrc(null);
+  };
+
+  const handleDeleteImage = async () => {
+    setIsDeletingImage(true);
+    try {
+      await deleteProfileImage();
+      updateUser({ profileUrl: null as unknown as string });
+      addToast("프로필 이미지가 삭제되었습니다", "success");
+      setIsDeleteImageConfirmOpen(false);
+    } catch {
+      addToast("프로필 이미지 삭제에 실패했습니다", "error");
+    } finally {
+      setIsDeletingImage(false);
+    }
+  };
+
   return (
     <div className="max-w-md mx-auto space-y-6">
       <h1 className="text-4xl font-black">마이페이지</h1>
 
       <Card className="flex flex-col items-center space-y-4 py-8">
-        {user?.profileUrl ? (
-          <img
-            src={user.profileUrl}
-            alt="프로필"
-            className="w-24 h-24 border-4 border-black dark:border-white object-cover"
-          />
-        ) : (
-          <div className="w-24 h-24 border-4 border-black dark:border-white bg-gray-200 dark:bg-gray-800 flex items-center justify-center">
-            <svg
-              width="48"
-              height="48"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              className="text-gray-400 dark:text-gray-500"
-            >
-              <circle cx="12" cy="9" r="3.5" />
-              <path d="M12 14c-4.42 0-8 2.24-8 5v1h16v-1c0-2.76-3.58-5-8-5z" />
-            </svg>
-          </div>
-        )}
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setIsPopoverOpen((prev) => !prev)}
+            className="group relative cursor-pointer"
+            aria-label="프로필 이미지 변경"
+          >
+            {user?.profileUrl ? (
+              <img
+                src={resolveProfileUrl(user.profileUrl) ?? ""}
+                alt="프로필"
+                className="w-24 h-24 border-4 border-black dark:border-white object-cover"
+              />
+            ) : (
+              <div className="w-24 h-24 border-4 border-black dark:border-white bg-gray-200 dark:bg-gray-800 flex items-center justify-center">
+                <svg
+                  width="48"
+                  height="48"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="text-gray-400 dark:text-gray-500"
+                >
+                  <circle cx="12" cy="9" r="3.5" />
+                  <path d="M12 14c-4.42 0-8 2.24-8 5v1h16v-1c0-2.76-3.58-5-8-5z" />
+                </svg>
+              </div>
+            )}
+            <div className="absolute inset-0 border-4 border-black dark:border-white bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="white">
+                <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
+              </svg>
+            </div>
+          </button>
+
+          {isPopoverOpen && (
+            <ProfileImagePopover
+              hasImage={!!user?.profileUrl}
+              onChangeClick={() => {
+                setIsPopoverOpen(false);
+                fileInputRef.current?.click();
+              }}
+              onDeleteClick={() => {
+                setIsPopoverOpen(false);
+                setIsDeleteImageConfirmOpen(true);
+              }}
+              onClose={() => setIsPopoverOpen(false)}
+            />
+          )}
+        </div>
+
+        <input ref={fileInputRef} type="file" accept="image/*" onChange={handleFileSelect} className="hidden" />
 
         <div className="text-center">
           <p className="text-sm font-extrabold uppercase tracking-wider text-gray-600 dark:text-gray-400 mb-1">
@@ -112,6 +221,10 @@ export function MyPage() {
         </Button>
       </div>
 
+      {selectedImageSrc && (
+        <ProfileImageCropDialog imageSrc={selectedImageSrc} onClose={handleCropClose} onSuccess={handleCropSuccess} />
+      )}
+
       {isNicknameEditOpen && (
         <NicknameEditDialog
           onClose={() => setIsNicknameEditOpen(false)}
@@ -138,6 +251,16 @@ export function MyPage() {
         message="탈퇴 시 게임 기록이 익명 처리되며 복구할 수 없습니다. 정말 탈퇴하시겠습니까?"
         confirmLabel="탈퇴하기"
         isLoading={isDeleting}
+      />
+
+      <ConfirmDialog
+        isOpen={isDeleteImageConfirmOpen}
+        onClose={() => setIsDeleteImageConfirmOpen(false)}
+        onConfirm={handleDeleteImage}
+        title="프로필 이미지 삭제"
+        message="프로필 이미지를 삭제하시겠습니까?"
+        confirmLabel="삭제"
+        isLoading={isDeletingImage}
       />
     </div>
   );

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -23,3 +23,13 @@ export function register(username: string, password: string) {
 export function login(username: string, password: string) {
   return apiFetch<MeResponse>("/auth/login", { method: "POST", body: { username, password } });
 }
+
+export function uploadProfileImage(file: Blob): Promise<MeResponse> {
+  const formData = new FormData();
+  formData.append("file", file, "profile.webp");
+  return apiFetch<MeResponse>("/auth/profile-image", { method: "PATCH", body: formData });
+}
+
+export function deleteProfileImage() {
+  return apiFetch<MeResponse>("/auth/profile-image", { method: "DELETE" });
+}

--- a/frontend/src/features/auth/components/ProfileImageCropDialog.tsx
+++ b/frontend/src/features/auth/components/ProfileImageCropDialog.tsx
@@ -1,0 +1,140 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { CSSProperties } from "react";
+import Cropper from "react-easy-crop";
+import type { Area } from "react-easy-crop";
+import { ApiError } from "@/shared/api/client";
+import { Button } from "@/shared/ui/Button";
+import { uploadProfileImage } from "@/features/auth/api";
+import { cropImage } from "@/features/auth/utils/cropImage";
+import type { MeResponse } from "@/shared/api/types";
+
+interface ProfileImageCropDialogProps {
+  imageSrc: string;
+  onClose: () => void;
+  onSuccess: (response: MeResponse) => void;
+}
+
+const sliderStyle: CSSProperties = {
+  WebkitAppearance: "none",
+  appearance: "none",
+  height: "6px",
+  background: "var(--slider-track, #d1d5db)",
+  outline: "none",
+  cursor: "pointer",
+};
+
+export function ProfileImageCropDialog({ imageSrc, onClose, onSuccess }: ProfileImageCropDialogProps) {
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const onCropComplete = useCallback((_: Area, pixels: Area) => {
+    setCroppedAreaPixels(pixels);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !isSubmitting) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isSubmitting, onClose]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (!isSubmitting && dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isSubmitting, onClose]);
+
+  const handleSubmit = async () => {
+    if (!croppedAreaPixels) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const blob = await cropImage(imageSrc, croppedAreaPixels);
+      const response = await uploadProfileImage(blob);
+      onSuccess(response);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("이미지 업로드에 실패했습니다");
+      }
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
+      <div
+        ref={dialogRef}
+        className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-sm"
+      >
+        <div className="px-6 py-5 space-y-4">
+          <h2 className="text-xl font-black">프로필 이미지 편집</h2>
+
+          <div className="relative w-full aspect-square border-4 border-black dark:border-white overflow-hidden bg-gray-100 dark:bg-gray-800">
+            <Cropper
+              image={imageSrc}
+              crop={crop}
+              zoom={zoom}
+              aspect={1}
+              cropShape="rect"
+              onCropChange={setCrop}
+              onZoomChange={setZoom}
+              onCropComplete={onCropComplete}
+              style={{
+                containerStyle: { position: "absolute", inset: 0 },
+              }}
+            />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <span className="text-sm font-bold shrink-0">줌</span>
+            <input
+              type="range"
+              min={1}
+              max={10}
+              step={0.1}
+              value={zoom}
+              onChange={(e) => setZoom(Number(e.target.value))}
+              className="w-full"
+              style={sliderStyle}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          {error && <p className="text-sm font-medium text-red-500">{error}</p>}
+        </div>
+
+        <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white">
+          <Button variant="secondary" size="sm" className="flex-1" onClick={onClose} disabled={isSubmitting}>
+            취소
+          </Button>
+          <Button size="sm" className="flex-1" onClick={handleSubmit} isLoading={isSubmitting} disabled={isSubmitting}>
+            저장
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/auth/components/ProfileImagePopover.tsx
+++ b/frontend/src/features/auth/components/ProfileImagePopover.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from "react";
+
+interface ProfileImagePopoverProps {
+  hasImage: boolean;
+  onChangeClick: () => void;
+  onDeleteClick: () => void;
+  onClose: () => void;
+}
+
+export function ProfileImagePopover({ hasImage, onChangeClick, onDeleteClick, onClose }: ProfileImagePopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={popoverRef}
+      className="absolute top-full left-1/2 -translate-x-1/2 mt-2 z-10 border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal-sm"
+    >
+      <button
+        type="button"
+        onClick={onChangeClick}
+        className="block w-full px-5 py-2.5 text-sm font-bold text-left hover:bg-indigo-50 dark:hover:bg-gray-800 cursor-pointer whitespace-nowrap"
+      >
+        변경
+      </button>
+      {hasImage && (
+        <button
+          type="button"
+          onClick={onDeleteClick}
+          className="block w-full px-5 py-2.5 text-sm font-bold text-left text-red-500 hover:bg-red-50 dark:hover:bg-gray-800 cursor-pointer whitespace-nowrap border-t-2 border-black dark:border-white"
+        >
+          삭제
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/auth/utils/cropImage.ts
+++ b/frontend/src/features/auth/utils/cropImage.ts
@@ -1,0 +1,49 @@
+import type { Area } from "react-easy-crop";
+
+function createImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener("load", () => resolve(image));
+    image.addEventListener("error", (error) => reject(error));
+    image.src = url;
+  });
+}
+
+export async function cropImage(imageSrc: string, croppedAreaPixels: Area): Promise<Blob> {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) {
+    throw new Error("Canvas 2D context를 가져올 수 없습니다");
+  }
+
+  canvas.width = 256;
+  canvas.height = 256;
+
+  ctx.drawImage(
+    image,
+    croppedAreaPixels.x,
+    croppedAreaPixels.y,
+    croppedAreaPixels.width,
+    croppedAreaPixels.height,
+    0,
+    0,
+    256,
+    256,
+  );
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("이미지 변환에 실패했습니다"));
+        }
+      },
+      "image/webp",
+      0.85,
+    );
+  });
+}

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -57,8 +57,12 @@ export function GamePage() {
     if (!localCleared) {
       return;
     }
-    confetti({ particleCount: 80, spread: 70, origin: { x: 0.3, y: 0.5 } });
-    confetti({ particleCount: 80, spread: 70, origin: { x: 0.7, y: 0.5 } });
+    const opts = { particleCount: 200, spread: 360, origin: { y: 0.5 } };
+    confetti({ ...opts, origin: { x: 0.2, y: 0.5 } });
+    confetti({ ...opts, origin: { x: 0.35, y: 0.5 } });
+    confetti({ ...opts, origin: { x: 0.5, y: 0.5 } });
+    confetti({ ...opts, origin: { x: 0.65, y: 0.5 } });
+    confetti({ ...opts, origin: { x: 0.8, y: 0.5 } });
   }, [localCleared]);
 
   useEffect(

--- a/frontend/src/features/ranking/components/RankingEntryRow.tsx
+++ b/frontend/src/features/ranking/components/RankingEntryRow.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { RankingEntry } from "@/shared/api/types";
 import { getSimilarityColor } from "@/shared/utils/similarity";
+import { resolveProfileUrl } from "@/shared/utils/url";
 
 interface RankingEntryRowProps {
   entry: RankingEntry;
@@ -54,7 +55,7 @@ export function RankingEntryRow({ entry }: RankingEntryRowProps) {
 
         {entry.profileUrl && !imgError ? (
           <img
-            src={entry.profileUrl}
+            src={resolveProfileUrl(entry.profileUrl) ?? ""}
             alt=""
             className="w-7 h-7 border-2 border-black dark:border-white object-cover shrink-0"
             onError={() => setImgError(true)}

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -66,7 +66,7 @@ export async function apiFetch<T>(path: string, { body: rawBody, ...restOptions 
   const hasBody = method !== "GET" && method !== "HEAD";
 
   const headers: Record<string, string> = {};
-  if (hasBody) {
+  if (hasBody && !(rawBody instanceof FormData)) {
     headers["Content-Type"] = "application/json";
   }
 

--- a/frontend/src/shared/utils/url.ts
+++ b/frontend/src/shared/utils/url.ts
@@ -1,0 +1,12 @@
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+
+/** 상대경로 프로필 URL에 API base URL을 붙인다. 배포 시 같은 도메인이면 이 함수만 제거. */
+export function resolveProfileUrl(url: string | null | undefined): string | null {
+  if (!url) {
+    return null;
+  }
+  if (url.startsWith("http")) {
+    return url;
+  }
+  return `${API_BASE}${url}`;
+}


### PR DESCRIPTION
## 관련 이슈

Closes #72 

## 변경 사항

마이페이지에서 프로필 이미지를 업로드/삭제할 수 있는 풀스택 기능 추가.

- **플로우**: 프로필 이미지 클릭 → 팝오버(변경/삭제) → 파일 선택 → 정사각형 크롭 모달 → 클라이언트 리사이징(256×256 WebP) → 서버 저장
- **저장소**: 로컬 파일 시스템 (`{publicId}.webp` 덮어쓰기, 쿼리스트링 버전 캐시 무효화)
- **동기화**: 프로필 변경 시 Redis 랭킹 Hash + SSE 브로드캐스트
- **부가 수정**: 로그인 후 랭킹 캐시 미갱신 버그 수정, 정답 폭죽 효과 강화

### Backend
- `PATCH /auth/profile-image` — 업로드 (multipart, WebP magic bytes 검증)
- `DELETE /auth/profile-image` — 삭제 (DB null + 파일 삭제)
- ProfileImageService, ProfileImageProperties, WebConfig (정적 리소스 서빙)
- SecurityConfig, EndpointGroupResolver, GlobalExceptionHandler 업데이트
- 회원 탈퇴 시 프로필 이미지 파일 정리

### Frontend
- apiFetch: FormData Content-Type 버그 수정
- react-easy-crop 기반 크롭 모달 (ProfileImageCropDialog)
- 팝오버 메뉴 (ProfileImagePopover)
- MyPage 통합 (GIF 정지 이미지 변환 포함)
- resolveProfileUrl 유틸 (개발 환경 cross-origin 대응)
- 로그인 후 랭킹 쿼리 invalidate 추가

### Docs
- api-spec.md, design-system.md 갱신

### 코드리뷰 반영
- ErrorCode enum에 MISSING_PARAMETER, METHOD_NOT_ALLOWED 추가 (하드코딩 제거)
- FILE_TOO_LARGE 상태코드 400 → 413 (RFC 9110)
- ProfileImageService: readNBytes()로 부분 읽기 방어
- MeResponse.profileUrl 타입 nullable 수정 + 캐스팅 제거
- React.ChangeEvent 네임스페이스 참조 → named import
- canvas.getContext null 체크 + img.onerror 사용자 피드백
- ProfileImagePopover click-outside 버튼 충돌 수정

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

