### PR TITLE
feat: 어드민 대시보드 정답 문장 스포일러 방지

### DIFF
--- a/frontend/src/app/layout/Footer.tsx
+++ b/frontend/src/app/layout/Footer.tsx
@@ -30,7 +30,12 @@ export function Footer() {
 
         <nav className="flex items-center gap-4">
           {EXTERNAL_LINKS.map((link) => (
-            <a key={link.href} href={link.href} target="_blank" rel="noopener noreferrer" className={linkClassName}>
+            <a
+              key={link.href}
+              href={link.href}
+              {...(!link.href.startsWith("mailto:") && { target: "_blank", rel: "noopener noreferrer" })}
+              className={linkClassName}
+            >
               {link.label}
             </a>
           ))}

--- a/frontend/src/features/admin/components/DashboardTab.tsx
+++ b/frontend/src/features/admin/components/DashboardTab.tsx
@@ -18,17 +18,17 @@ function SentenceSpoiler({ sentence }: { sentence: string }) {
   return (
     <div className="border-4 border-black dark:border-white bg-indigo-50 dark:bg-gray-900 shadow-brutal-sm p-4">
       <p className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">오늘 문장</p>
-      {revealed ? (
-        <p className="text-lg font-black mt-1">{sentence}</p>
-      ) : (
-        <button
-          type="button"
-          onClick={() => setRevealed(true)}
-          className="mt-1 text-sm font-bold text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white transition-colors"
-        >
-          클릭하여 정답 확인 (스포일러 주의)
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={() => setRevealed((prev) => !prev)}
+        className={`mt-1 text-left w-full transition-colors ${
+          revealed
+            ? "text-lg font-black"
+            : "text-sm font-bold text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white"
+        }`}
+      >
+        {revealed ? sentence : "클릭하여 정답 확인 (스포일러 주의)"}
+      </button>
     </div>
   );
 }
@@ -99,7 +99,7 @@ export function DashboardTab() {
             />
           </div>
 
-          <SentenceSpoiler sentence={widget.sentence} />
+          <SentenceSpoiler key={widget.sentenceId} sentence={widget.sentence} />
         </>
       )}
 

--- a/frontend/src/features/admin/components/DashboardTab.tsx
+++ b/frontend/src/features/admin/components/DashboardTab.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTodayWidget, useTrends } from "@/features/admin/hooks/useAdminDashboard";
 import type { DailyTrend } from "@/features/admin/types";
 
@@ -7,6 +8,27 @@ function WidgetCard({ label, value, sub }: { label: string; value: string | numb
       <p className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">{label}</p>
       <p className="text-3xl font-black tabular-nums mt-1">{value}</p>
       {sub && <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+function SentenceSpoiler({ sentence }: { sentence: string }) {
+  const [revealed, setRevealed] = useState(false);
+
+  return (
+    <div className="border-4 border-black dark:border-white bg-indigo-50 dark:bg-gray-900 shadow-brutal-sm p-4">
+      <p className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">오늘 문장</p>
+      {revealed ? (
+        <p className="text-lg font-black mt-1">{sentence}</p>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setRevealed(true)}
+          className="mt-1 text-sm font-bold text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white transition-colors"
+        >
+          클릭하여 정답 확인 (스포일러 주의)
+        </button>
+      )}
     </div>
   );
 }
@@ -77,10 +99,7 @@ export function DashboardTab() {
             />
           </div>
 
-          <div className="border-4 border-black dark:border-white bg-indigo-50 dark:bg-gray-900 shadow-brutal-sm p-4">
-            <p className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">오늘 문장</p>
-            <p className="text-lg font-black mt-1">{widget.sentence}</p>
-          </div>
+          <SentenceSpoiler sentence={widget.sentence} />
         </>
       )}
 


### PR DESCRIPTION
## 관련 이슈

Closes #90 

## 변경 사항

- 어드민 대시보드 오늘 문장 영역을 클릭 토글로 변경
- 기본 상태에서 정답 숨김, 클릭 시 노출 (관리자도 플레이어이므로 스포일러 방지)

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
