### PR TITLE
fix: 100% 달성자 랭킹 clearedAt 정렬 버그 수정

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -82,6 +82,10 @@ public class GameSession {
     }
   }
 
+  public void updateClearedAt() {
+    this.clearedAt = Instant.now();
+  }
+
   public void markCleared() {
     this.status = GameSessionStatus.CLEARED;
     this.clearedAt = Instant.now();

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -83,7 +83,9 @@ public class GameSession {
   }
 
   public void updateClearedAt() {
-    this.clearedAt = Instant.now();
+    if (this.bestSimilarity.compareTo(new BigDecimal("100")) < 0) {
+      this.clearedAt = Instant.now();
+    }
   }
 
   public void markCleared() {

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -99,6 +99,8 @@ public class DailyGameService {
       if (isCorrect) {
         session.markCleared();
       }
+    } else if (session.isCleared() && isPerfect(similarity)) {
+      session.updateClearedAt();
     }
     session.updateBestSimilarity(similarity);
 
@@ -264,6 +266,10 @@ public class DailyGameService {
     return memberRepository
         .findByPublicId(publicId)
         .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+  }
+
+  private static boolean isPerfect(BigDecimal similarity) {
+    return similarity.compareTo(new BigDecimal("100")) >= 0;
   }
 
   private void validateGuessAllowed(GameSession session) {


### PR DESCRIPTION
## 관련 이슈

Closes #107

## 변경 사항

- CLEARED 상태에서 100% 달성 시 `clearedAt`을 현재 시각으로 갱신하도록 수정
- `GameSession.updateClearedAt()` 메서드 추가
- `DailyGameService`에서 이미 클리어된 세션이 100%를 달성하면 `clearedAt` 갱신 로직 추가

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- `encodeScore`는 100% 달성자에 한해 `clearedAt` 선착순으로 점수를 계산
- 95~99.9% 구간은 `clearedAt`을 사용하지 않으므로 영향 없음