### PR TITLE
feat: 프론트엔드 UX 개선 + SSE 접속자 수 표시

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/ranking/dto/HeartbeatResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/dto/HeartbeatResponse.java
@@ -1,0 +1,3 @@
+package com.gakkaweo.backend.ranking.dto;
+
+public record HeartbeatResponse(int sseConnectionCount) {}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
@@ -2,6 +2,7 @@ package com.gakkaweo.backend.ranking.sse;
 
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.ranking.dto.HeartbeatResponse;
 import com.gakkaweo.backend.ranking.dto.RankingResponse;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import jakarta.annotation.PostConstruct;
@@ -77,13 +78,18 @@ public class SseConnectionManager {
     sendToAll(emitter -> emitter.send(SseEmitter.event().name(type.name()).data(data)));
   }
 
+  private SseEmitter.SseEventBuilder heartbeatEvent() {
+    return SseEmitter.event()
+        .name(SseEventType.HEARTBEAT.name())
+        .data(new HeartbeatResponse(getConnectionCount()));
+  }
+
   private void sendHeartbeat() {
     try {
       if (emitters.isEmpty()) {
         return;
       }
-      sendToAll(
-          emitter -> emitter.send(SseEmitter.event().name(SseEventType.HEARTBEAT.name()).data("")));
+      sendToAll(emitter -> emitter.send(heartbeatEvent()));
     } catch (Exception e) {
       log.error("SSE heartbeat 처리 중 예외", e);
     }
@@ -91,6 +97,7 @@ public class SseConnectionManager {
 
   private void sendInitialRanking(SseEmitter emitter) {
     try {
+      emitter.send(heartbeatEvent());
       RankingResponse ranking = rankingService.getRankings();
       emitter.send(SseEmitter.event().name(SseEventType.RANKING_UPDATE.name()).data(ranking));
     } catch (Exception e) {

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -428,7 +428,7 @@
 | `RANKING_UPDATE` | 랭킹 변경 (연결 시 즉시 + 변경 시) | `{"rankings":[...],"totalPlayers":N}`       |
 | `DAY_CHANGE`     | 자정 날짜 전환                     | `{"sentenceId":"...","hintMask":"...",...}` |
 | `ANNOUNCEMENT`   | 공지 생성/수정/삭제                | `{"id":N,"title":"...","type":"INFO"}`     |
-| `HEARTBEAT`      | 연결 유지 (10초 간격)              | (빈 데이터)                                 |
+| `HEARTBEAT`      | 연결 유지 (10초 간격)              | `{"sseConnectionCount":N}`                  |
 
 - 100ms 디바운스 (짧은 시간 내 다수 변경 시 한 번만 전송)
 - **에러**: `SSE_MAX_CONNECTIONS`(503)

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -206,6 +206,23 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - 링크: `text-sm font-bold text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white transition-colors`
 - Layout: `flex flex-col min-h-screen` + `<main>` `flex-1` (스티키 푸터)
 
+### 랭킹 패널
+
+- **1·2·3등 액센트**: `box-shadow: inset 4px 0 0 0` CSS 변수 (`--rank-1-accent`, `--rank-2-accent`, `--rank-3-accent`). 다크모드 변수 자동 전환
+- **1등 시머**: `rank-shimmer` 애니메이션 (금색 좌측 액센트 반짝임)
+- **1등 배지**: 트로피 SVG 아이콘 (`text-black`)
+- **배지 색상**: 1등=`yellow-400/300`, 2등=`slate-300/400`, 3등=`amber-600/500 text-white`. 4+등=`gray-200/700`
+- **라이브 인디케이터**: `live-pulse` 애니메이션 (초록 펄스 도트) + `sseConnectionCount` (Zustand store, HEARTBEAT 기반)
+- **재생/정지 버튼**: `border-2 shadow-brutal-sm-hover w-7 h-7`. 호버 시 `-top-7` 위치 툴팁 (재생/정지)
+
+### 플레이 방법 모달
+
+- 최초 방문 시 자동 표시 (localStorage `help_modal_shown`). 닫으면 재표시 안 함
+- "플레이 방법" 버튼으로 언제든 재열람 (`border-2 bg-yellow-300 text-xs font-black`)
+- 섹션 간 `border-t-2 border-gray-200 dark:border-gray-800` 구분선
+- AI 유사도 설명: 의미 기반 측정, 글자 매칭 아님 (예시 포함)
+- 클리어 후 계속 플레이 가능 안내 (left-accent 콜아웃)
+
 ### 프로필 이미지 (마이페이지)
 
 - **프로필 이미지 클릭** → 팝오버(변경/삭제) 표시

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -8,11 +8,19 @@ import { useToastStore } from "@/shared/stores/useToastStore";
 
 export function App() {
   const fetchUser = useAuthStore((s) => s.fetchUser);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isLoading = useAuthStore((s) => s.isLoading);
   const addToast = useToastStore((s) => s.addToast);
 
   useEffect(() => {
     fetchUser();
   }, [fetchUser]);
+
+  useEffect(() => {
+    if (isAuthenticated && !isLoading) {
+      queryClient.invalidateQueries({ queryKey: ["ranking"] });
+    }
+  }, [isAuthenticated, isLoading]);
 
   useEffect(() => {
     const error = new URLSearchParams(window.location.search).get("error");

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -14,6 +14,7 @@ import { GuessInput } from "@/features/game/components/GuessInput";
 import { GuessHistory } from "@/features/game/components/GuessHistory";
 import { GameClearedCard } from "@/features/game/components/GameClearedCard";
 import { YesterdayAnswer } from "@/features/game/components/YesterdayAnswer";
+import { HelpModal, HELP_SHOWN_KEY } from "@/features/game/components/HelpModal";
 
 export function GamePage() {
   const queryClient = useQueryClient();
@@ -33,6 +34,7 @@ export function GamePage() {
   const [inputError, setInputError] = useState<string | null>(null);
   const [rateLimited, setRateLimited] = useState(false);
   const [localCleared, setLocalCleared] = useState(false);
+  const [isHelpOpen, setIsHelpOpen] = useState(() => !localStorage.getItem(HELP_SHOWN_KEY));
   const retryRef = useRef(false);
   const rateLimitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -204,15 +206,25 @@ export function GamePage() {
     <div className="max-w-2xl flex-1 min-w-0 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-4xl font-black">오늘의 문장</h1>
-        <span className="text-sm font-bold text-gray-600 dark:text-gray-400">
-          {isExpired ? (
-            "새 문장 준비 중..."
-          ) : (
-            <>
-              다음 문장까지: <span className="tabular-nums">{countdown}</span>
-            </>
-          )}
-        </span>
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-bold text-gray-600 dark:text-gray-400">
+            {isExpired ? (
+              "새 문장 준비 중..."
+            ) : (
+              <>
+                다음 문장까지: <span className="tabular-nums">{countdown}</span>
+              </>
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={() => setIsHelpOpen(true)}
+            className="border-2 border-black dark:border-white bg-yellow-300 text-black px-2 py-0.5 text-xs font-black shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]"
+            aria-label="플레이 방법"
+          >
+            플레이 방법
+          </button>
+        </div>
       </div>
 
       {today.yesterdaySentence && today.yesterdayDate && (
@@ -233,6 +245,14 @@ export function GamePage() {
       />
 
       <GuessHistory guesses={displayGuesses} />
+
+      <HelpModal
+        isOpen={isHelpOpen}
+        onClose={() => {
+          localStorage.setItem(HELP_SHOWN_KEY, "true");
+          setIsHelpOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/features/game/components/GuessHistory.tsx
+++ b/frontend/src/features/game/components/GuessHistory.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { SimilarityBadge } from "@/shared/ui/SimilarityBadge";
 
 interface GuessItem {
@@ -10,26 +11,41 @@ interface GuessHistoryProps {
   guesses: GuessItem[];
 }
 
+const PAGE_SIZE = 5;
+
 export function GuessHistory({ guesses }: GuessHistoryProps) {
+  const [page, setPage] = useState(0);
+
   if (guesses.length === 0) {
     return null;
   }
 
   const sorted = [...guesses].reverse();
   const total = guesses.length;
+  const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
+  const safePage = Math.min(page, totalPages - 1);
+  const pageGuesses = sorted.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
 
   return (
     <div className="space-y-3">
-      <h2 className="text-2xl font-extrabold">추측 기록</h2>
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-extrabold">추측 기록</h2>
+        {totalPages > 1 && (
+          <span className="text-sm font-bold text-gray-500 dark:text-gray-400 tabular-nums">
+            {safePage + 1} / {totalPages}
+          </span>
+        )}
+      </div>
+
       <div className="space-y-3">
-        {sorted.map((guess, i) => (
+        {pageGuesses.map((guess, i) => (
           <div
-            key={`${guess.attemptNumber ?? total - i}-${guess.guessText}`}
+            key={`${guess.attemptNumber ?? total - (safePage * PAGE_SIZE + i)}-${guess.guessText}`}
             className="flex items-center justify-between border-4 border-black dark:border-white shadow-brutal bg-white dark:bg-gray-900 p-3"
           >
             <div className="flex items-center gap-3">
               <span className="text-sm font-bold text-gray-500 dark:text-gray-400 tabular-nums shrink-0">
-                #{guess.attemptNumber ?? total - i}
+                #{guess.attemptNumber ?? total - (safePage * PAGE_SIZE + i)}
               </span>
               <span className="font-medium">{guess.guessText}</span>
             </div>
@@ -37,6 +53,27 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
           </div>
         ))}
       </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3">
+          <button
+            type="button"
+            disabled={safePage === 0}
+            onClick={() => setPage((p) => p - 1)}
+            className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 bg-white dark:bg-gray-900"
+          >
+            이전
+          </button>
+          <button
+            type="button"
+            disabled={safePage >= totalPages - 1}
+            onClick={() => setPage((p) => p + 1)}
+            className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 bg-white dark:bg-gray-900"
+          >
+            다음
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/game/components/HelpModal.tsx
+++ b/frontend/src/features/game/components/HelpModal.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef } from "react";
+
+interface HelpModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const HELP_SHOWN_KEY = "help_modal_shown";
+
+export function HelpModal({ isOpen, onClose }: HelpModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleClickOutside = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
+      <div
+        ref={modalRef}
+        className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-lg max-h-[80vh] flex flex-col"
+      >
+        <div className="flex items-center justify-between border-b-4 border-black dark:border-white px-6 py-4 shrink-0">
+          <h2 className="text-xl font-black">게임 방법</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-black dark:text-white px-3 py-1 font-black text-lg transition-all duration-100 shadow-brutal-sm hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]"
+            aria-label="닫기"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="px-6 py-5 overflow-y-auto">
+          <section className="pb-5">
+            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">개요</h3>
+            <p className="text-sm font-medium leading-relaxed">
+              <strong className="font-black">가까워</strong>는 매일 출제되는 정답 문장을 AI 유사도를 기반으로 맞추는
+              게임입니다.<br></br>정답에 가까운 <strong className="font-black">의미</strong>의 문장을 입력할수록 높은
+              유사도를 얻습니다.
+            </p>
+          </section>
+
+          <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
+            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">AI 유사도란?</h3>
+            <p className="text-sm font-medium leading-relaxed mb-3">
+              이 게임의 유사도는 <strong className="font-black">문장의 의미적 유사성</strong>을 측정합니다.<br></br>
+              글자가 겹치거나 초성이 비슷하다고 높은 점수가 나오지 않습니다.<br></br>AI가 문장의{" "}
+              <strong className="font-black">뜻과 맥락</strong>을 분석하여 정답과 얼마나 가까운 의미인지 판단합니다.
+            </p>
+            <div className="border-2 border-black dark:border-white bg-gray-50 dark:bg-gray-800 p-3 space-y-2 text-sm">
+              <p className="font-bold text-green-700 dark:text-green-400">높은 유사도 — 의미가 비슷한 경우</p>
+              <p className="font-medium text-gray-600 dark:text-gray-400">
+                정답: &quot;오늘 날씨가 좋다&quot; → &quot;화창한 하루다&quot; (비슷한 뜻)
+              </p>
+              <div className="border-t border-gray-300 dark:border-gray-600 my-1" />
+              <p className="font-bold text-red-600 dark:text-red-400">낮은 유사도 — 의미가 다른 경우</p>
+              <p className="font-medium text-gray-600 dark:text-gray-400">
+                정답: &quot;오늘 날씨가 좋다&quot; → &quot;오늘 국수가 좋다&quot; (비슷하지만 뜻이 다름)
+              </p>
+            </div>
+          </section>
+
+          <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
+            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-3">플레이 방법</h3>
+            <ol className="space-y-2.5 text-sm font-medium">
+              <li className="flex gap-3">
+                <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
+                  -
+                </span>
+                <span>
+                  힌트 마스크로 정답의 <strong className="font-black">단어 수와 글자 수</strong>를 확인하세요.
+                </span>
+              </li>
+              <li className="flex gap-3">
+                <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
+                  -
+                </span>
+                <span>정답이라고 생각하는 문장을 입력하세요.</span>
+              </li>
+              <li className="flex gap-3">
+                <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
+                  -
+                </span>
+                <span>
+                  AI가 <strong className="font-black">유사도(0~100%)</strong>를 알려줍니다.
+                </span>
+              </li>
+              <li className="flex gap-3">
+                <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
+                  -
+                </span>
+                <span>
+                  유사도 <strong className="font-black">95% 이상</strong>이면 정답! 차지합니다.
+                </span>
+              </li>
+              <li className="flex gap-3">
+                <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
+                  -
+                </span>
+                <span>적은 시도로 맞출수록 높은 순위를 차지합니다.</span>
+              </li>
+            </ol>
+            <p className="mt-3 text-sm font-medium leading-relaxed border-l-4 border-yellow-400 pl-3 bg-yellow-50 dark:bg-yellow-900/20 py-2">
+              - 정답을 맞힌 이후에도 계속 추측할 수 있습니다.<br></br>- 시도 횟수는 최초 맞춘 시점으로 고정되며, 최고
+              유사도만 업데이트됩니다.<br></br>- 다른 플레이어와 유사도를 경쟁하며 순위를 올려보세요!
+            </p>
+          </section>
+
+          <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
+            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">유사도 색상</h3>
+            <div className="flex h-3 border-2 border-black dark:border-white overflow-hidden">
+              {Array.from({ length: 20 }, (_, i) => {
+                const hue = (i / 19) * 120;
+                return <div key={i} className="flex-1" style={{ backgroundColor: `hsl(${hue}, 80%, 45%)` }} />;
+              })}
+            </div>
+            <div className="flex justify-between mt-1">
+              <span className="text-[10px] font-bold text-gray-500">0% (멀어요)</span>
+              <span className="text-[10px] font-bold text-gray-500">100% (정답!)</span>
+            </div>
+          </section>
+
+          <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5">
+            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">팁</h3>
+            <ul className="space-y-1.5 text-sm font-medium">
+              <li className="flex gap-2">
+                <span className="shrink-0 font-black">·</span>
+                <span>정답과 같은 주제, 같은 상황을 표현하는 문장을 시도해보세요.</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="shrink-0 font-black">·</span>
+                <span>유사도가 오르는 방향으로 점진적으로 접근하세요.</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="shrink-0 font-black">·</span>
+                <span>문장이 아니라 단어 단위로도 시도해보세요.</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="shrink-0 font-black">·</span>
+                <span>익숙해진다면, 패턴이 보일지도..?</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="shrink-0 font-black">·</span>
+                <span>매일 자정(KST)에 새로운 문장이 출제됩니다.</span>
+              </li>
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/ranking/components/RankingEntryRow.tsx
+++ b/frontend/src/features/ranking/components/RankingEntryRow.tsx
@@ -5,6 +5,7 @@ import { resolveProfileUrl } from "@/shared/utils/url";
 
 interface RankingEntryRowProps {
   entry: RankingEntry;
+  isPaused?: boolean;
 }
 
 const RANK_BADGE_COLORS: Record<number, string> = {
@@ -14,9 +15,9 @@ const RANK_BADGE_COLORS: Record<number, string> = {
 };
 
 const TOP_RANK_STYLES: Record<number, { bg: string; shadowVar: string }> = {
-  1: { bg: "bg-yellow-50 dark:bg-yellow-900/25", shadowVar: "--rank-1-accent" },
-  2: { bg: "bg-slate-100 dark:bg-slate-800/40", shadowVar: "--rank-2-accent" },
-  3: { bg: "bg-amber-50 dark:bg-amber-900/25", shadowVar: "--rank-3-accent" },
+  1: { bg: "bg-yellow-200 dark:bg-yellow-900/40", shadowVar: "--rank-1-accent" },
+  2: { bg: "bg-slate-200 dark:bg-slate-700/50", shadowVar: "--rank-2-accent" },
+  3: { bg: "bg-amber-200 dark:bg-amber-900/40", shadowVar: "--rank-3-accent" },
 };
 
 function TrophyIcon() {
@@ -42,7 +43,7 @@ function DefaultAvatar() {
   );
 }
 
-export function RankingEntryRow({ entry }: RankingEntryRowProps) {
+export function RankingEntryRow({ entry, isPaused }: RankingEntryRowProps) {
   const [imgError, setImgError] = useState(false);
   const badgeColor = RANK_BADGE_COLORS[entry.rank] ?? "bg-gray-200 dark:bg-gray-700 text-black dark:text-white";
   const topStyle = TOP_RANK_STYLES[entry.rank];
@@ -57,7 +58,14 @@ export function RankingEntryRow({ entry }: RankingEntryRowProps) {
       ].join(" ")}
       style={
         isFirst
-          ? { animation: "rank-shimmer 2.5s ease-in-out infinite" }
+          ? {
+              backgroundImage: isPaused
+                ? undefined
+                : "linear-gradient(110deg, transparent 40%, rgba(255,255,255,0.15) 44%, rgba(255,255,255,0.5) 50%, rgba(255,255,255,0.15) 56%, transparent 60%)",
+              backgroundSize: "200% 100%",
+              animation: isPaused ? "none" : "rank-shine 4s linear infinite",
+              boxShadow: `inset 4px 0 0 0 var(${topStyle.shadowVar})`,
+            }
           : topStyle
             ? { boxShadow: `inset 4px 0 0 0 var(${topStyle.shadowVar})` }
             : undefined

--- a/frontend/src/features/ranking/components/RankingEntryRow.tsx
+++ b/frontend/src/features/ranking/components/RankingEntryRow.tsx
@@ -8,16 +8,28 @@ interface RankingEntryRowProps {
 }
 
 const RANK_BADGE_COLORS: Record<number, string> = {
-  1: "bg-yellow-400",
-  2: "bg-gray-300",
-  3: "bg-orange-300",
+  1: "bg-yellow-400 dark:bg-yellow-300 text-black",
+  2: "bg-slate-300 dark:bg-slate-400 text-black",
+  3: "bg-amber-600 dark:bg-amber-500 text-white",
 };
 
-const RANK_ROW_COLORS: Record<number, string> = {
-  1: "bg-yellow-50 dark:bg-yellow-900/20",
-  2: "bg-gray-50 dark:bg-gray-800/30",
-  3: "bg-orange-50 dark:bg-orange-900/20",
+const TOP_RANK_STYLES: Record<number, { bg: string; shadowVar: string }> = {
+  1: { bg: "bg-yellow-50 dark:bg-yellow-900/25", shadowVar: "--rank-1-accent" },
+  2: { bg: "bg-slate-100 dark:bg-slate-800/40", shadowVar: "--rank-2-accent" },
+  3: { bg: "bg-amber-50 dark:bg-amber-900/25", shadowVar: "--rank-3-accent" },
 };
+
+function TrophyIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" className="text-black">
+      <path d="M5 3h14v7c0 3.9-3.1 7-7 7s-7-3.1-7-7V3z" />
+      <path d="M5 5H2.5c0 3.5 1.5 5.5 2.5 6" />
+      <path d="M19 5h2.5c0 3.5-1.5 5.5-2.5 6" />
+      <rect x="10" y="17" width="4" height="2" />
+      <rect x="7" y="19" width="10" height="2.5" />
+    </svg>
+  );
+}
 
 function DefaultAvatar() {
   return (
@@ -32,16 +44,24 @@ function DefaultAvatar() {
 
 export function RankingEntryRow({ entry }: RankingEntryRowProps) {
   const [imgError, setImgError] = useState(false);
-  const badgeColor = RANK_BADGE_COLORS[entry.rank] ?? "bg-white dark:bg-gray-900";
-  const rowColor = RANK_ROW_COLORS[entry.rank] ?? "";
+  const badgeColor = RANK_BADGE_COLORS[entry.rank] ?? "bg-gray-200 dark:bg-gray-700 text-black dark:text-white";
+  const topStyle = TOP_RANK_STYLES[entry.rank];
+  const isFirst = entry.rank === 1;
   const { bg } = getSimilarityColor(entry.similarity);
 
   return (
     <div
       className={[
         "px-2.5 py-1.5 border-2 border-black dark:border-white transition-all duration-100 space-y-1",
-        rowColor,
+        topStyle ? topStyle.bg : "",
       ].join(" ")}
+      style={
+        isFirst
+          ? { animation: "rank-shimmer 2.5s ease-in-out infinite" }
+          : topStyle
+            ? { boxShadow: `inset 4px 0 0 0 var(${topStyle.shadowVar})` }
+            : undefined
+      }
     >
       <div className="flex items-center gap-2">
         <span
@@ -50,7 +70,7 @@ export function RankingEntryRow({ entry }: RankingEntryRowProps) {
             badgeColor,
           ].join(" ")}
         >
-          {entry.rank}
+          {isFirst ? <TrophyIcon /> : entry.rank}
         </span>
 
         {entry.profileUrl && !imgError ? (

--- a/frontend/src/features/ranking/components/RankingPanel.tsx
+++ b/frontend/src/features/ranking/components/RankingPanel.tsx
@@ -122,7 +122,7 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
             onTransitionEnd={handleTransitionEnd}
           >
             {visibleEntries.map((entry) => (
-              <RankingEntryRow key={entry.publicId} entry={entry} />
+              <RankingEntryRow key={entry.publicId} entry={entry} isPaused={isPaused} />
             ))}
           </div>
         </div>
@@ -141,6 +141,7 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
                 similarity: ranking.myRank.similarity,
                 attemptCount: ranking.myRank.attemptCount,
               }}
+              isPaused={isPaused}
             />
           ) : (
             <p className="text-sm font-bold text-gray-500 dark:text-gray-400 text-center py-2">

--- a/frontend/src/features/ranking/components/RankingPanel.tsx
+++ b/frontend/src/features/ranking/components/RankingPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { RankingResponse } from "@/shared/api/types";
 import { Card } from "@/shared/ui/Card";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
+import { useConnectionStore } from "@/shared/stores/useConnectionStore";
 import { RankingEntryRow } from "@/features/ranking/components/RankingEntryRow";
 import { RankingEmptyState } from "@/features/ranking/components/RankingEmptyState";
 
@@ -25,6 +26,7 @@ function SkeletonRow() {
 
 export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
   const { user, isAuthenticated } = useAuthStore();
+  const sseConnectionCount = useConnectionStore((s) => s.sseConnectionCount);
 
   const entries = (ranking?.rankings ?? []).slice(0, 10);
   const shouldAnimate = entries.length > VISIBLE;
@@ -81,10 +83,13 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
           <button
             type="button"
             onClick={() => setIsPaused((p) => !p)}
-            className="text-xs font-bold text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white transition-colors"
+            className="relative group border-2 border-black dark:border-white bg-white dark:bg-gray-900 w-7 h-7 flex items-center justify-center text-[10px] font-black transition-all duration-100 shadow-brutal-sm-hover hover:shadow-none hover:translate-x-[1px] hover:translate-y-[1px]"
             aria-label={isPaused ? "자동 순환 시작" : "자동 순환 정지"}
           >
             {isPaused ? "▶" : "❚❚"}
+            <span className="absolute -top-7 left-1/2 -translate-x-1/2 hidden group-hover:block bg-black dark:bg-white text-white dark:text-black text-[10px] font-bold px-1.5 py-0.5 whitespace-nowrap z-50">
+              {isPaused ? "재생" : "정지"}
+            </span>
           </button>
         )}
       </div>
@@ -146,10 +151,21 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
       )}
 
       <div className="border-t-2 border-black dark:border-white pt-2 space-y-2">
-        <p className="text-xs font-bold text-gray-600 dark:text-gray-400">
-          <span className="text-black dark:text-white">오늘</span>{" "}
-          <span className="text-black dark:text-white tabular-nums">{ranking?.totalPlayers ?? 0}</span>명 도전 중
-        </p>
+        <div className="flex items-center justify-between text-xs font-bold text-gray-600 dark:text-gray-400">
+          <span>
+            <span
+              className="inline-block w-1.5 h-1.5 bg-green-500 dark:bg-green-400 mr-1 align-middle"
+              style={{ animation: "live-pulse 2s ease-in-out infinite" }}
+            />
+            <span className="text-black dark:text-white">오늘</span>{" "}
+            <span className="text-black dark:text-white tabular-nums">{ranking?.totalPlayers ?? 0}</span>명 도전
+          </span>
+          {sseConnectionCount != null && (
+            <span>
+              현재 <span className="text-black dark:text-white tabular-nums">{sseConnectionCount}</span>명 접속 중
+            </span>
+          )}
+        </div>
 
         {ranking?.yesterdayTotalPlayers != null && (
           <>

--- a/frontend/src/features/ranking/hooks/useRankingSSE.ts
+++ b/frontend/src/features/ranking/hooks/useRankingSSE.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { RankingResponse } from "@/shared/api/types";
+import { useConnectionStore } from "@/shared/stores/useConnectionStore";
 
 const SSE_URL = `${import.meta.env.VITE_API_BASE_URL}/ranking/stream`;
 const INITIAL_DELAY = 2000;
@@ -26,7 +27,7 @@ export function useRankingSSE() {
         const data = JSON.parse(e.data) as Pick<RankingResponse, "rankings" | "totalPlayers">;
         queryClient.setQueryData<RankingResponse>(["ranking"], (old) => {
           if (!old) {
-            return { ...data, myRank: null, yesterdayRank: null, yesterdayTotalPlayers: null };
+            return old;
           }
           return { ...old, rankings: data.rankings, totalPlayers: data.totalPlayers };
         });
@@ -43,7 +44,19 @@ export function useRankingSSE() {
         window.dispatchEvent(new CustomEvent("sse:announcement"));
       });
 
-      es.addEventListener("HEARTBEAT", () => {});
+      es.addEventListener("HEARTBEAT", (e: MessageEvent) => {
+        if (!e.data) {
+          return;
+        }
+        try {
+          const data = JSON.parse(e.data) as { sseConnectionCount?: number };
+          if (data.sseConnectionCount != null) {
+            useConnectionStore.getState().setSseConnectionCount(data.sseConnectionCount);
+          }
+        } catch {
+          // 빈 문자열 등 파싱 실패 시 무시 (하위 호환)
+        }
+      });
 
       es.onerror = () => {
         es?.close();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,13 +34,12 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-@keyframes rank-shimmer {
-  0%,
-  100% {
-    box-shadow: inset 4px 0 0 0 var(--rank-1-accent);
+@keyframes rank-shine {
+  0% {
+    background-position: -200% 0;
   }
-  50% {
-    box-shadow: inset 4px 0 0 0 var(--rank-1-shine);
+  100% {
+    background-position: 200% 0;
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,16 +14,44 @@
 
 :root {
   --shadow-color: 0, 0, 0;
+  --rank-1-accent: #eab308;
+  --rank-1-shine: #fde047;
+  --rank-2-accent: #94a3b8;
+  --rank-3-accent: #b45309;
 }
 
 .dark {
   --shadow-color: 255, 255, 255;
+  --rank-1-accent: #facc15;
+  --rank-1-shine: #fef9c3;
+  --rank-2-accent: #cbd5e1;
+  --rank-3-accent: #f59e0b;
 }
 
 body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+@keyframes rank-shimmer {
+  0%,
+  100% {
+    box-shadow: inset 4px 0 0 0 var(--rank-1-accent);
+  }
+  50% {
+    box-shadow: inset 4px 0 0 0 var(--rank-1-shine);
+  }
+}
+
+@keyframes live-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
 }
 
 @keyframes toast-enter {

--- a/frontend/src/shared/stores/useConnectionStore.ts
+++ b/frontend/src/shared/stores/useConnectionStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface ConnectionState {
+  sseConnectionCount: number | null;
+  setSseConnectionCount: (count: number) => void;
+}
+
+export const useConnectionStore = create<ConnectionState>((set) => ({
+  sseConnectionCount: null,
+  setSseConnectionCount: (count) => set({ sseConnectionCount: count }),
+}));


### PR DESCRIPTION
## 관련 이슈

Closes #93 

## 변경 사항

- 플레이 방법 안내 모달 추가 (최초 방문 시 자동 표시, AI 유사도 상세 설명, 클리어 후 계속 플레이 안내)
- 랭킹 1·2·3등 시각효과 강화 (inset shadow 액센트, 1등 shine 애니메이션, 트로피 아이콘, 다크모드 시인성 개선)
- SSE HEARTBEAT에 접속자 수 포함 (BE) + Zustand store로 실시간 표시 (FE)
- 추측 기록 클라이언트 페이지네이션 (5개씩)
- 랭킹 재생/정지 버튼 네오브루탈리즘 스타일 + 호버 툴팁 + shine 애니메이션 연동
- 라이브 인디케이터 (초록 펄스 도트)
- 토큰 갱신 후 랭킹 캐시 무효화로 myRank 누락 버그 수정

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
