### PR TITLE
fix: 프로필 이미지 코드리뷰 반영

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/ProfileImageService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/ProfileImageService.java
@@ -74,8 +74,8 @@ public class ProfileImageService {
     }
 
     try (InputStream is = file.getInputStream()) {
-      byte[] header = new byte[12];
-      if (is.read(header) < 12) {
+      byte[] header = is.readNBytes(12);
+      if (header.length < 12) {
         throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
       }
 

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
@@ -29,8 +29,10 @@ public enum ErrorCode {
   RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요"),
   DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다"),
   INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다"),
+  MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다"),
+  METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다"),
   INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다"),
-  FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "파일 크기가 제한을 초과했습니다"),
+  FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "파일 크기가 제한을 초과했습니다"),
   FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다"),
   SSE_MAX_CONNECTIONS(HttpStatus.SERVICE_UNAVAILABLE, "SSE 최대 연결 수를 초과했습니다"),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
@@ -101,10 +101,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
       HttpStatusCode status,
       WebRequest request) {
     log.warn("필수 파라미터 누락: {}", ex.getMessage());
+    ErrorCode errorCode = ErrorCode.MISSING_PARAMETER;
     ErrorBody body =
         new ErrorBody(
-            status.value(), "MISSING_PARAMETER", ex.getMessage(), Instant.now().toString());
-    return ResponseEntity.status(status).body(body);
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            ex.getMessage(),
+            Instant.now().toString());
+    return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
   @Override
@@ -114,10 +118,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
       HttpStatusCode status,
       WebRequest request) {
     log.warn("지원하지 않는 HTTP 메서드: {}", ex.getMessage());
+    ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
     ErrorBody body =
         new ErrorBody(
-            status.value(), "METHOD_NOT_ALLOWED", ex.getMessage(), Instant.now().toString());
-    return ResponseEntity.status(status).body(body);
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            ex.getMessage(),
+            Instant.now().toString());
+    return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
   @Override

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -428,7 +428,7 @@
 | `DUPLICATE_USERNAME`           | 409  | 이미 사용 중인 아이디             |
 | `INVALID_CREDENTIALS`          | 401  | 아이디 또는 비밀번호 불일치       |
 | `INVALID_FILE_TYPE`            | 400  | 지원하지 않는 파일 형식           |
-| `FILE_TOO_LARGE`               | 400  | 파일 크기 제한 초과               |
+| `FILE_TOO_LARGE`               | 413  | 파일 크기 제한 초과               |
 | `FILE_UPLOAD_FAILED`           | 500  | 파일 업로드 실패                  |
 | `OAUTH_PROVIDER_NOT_SUPPORTED` | 400  | 지원하지 않는 OAuth 프로바이더    |
 | `VALIDATION_FAILED`            | 400  | 요청 검증 실패                    |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -196,6 +196,6 @@ dark:shadow-brutal-dark bg-white dark:bg-gray-900 p-6
 - **프로필 이미지 클릭** → 팝오버(변경/삭제) 표시
 - **변경**: hidden `<input type="file" accept="image/*">` → 크롭 모달 → 256×256 WebP 리사이징 → 서버 업로드
 - **삭제**: ConfirmDialog 확인 후 서버 삭제 → 기본 아바타 복원
-- **크롭 모달**: `react-easy-crop` — `aspect={1}`, `cropShape="rect"` (직각, 네오브루탈리즘). 줌 슬라이더 1.0~3.0
+- **크롭 모달**: `react-easy-crop` — `aspect={1}`, `cropShape="rect"` (직각, 네오브루탈리즘). 줌 슬라이더 1.0~10.0
 - **팝오버**: `border-4 shadow-brutal-sm`, click-outside/Escape 닫기
 - **hover 오버레이**: `bg-black/40` + 편집 아이콘 (프로필 이미지 위)

--- a/frontend/src/features/auth/MyPage.tsx
+++ b/frontend/src/features/auth/MyPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import type { ChangeEvent } from "react";
 import type { MeResponse } from "@/shared/api/types";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { useToastStore } from "@/shared/stores/useToastStore";
@@ -26,6 +27,7 @@ export function MyPage() {
   const [isDeleteImageConfirmOpen, setIsDeleteImageConfirmOpen] = useState(false);
   const [isDeletingImage, setIsDeletingImage] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const profileBtnRef = useRef<HTMLButtonElement>(null);
 
   useEffect(
     () => () => {
@@ -69,7 +71,7 @@ export function MyPage() {
     }
   };
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) {
       return;
@@ -85,12 +87,18 @@ export function MyPage() {
       const canvas = document.createElement("canvas");
       canvas.width = img.naturalWidth;
       canvas.height = img.naturalHeight;
-      canvas.getContext("2d")!.drawImage(img, 0, 0);
+      const ctx = canvas.getContext("2d");
       URL.revokeObjectURL(blobUrl);
+      if (!ctx) {
+        addToast("이미지 편집을 지원하지 않는 환경입니다", "error");
+        return;
+      }
+      ctx.drawImage(img, 0, 0);
       setSelectedImageSrc(canvas.toDataURL("image/png"));
     };
     img.onerror = () => {
       URL.revokeObjectURL(blobUrl);
+      addToast("이미지를 불러올 수 없습니다", "error");
     };
     img.src = blobUrl;
 
@@ -118,8 +126,8 @@ export function MyPage() {
   const handleDeleteImage = async () => {
     setIsDeletingImage(true);
     try {
-      await deleteProfileImage();
-      updateUser({ profileUrl: null as unknown as string });
+      const response = await deleteProfileImage();
+      updateUser({ profileUrl: response.profileUrl });
       addToast("프로필 이미지가 삭제되었습니다", "success");
       setIsDeleteImageConfirmOpen(false);
     } catch {
@@ -136,6 +144,7 @@ export function MyPage() {
       <Card className="flex flex-col items-center space-y-4 py-8">
         <div className="relative">
           <button
+            ref={profileBtnRef}
             type="button"
             onClick={() => setIsPopoverOpen((prev) => !prev)}
             className="group relative cursor-pointer"
@@ -171,6 +180,7 @@ export function MyPage() {
           {isPopoverOpen && (
             <ProfileImagePopover
               hasImage={!!user?.profileUrl}
+              triggerRef={profileBtnRef}
               onChangeClick={() => {
                 setIsPopoverOpen(false);
                 fileInputRef.current?.click();

--- a/frontend/src/features/auth/components/ProfileImagePopover.tsx
+++ b/frontend/src/features/auth/components/ProfileImagePopover.tsx
@@ -1,18 +1,27 @@
 import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
 
 interface ProfileImagePopoverProps {
   hasImage: boolean;
+  triggerRef: RefObject<HTMLButtonElement | null>;
   onChangeClick: () => void;
   onDeleteClick: () => void;
   onClose: () => void;
 }
 
-export function ProfileImagePopover({ hasImage, onChangeClick, onDeleteClick, onClose }: ProfileImagePopoverProps) {
+export function ProfileImagePopover({
+  hasImage,
+  triggerRef,
+  onChangeClick,
+  onDeleteClick,
+  onClose,
+}: ProfileImagePopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      if (popoverRef.current && !popoverRef.current.contains(target) && !triggerRef.current?.contains(target)) {
         onClose();
       }
     };
@@ -21,7 +30,7 @@ export function ProfileImagePopover({ hasImage, onChangeClick, onDeleteClick, on
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [onClose]);
+  }, [onClose, triggerRef]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/frontend/src/shared/api/types.ts
+++ b/frontend/src/shared/api/types.ts
@@ -3,7 +3,7 @@
 export interface MeResponse {
   publicId: string;
   nickname: string;
-  profileUrl: string;
+  profileUrl: string | null;
   role: "ROLE_USER" | "ROLE_ADMIN";
 }
 


### PR DESCRIPTION
## 관련 이슈

#72 코드리뷰 반영 (PR #73 머지 후 미push된 커밋)

## 변경 사항

### Backend
- ErrorCode에 MISSING_PARAMETER, METHOD_NOT_ALLOWED 추가 (하드코딩 제거)
- GlobalExceptionHandler에서 ErrorCode enum 참조로 통일
- FILE_TOO_LARGE 상태코드 400 → 413 (PAYLOAD_TOO_LARGE)
- ProfileImageService: InputStream.read() → readNBytes() (부분 읽기 방어)

### Frontend
- MeResponse.profileUrl 타입 string → string | null
- null as unknown as string 캐스팅 제거, 서버 응답 활용
- React.ChangeEvent → import type { ChangeEvent } (네임스페이스 참조 금지)
- canvas.getContext("2d") null 체크 + img.onerror 토스트 추가
- ProfileImagePopover: triggerRef prop 추가 (click-outside 버튼 충돌 수정)

### Docs
- api-spec.md: FILE_TOO_LARGE 상태코드 413 반영
- design-system.md: 줌 슬라이더 범위 1.0~10.0 반영

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다