### PR TITLE
fix: 프론트엔드 버그 수정

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -61,7 +61,7 @@ boxShadow: {
 | 기본           | `shadow-brutal`                                                             |
 | Hover          | `hover:shadow-brutal-hover hover:translate-x-[4px] hover:translate-y-[4px]` |
 | Active (Click) | `active:shadow-none active:translate-x-[6px] active:translate-y-[6px]`      |
-| Disabled       | `opacity-50 cursor-not-allowed translate-x-0 translate-y-0` (그림자 유지)   |
+| Disabled       | `opacity-50 cursor-not-allowed pointer-events-none translate-x-0 translate-y-0` (그림자 유지) |
 | Loading        | `opacity-70 cursor-wait shadow-brutal animate-pulse`                        |
 
 ### sm 버튼 (shadow-brutal-sm, 3px)
@@ -71,7 +71,7 @@ boxShadow: {
 | 기본           | `shadow-brutal-sm`                                                             |
 | Hover          | `hover:shadow-brutal-sm-hover hover:translate-x-[2px] hover:translate-y-[2px]` |
 | Active (Click) | `active:shadow-none active:translate-x-[3px] active:translate-y-[3px]`         |
-| Disabled       | `opacity-50 cursor-not-allowed translate-x-0 translate-y-0` (그림자 유지)      |
+| Disabled       | `opacity-50 cursor-not-allowed pointer-events-none translate-x-0 translate-y-0` (그림자 유지) |
 | Loading        | `opacity-70 cursor-wait shadow-brutal-sm animate-pulse`                        |
 
 모든 상태 전환에는 `transition-all duration-100`을 적용하여 부드러운 전환을 준다.
@@ -174,8 +174,8 @@ hue = (similarity / 100) × 120
       px-6 py-3 transition-all duration-100
 호버: hover:shadow-brutal-hover hover:translate-x-[4px] hover:translate-y-[4px]
 클릭: active:shadow-none active:translate-x-[6px] active:translate-y-[6px]
-비활성: disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none
-        disabled:translate-x-0 disabled:translate-y-0
+비활성: disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none
+        disabled:shadow-none disabled:translate-x-0 disabled:translate-y-0
 ```
 
 ### 입력창

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -43,6 +43,14 @@ export function GamePage() {
   });
   const retryRef = useRef(false);
   const rateLimitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [trackedSentenceId, setTrackedSentenceId] = useState(sentenceId);
+
+  if (sentenceId !== trackedSentenceId) {
+    setTrackedSentenceId(sentenceId);
+    setLocalCleared(false);
+    setInputError(null);
+    setRateLimited(false);
+  }
 
   const isCleared = isAuthenticated
     ? status?.gameStatus === "CLEARED" || localCleared
@@ -115,8 +123,9 @@ export function GamePage() {
         break;
       }
       case "GAME_EXPIRED":
-        addToast("게임이 만료되었습니다. 새로운 문제를 불러옵니다.", "info");
-        queryClient.invalidateQueries({ queryKey: ["game", "today"] });
+      case "SENTENCE_NOT_FOUND":
+        addToast("새로운 문제를 불러옵니다.", "info");
+        queryClient.removeQueries({ queryKey: ["game"] });
         break;
       case "CONCURRENT_MODIFICATION":
         if (!retryRef.current) {

--- a/frontend/src/features/game/components/GuessHistory.tsx
+++ b/frontend/src/features/game/components/GuessHistory.tsx
@@ -60,7 +60,7 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
             type="button"
             disabled={safePage === 0}
             onClick={() => setPage(safePage - 1)}
-            className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 bg-white dark:bg-gray-900"
+            className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 disabled:pointer-events-none bg-white dark:bg-gray-900"
           >
             이전
           </button>
@@ -68,7 +68,7 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
             type="button"
             disabled={safePage >= totalPages - 1}
             onClick={() => setPage(safePage + 1)}
-            className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 bg-white dark:bg-gray-900"
+            className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 disabled:pointer-events-none bg-white dark:bg-gray-900"
           >
             다음
           </button>

--- a/frontend/src/features/ranking/components/RankingPanel.tsx
+++ b/frontend/src/features/ranking/components/RankingPanel.tsx
@@ -38,10 +38,19 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
   const [itemHeight, setItemHeight] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
   const entriesRef = useRef(entries);
+  const [prevEntriesLength, setPrevEntriesLength] = useState(entries.length);
 
   useEffect(() => {
     entriesRef.current = entries;
   }, [entries]);
+
+  if (entries.length !== prevEntriesLength) {
+    setPrevEntriesLength(entries.length);
+    if (entries.length === 0) {
+      setOffset(0);
+      setIsSliding(false);
+    }
+  }
 
   useEffect(() => {
     if (!listRef.current?.firstElementChild) {

--- a/frontend/src/features/ranking/hooks/useRankingSSE.ts
+++ b/frontend/src/features/ranking/hooks/useRankingSSE.ts
@@ -35,8 +35,7 @@ export function useRankingSSE() {
       });
 
       es.addEventListener("DAY_CHANGE", () => {
-        queryClient.invalidateQueries({ queryKey: ["game", "today"] });
-        queryClient.invalidateQueries({ queryKey: ["game", "status"] });
+        queryClient.removeQueries({ queryKey: ["game"] });
         queryClient.invalidateQueries({ queryKey: ["ranking"] });
       });
 


### PR DESCRIPTION
## 관련 이슈

Closes #96 

## 변경 사항

 DAY_CHANGE SSE 수신 시 `invalidateQueries` → `removeQueries(["game"])` 변경으로 게임 캐시 완전 초기화 (stale sentenceId 방지)
- `SENTENCE_NOT_FOUND`/`GAME_EXPIRED` 에러 시 게임 캐시 초기화 + sentenceId 변경 감지 시 로컬 상태(localCleared, inputError, rateLimited) 리셋
- 페이지네이션 disabled 버튼에 `pointer-events-none` 추가 (hover/active 시각 효과 차단)
- 랭킹 entries 빈 배열 전환 시 애니메이션 상태(offset, isSliding) 리셋
- 디자인 시스템 문서에 disabled 버튼 `pointer-events-none` 규칙 반영

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
