### PR TITLE
chore: GitHub Actions Node.js 24 대응 및 조건부 CI 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,13 +48,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./backend
           push: true
@@ -71,13 +71,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./ai-service
           push: true
@@ -94,11 +94,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.32.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -110,7 +110,7 @@ jobs:
         env:
           VITE_API_BASE_URL: https://api.r4b2.xyz
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: frontend-dist
           path: frontend/dist
@@ -134,7 +134,7 @@ jobs:
       # --- Frontend ---
       - name: Download frontend artifact
         if: needs.changes.outputs.frontend == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: frontend-dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+      ai_service: ${{ steps.filter.outputs.ai_service }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+            backend:
+              - 'backend/**'
+            ai_service:
+              - 'ai-service/**'
+
   frontend:
     name: Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -38,6 +62,8 @@ jobs:
 
   backend:
     name: Backend
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -60,6 +86,8 @@ jobs:
 
   ai-service:
     name: AI Service
+    needs: changes
+    if: needs.changes.outputs.ai_service == 'true'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -75,3 +103,16 @@ jobs:
         with:
           args: format --check
           src: ai-service
+
+  ci-result:
+    name: CI Result
+    if: always()
+    needs: [frontend, backend, ai-service]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "CI failed"
+            exit 1
+          fi
+          echo "CI passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.32.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -45,12 +45,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
 
       - run: chmod +x gradlew
 
@@ -61,6 +61,8 @@ jobs:
   ai-service:
     name: AI Service
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## 관련 이슈

Closes #105 

## 변경 사항

- 8개 액션 Node.js 24 지원 버전으로 업그레이드 (pnpm/action-setup v5, actions/setup-node v6, actions/setup-java v5, gradle/actions v5, docker/login-action v4, docker/build-push-action v7, actions/upload-artifact v7, actions/download-artifact v8)
- `astral-sh/ruff-action@v3`는 미지원으로 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` 환경변수 적용
- `gradle/actions` v6 대신 v5 선택 (v6 캐싱 컴포넌트 라이선스 프로프리어터리 변경 회피)
- `dorny/paths-filter@v4`는 이미 node24 지원, `appleboy/scp-action`·`ssh-action`은 composite action으로 Node 무관
- CI에 `dorny/paths-filter` 도입하여 변경된 영역(frontend/backend/ai-service)만 조건부 실행

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
