### PR TITLE
fix: 힌트 후속 수정 + 추측 기록 UX 개선

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GuessHistoryRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/repository/GuessHistoryRepository.java
@@ -45,7 +45,7 @@ public interface GuessHistoryRepository extends JpaRepository<GuessHistory, Long
               + " FROM guess_history h JOIN game_sessions gs ON h.session_id = gs.id"
               + " WHERE gs.sentence_id = :sentenceId"
               + " AND (gs.member_id IS NULL OR gs.member_id != :memberId)"
-              + " AND h.similarity <= :maxSimilarity"
+              + " AND h.similarity < :maxSimilarity"
               + " ORDER BY h.guess_text, h.similarity DESC) sub"
               + " ORDER BY sub.similarity DESC LIMIT :maxCount",
       nativeQuery = true)

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -387,7 +387,7 @@
 
 - **동작**:
   - 요청자의 bestSimilarity가 60% 미만이면 403 반환
-  - 다른 유저의 추측 중 요청자의 bestSimilarity 이하만 반환
+  - 다른 유저의 추측 중 요청자의 bestSimilarity 미만만 반환
   - 동일 guessText는 최고 유사도 1건만 (DISTINCT ON)
   - 요청자 본인의 추측은 제외
   - 최대 5개, 유사도 높은 순 정렬

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -240,9 +240,19 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **팝오버**: `border-4 shadow-brutal-sm`, click-outside/Escape 닫기
 - **hover 오버레이**: `bg-black/40` + 편집 아이콘 (프로필 이미지 위)
 
+### 추측 피드백
+
+- **위치**: 게임 페이지 중앙 칼럼, GuessInput 위
+- **구조**: 고정 높이 2행 (`h-6` × 2, `space-y-1`). 레이아웃 시프트 방지
+- **Row 1**: 최고 유사도 — `displayGuesses`에서 `useMemo` 파생. HSL 색상 퍼센트
+- **Row 2**: 에러 시 에러 메시지 (`text-red-500`) / 정상 시 마지막 추측 (guessText + HSL 퍼센트)
+- **빈 상태**: 라벨 + `—` (대시)로 공간 유지
+- **데이터 원천**: `displayGuesses` 파생 (추가 API 없음). 새로고침 시 history API → 자동 복원
+- **FE 정규화**: `normalizeGuessText()` — BE `TextNormalizer`와 동일 로직 (`[^가-힣a-zA-Z0-9\s]` 제거). 서버 호출 전 선검증
+
 ### 힌트 패널
 
-- **위치**: 좌측 칼럼, RankingPanel 아래 (sticky 영역 내). 부모 `div.w-72.shrink-0.sticky.top-24.space-y-4`가 RankingPanel + HintPanel 래핑
+- **위치**: 좌측 칼럼, RankingPanel 아래. 부모 `div.w-72.shrink-0.space-y-6`이 RankingPanel + HintPanel 래핑
 - **조건**: 항상 표시. 비로그인 → 로그인 유도 안내. 로그인 + bestSimilarity < 60 → 잠금 안내
 - **카드**: `Card` + `!p-4 space-y-3` (RankingPanel과 동일 배경)
 - **제목**: "다른 플레이어의 추측" `text-lg font-extrabold`
@@ -250,7 +260,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **스포일러**: 힌트 목록 기본 `blur-sm` 처리. 클릭 시 전체 해제. 새로고침 시 자동 리셋 (React state, localStorage 미사용)
 - **행 구분선**: `border-b-2 border-black/20 dark:border-white/20` (마지막 항목 제외)
 - **갱신**: 매 추측 시 `["game", "hints", sentenceId]` invalidate + `staleTime: 60_000`
-- **힌트 범위**: 요청자의 bestSimilarity 이하 추측만 표시 (서버측 필터링)
+- **힌트 범위**: 요청자의 bestSimilarity 미만 추측만 표시 (서버측 필터링)
 
 ### 어드민 패널 (`/admin`)
 

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import confetti from "canvas-confetti";
 import { ApiError } from "@/shared/api/client";
@@ -11,11 +11,13 @@ import { useCountdown } from "@/features/game/hooks/useCountdown";
 import { useAnonymousGame } from "@/features/game/hooks/useAnonymousGame";
 import { HintMask } from "@/features/game/components/HintMask";
 import { GuessInput } from "@/features/game/components/GuessInput";
+import { GuessFeedback } from "@/features/game/components/GuessFeedback";
 import { GuessHistory } from "@/features/game/components/GuessHistory";
 import { GameClearedCard } from "@/features/game/components/GameClearedCard";
 import { YesterdayAnswer } from "@/features/game/components/YesterdayAnswer";
 import { HelpModal, HELP_SHOWN_KEY } from "@/features/game/components/HelpModal";
 import { getSoundVolume } from "@/shared/config/sound";
+import { normalizeGuessText } from "@/shared/utils/normalize";
 
 export function GamePage() {
   const queryClient = useQueryClient();
@@ -33,7 +35,6 @@ export function GamePage() {
   const { formatted: countdown, isExpired } = useCountdown(today?.expiresAt);
 
   const [inputError, setInputError] = useState<string | null>(null);
-  const [lastResult, setLastResult] = useState<{ guessText: string; similarity: number } | null>(null);
   const [rateLimited, setRateLimited] = useState(false);
   const [localCleared, setLocalCleared] = useState(false);
   const [isHelpOpen, setIsHelpOpen] = useState(() => {
@@ -51,7 +52,6 @@ export function GamePage() {
     setTrackedSentenceId(sentenceId);
     setLocalCleared(false);
     setInputError(null);
-    setLastResult(null);
     setRateLimited(false);
   }
 
@@ -59,11 +59,30 @@ export function GamePage() {
     ? status?.gameStatus === "CLEARED" || localCleared
     : anonState.isCleared || localCleared;
 
-  const displayGuesses = isAuthenticated ? (history?.guesses ?? []) : anonState.guesses;
+  const displayGuesses = useMemo(
+    () => (isAuthenticated ? (history?.guesses ?? []) : anonState.guesses),
+    [isAuthenticated, history?.guesses, anonState.guesses],
+  );
 
   const attemptCount = isAuthenticated ? (status?.attemptCount ?? 0) : anonState.attemptCount;
 
   const bestSimilarity = isAuthenticated ? (status?.bestSimilarity ?? 0) : anonState.bestSimilarity;
+
+  const lastGuess = useMemo(() => {
+    if (displayGuesses.length === 0) {
+      return null;
+    }
+    const last = displayGuesses[displayGuesses.length - 1];
+    return { guessText: last.guessText, similarity: last.similarity };
+  }, [displayGuesses]);
+
+  const bestGuess = useMemo(() => {
+    if (displayGuesses.length === 0) {
+      return null;
+    }
+    const best = displayGuesses.reduce((acc, g) => (g.similarity > acc.similarity ? g : acc));
+    return { guessText: best.guessText, similarity: best.similarity };
+  }, [displayGuesses]);
 
   useEffect(() => {
     if (!isExpired || !today?.expiresAt) {
@@ -182,7 +201,11 @@ export function GamePage() {
       return;
     }
     setInputError(null);
-    setLastResult(null);
+
+    if (!normalizeGuessText(text)) {
+      setInputError("유효한 문자(한글, 영문, 숫자)를 포함해야 합니다");
+      return;
+    }
 
     const existing = displayGuesses.find((g) => g.guessText === text);
     if (existing) {
@@ -194,7 +217,6 @@ export function GamePage() {
       { sentenceId, guessText: text },
       {
         onSuccess: (res) => {
-          setLastResult({ guessText: text, similarity: res.similarity });
           if (isAuthenticated) {
             appendGuessToCache(text, res);
           } else {
@@ -271,15 +293,11 @@ export function GamePage() {
 
       {isCleared && <GameClearedCard attemptCount={attemptCount} bestSimilarity={bestSimilarity} />}
 
-      <GuessInput
-        onSubmit={handleSubmit}
-        isLoading={guessMutation.isPending}
-        disabled={rateLimited}
-        error={inputError}
-        result={lastResult}
-      />
+      <GuessFeedback error={inputError} lastGuess={lastGuess} bestGuess={bestGuess} />
 
-      <GuessHistory guesses={displayGuesses} />
+      <GuessInput onSubmit={handleSubmit} isLoading={guessMutation.isPending} disabled={rateLimited} />
+
+      <GuessHistory key={sentenceId} guesses={displayGuesses} />
 
       <HelpModal
         isOpen={isHelpOpen}

--- a/frontend/src/features/game/components/GuessFeedback.tsx
+++ b/frontend/src/features/game/components/GuessFeedback.tsx
@@ -1,0 +1,51 @@
+import { getSimilarityColor } from "@/shared/utils/similarity";
+
+interface GuessInfo {
+  guessText: string;
+  similarity: number;
+}
+
+interface GuessFeedbackProps {
+  error: string | null;
+  lastGuess: GuessInfo | null;
+  bestGuess: GuessInfo | null;
+}
+
+function FeedbackRow({ label, guess }: { label: string; guess: GuessInfo | null }) {
+  if (!guess) {
+    return (
+      <div className="h-6 flex items-center">
+        <span className="text-sm font-bold text-gray-400 dark:text-gray-500">{label}: —</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-6 flex items-center justify-between gap-2">
+      <p className="text-sm font-bold text-gray-700 dark:text-gray-300 truncate min-w-0">
+        <span className="text-gray-500 dark:text-gray-400">{label}:</span> {guess.guessText}
+      </p>
+      <span
+        className="text-sm font-black tabular-nums shrink-0"
+        style={{ color: getSimilarityColor(guess.similarity).bg }}
+      >
+        {guess.similarity.toFixed(1)}%
+      </span>
+    </div>
+  );
+}
+
+export function GuessFeedback({ error, lastGuess, bestGuess }: GuessFeedbackProps) {
+  return (
+    <div className="space-y-1">
+      <FeedbackRow label="최고 유사도" guess={bestGuess} />
+      {error ? (
+        <div className="h-6 flex items-center">
+          <p className="text-sm font-bold text-red-500 truncate">{error}</p>
+        </div>
+      ) : (
+        <FeedbackRow label="마지막 추측" guess={lastGuess} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/game/components/GuessHistory.tsx
+++ b/frontend/src/features/game/components/GuessHistory.tsx
@@ -15,14 +15,6 @@ const PAGE_SIZE = 5;
 
 export function GuessHistory({ guesses }: GuessHistoryProps) {
   const [page, setPage] = useState(0);
-  const [prevLength, setPrevLength] = useState(guesses.length);
-
-  if (guesses.length !== prevLength) {
-    setPrevLength(guesses.length);
-    if (prevLength === 0 && guesses.length > 0) {
-      setPage(0);
-    }
-  }
 
   if (guesses.length === 0) {
     return null;
@@ -39,9 +31,27 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-extrabold">추측 기록</h2>
         {totalPages > 1 && (
-          <span className="text-sm font-bold text-gray-500 dark:text-gray-400 tabular-nums">
-            {safePage + 1} / {totalPages}
-          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled={safePage === 0}
+              onClick={() => setPage(safePage - 1)}
+              className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 disabled:hover:shadow-brutal-sm disabled:hover:translate-x-0 disabled:hover:translate-y-0 disabled:active:shadow-brutal-sm disabled:active:translate-x-0 disabled:active:translate-y-0 bg-white dark:bg-gray-900"
+            >
+              이전
+            </button>
+            <span className="text-sm font-bold text-gray-500 dark:text-gray-400 tabular-nums">
+              {safePage + 1} / {totalPages}
+            </span>
+            <button
+              type="button"
+              disabled={safePage >= totalPages - 1}
+              onClick={() => setPage(safePage + 1)}
+              className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 disabled:hover:shadow-brutal-sm disabled:hover:translate-x-0 disabled:hover:translate-y-0 disabled:active:shadow-brutal-sm disabled:active:translate-x-0 disabled:active:translate-y-0 bg-white dark:bg-gray-900"
+            >
+              다음
+            </button>
+          </div>
         )}
       </div>
 
@@ -61,27 +71,6 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
           </div>
         ))}
       </div>
-
-      {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-3">
-          <button
-            type="button"
-            disabled={safePage === 0}
-            onClick={() => setPage(safePage - 1)}
-            className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 disabled:hover:shadow-brutal-sm disabled:hover:translate-x-0 disabled:hover:translate-y-0 disabled:active:shadow-brutal-sm disabled:active:translate-x-0 disabled:active:translate-y-0 bg-white dark:bg-gray-900"
-          >
-            이전
-          </button>
-          <button
-            type="button"
-            disabled={safePage >= totalPages - 1}
-            onClick={() => setPage(safePage + 1)}
-            className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 disabled:hover:shadow-brutal-sm disabled:hover:translate-x-0 disabled:hover:translate-y-0 disabled:active:shadow-brutal-sm disabled:active:translate-x-0 disabled:active:translate-y-0 bg-white dark:bg-gray-900"
-          >
-            다음
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/features/game/components/GuessInput.tsx
+++ b/frontend/src/features/game/components/GuessInput.tsx
@@ -1,17 +1,14 @@
 import { useRef, useState } from "react";
 import { Button } from "@/shared/ui/Button";
 import { Input } from "@/shared/ui/Input";
-import { getSimilarityColor } from "@/shared/utils/similarity";
 
 interface GuessInputProps {
   onSubmit: (text: string) => void;
   isLoading: boolean;
   disabled?: boolean;
-  error?: string | null;
-  result?: { guessText: string; similarity: number } | null;
 }
 
-export function GuessInput({ onSubmit, isLoading, disabled = false, error = null, result = null }: GuessInputProps) {
+export function GuessInput({ onSubmit, isLoading, disabled = false }: GuessInputProps) {
   const [text, setText] = useState("");
   const wrapperRef = useRef<HTMLDivElement>(null);
   const isComposingRef = useRef(false);
@@ -70,15 +67,6 @@ export function GuessInput({ onSubmit, isLoading, disabled = false, error = null
           제출
         </Button>
       </div>
-      {error && <p className="text-sm font-bold text-red-500">{error}</p>}
-      {!error && result && (
-        <p className="text-sm font-bold text-gray-700 dark:text-gray-300">
-          {result.guessText}{" "}
-          <span style={{ color: getSimilarityColor(result.similarity).bg }}>
-            (유사도: {result.similarity.toFixed(1)}%)
-          </span>
-        </p>
-      )}
     </div>
   );
 }

--- a/frontend/src/features/game/components/HintPanel.tsx
+++ b/frontend/src/features/game/components/HintPanel.tsx
@@ -25,7 +25,9 @@ function HintList({ hints }: { hints: HintEntry[] }) {
             i < hints.length - 1 ? "border-b-2 border-black/20 dark:border-white/20" : "",
           ].join(" ")}
         >
-          <span className="text-sm font-medium truncate">{hint.guessText}</span>
+          <span className="text-sm font-medium truncate" title={hint.guessText}>
+            {hint.guessText}
+          </span>
           <span className="shrink-0">
             <SimilarityBadge similarity={hint.similarity} />
           </span>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -18,7 +18,7 @@ export function HomePage() {
 
   return (
     <div className="flex gap-6 items-start">
-      <div className="w-72 shrink-0 sticky top-24 space-y-6">
+      <div className="w-72 shrink-0 space-y-6">
         <RankingPanel ranking={ranking} isLoading={rankingLoading} />
         <HintPanel
           hints={hints?.hints ?? []}

--- a/frontend/src/shared/utils/normalize.ts
+++ b/frontend/src/shared/utils/normalize.ts
@@ -1,0 +1,13 @@
+const CLEAN_PATTERN = /[^가-힣a-zA-Z0-9\s]/g;
+const COLLAPSE_PATTERN = /\s+/g;
+
+/**
+ * BE TextNormalizer.normalize()와 동일한 로직.
+ * NFC 정규화 → 특수문자 제거 → 공백 정리.
+ */
+export function normalizeGuessText(text: string): string {
+  const nfc = text.normalize("NFC");
+  const cleaned = nfc.replace(CLEAN_PATTERN, "");
+  const collapsed = cleaned.replace(COLLAPSE_PATTERN, " ");
+  return collapsed.trim();
+}


### PR DESCRIPTION
## 관련 이슈

Closes #103 

## 변경 사항

- 힌트 쿼리 연산자 `<=` → `<` 수정 (bestSimilarity와 동일한 유사도 힌트 제외)
- 추측 피드백을 GuessFeedback 컴포넌트로 분리하여 레이아웃 시프트 해소 (고정 높이 2행: 최고 유사도 + 마지막 추측)
- BE TextNormalizer와 동일한 FE 정규화 선검증 추가 (불필요한 서버 왕복 제거)
- HintPanel hover title, GuessHistory 페이지네이션 상단 이동, key 리마운트, sticky 제거

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다
