### PR TITLE
feat: 헤더 로고 아이콘 + 푸터 컴포넌트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ node_modules/
 package-lock.json
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,linux,visualstudiocode,intellij+all,venv,dotenv,git
+.playwright-mcp/

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -194,6 +194,18 @@ border-4 border-black dark:border-white rounded-none shadow-brutal
 dark:shadow-brutal-dark bg-white dark:bg-gray-900 p-6
 ```
 
+### 푸터
+
+```
+border-t-4 border-black dark:border-white bg-white dark:bg-gray-950
+max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
+```
+
+- 좌측: `© 2026 가까워` (`text-sm font-bold text-gray-600 dark:text-gray-400`)
+- 우측: 이용약관, 개인정보처리방침 (내부 Link), GitHub, Blog (외부 `<a>` target="_blank")
+- 링크: `text-sm font-bold text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white transition-colors`
+- Layout: `flex flex-col min-h-screen` + `<main>` `flex-1` (스티키 푸터)
+
 ### 프로필 이미지 (마이페이지)
 
 - **프로필 이미지 클릭** → 팝오버(변경/삭제) 표시

--- a/frontend/src/app/layout/Footer.tsx
+++ b/frontend/src/app/layout/Footer.tsx
@@ -1,0 +1,41 @@
+import { Link } from "react-router-dom";
+
+const LEGAL_LINKS = [
+  { label: "이용약관", to: "/terms" },
+  { label: "개인정보처리방침", to: "/privacy" },
+] as const;
+
+const EXTERNAL_LINKS = [
+  { label: "버그제보/피드백", href: "https://forms.gle/UjqHjVuyJbpchooT6" },
+  { label: "이메일", href: "mailto:wnsgh5462@gmail.com" },
+  { label: "GitHub", href: "https://github.com/RabeMaster/gakkaweo" },
+  { label: "Blog", href: "https://r4b2.tistory.com/" },
+] as const;
+
+const linkClassName =
+  "text-sm font-bold text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white transition-colors";
+
+export function Footer() {
+  return (
+    <footer className="border-t-4 border-black dark:border-white bg-white dark:bg-gray-950">
+      <div className="max-w-6xl mx-auto px-6 py-6 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <span className="text-sm font-bold text-gray-600 dark:text-gray-400">© 2026 가까워</span>
+          {LEGAL_LINKS.map((link) => (
+            <Link key={link.to} to={link.to} className={linkClassName}>
+              {link.label}
+            </Link>
+          ))}
+        </div>
+
+        <nav className="flex items-center gap-4">
+          {EXTERNAL_LINKS.map((link) => (
+            <a key={link.href} href={link.href} target="_blank" rel="noopener noreferrer" className={linkClassName}>
+              {link.label}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/app/layout/Header.tsx
+++ b/frontend/src/app/layout/Header.tsx
@@ -20,7 +20,11 @@ export function Header() {
     <>
       <header className="border-b-4 border-black dark:border-white bg-white dark:bg-gray-950">
         <div className="max-w-6xl mx-auto flex items-center justify-between px-6 py-4">
-          <Link to="/" className="text-2xl font-black text-black dark:text-white tracking-tight">
+          <Link
+            to="/"
+            className="flex items-center gap-2 text-2xl font-black text-black dark:text-white tracking-tight"
+          >
+            <GakkaweoIcon size={28} />
             가까워
           </Link>
 

--- a/frontend/src/app/layout/Layout.tsx
+++ b/frontend/src/app/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "react-router-dom";
 import { Header } from "@/app/layout/Header";
+import { Footer } from "@/app/layout/Footer";
 import { AnnouncementBanner } from "@/shared/ui/AnnouncementBanner";
 import { useRankingSSE } from "@/features/ranking/hooks/useRankingSSE";
 import { useToastStore } from "@/shared/stores/useToastStore";
@@ -15,13 +16,15 @@ export function Layout() {
   const { toasts, removeToast } = useToastStore();
 
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-950 text-black dark:text-white">
+    <div className="flex flex-col min-h-screen bg-white dark:bg-gray-950 text-black dark:text-white">
       <Header />
 
-      <main className="max-w-6xl mx-auto px-6 py-8">
+      <main className="flex-1 max-w-6xl w-full mx-auto px-6 py-8">
         <AnnouncementBanner />
         <Outlet />
       </main>
+
+      <Footer />
 
       {toasts.length > 0 && (
         <div className="fixed bottom-6 right-6 flex flex-col gap-3 z-50">


### PR DESCRIPTION
- Header에 GakkaweoIcon SVG(28px) 로고 추가
- Footer 컴포넌트 신규 생성 (이용약관, 개인정보처리방침, GitHub, Blog 링크)
- Layout에 flex column 스티키 푸터 적용
- design-system.md에 푸터 컴포넌트 규칙 추가

## 관련 이슈

Closes #89 

## 변경 사항

- Header에 GakkaweoIcon SVG(28px) 로고 아이콘 추가
- Footer 컴포넌트 신규 생성 (좌: 저작권 + 법적 링크, 우: 외부 링크)
- Layout에 flex column 스티키 푸터 적용
- design-system.md에 푸터 컴포넌트 규칙 추가

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
