### PR TITLE
chore: 소규모 수정 (preflight 캐싱, rate limit 기본값, JSON 에러 핸들러, 공지 줄바꿈)

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.lang.Nullable;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -39,6 +40,23 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   public ResponseEntity<?> handleOptimisticLock(ObjectOptimisticLockingFailureException e) {
     log.warn("낙관적 락 충돌 발생: entity={}, id={}", e.getPersistentClassName(), e.getIdentifier());
     ErrorCode errorCode = ErrorCode.CONCURRENT_MODIFICATION;
+    ErrorBody body =
+        new ErrorBody(
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            errorCode.getMessage(),
+            Instant.now().toString());
+    return ResponseEntity.status(errorCode.getStatus()).body(body);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleHttpMessageNotReadable(
+      HttpMessageNotReadableException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
+    log.warn("잘못된 JSON 요청: {}", ex.getMessage());
+    ErrorCode errorCode = ErrorCode.VALIDATION_FAILED;
     ErrorBody body =
         new ErrorBody(
             errorCode.getStatus().value(),

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -89,6 +89,7 @@ public class SecurityConfig {
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setAllowCredentials(true);
     configuration.setExposedHeaders(List.of("Retry-After", "X-Rate-Limit-Remaining"));
+    configuration.setMaxAge(3600L);
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -94,7 +94,7 @@ app:
     profile-dir: ${UPLOAD_PROFILE_DIR:./uploads/profiles}
   rate-limit:
     guess-per-minute: ${RATE_LIMIT_GUESS:40}
-    read-per-minute: ${RATE_LIMIT_READ:90}
+    read-per-minute: ${RATE_LIMIT_READ:120}
     sse-per-minute: ${RATE_LIMIT_SSE:10}
     auth-per-minute: ${RATE_LIMIT_AUTH:10}
     admin-per-minute: ${RATE_LIMIT_ADMIN:120}

--- a/frontend/src/shared/ui/AnnouncementBanner.tsx
+++ b/frontend/src/shared/ui/AnnouncementBanner.tsx
@@ -48,7 +48,9 @@ function BannerItem({
     <div className={`border-4 ${colorClass} shadow-brutal-sm px-5 py-3 flex items-start gap-3`}>
       <div className="flex-1 min-w-0">
         <p className="font-black text-sm">{announcement.title}</p>
-        {announcement.content && <p className="text-xs font-medium mt-0.5 opacity-80">{announcement.content}</p>}
+        {announcement.content && (
+          <p className="whitespace-pre-line text-xs font-medium mt-0.5 opacity-80">{announcement.content}</p>
+        )}
       </div>
       <button
         type="button"


### PR DESCRIPTION
## 관련 이슈

Closes #115

## 변경 사항

- CORS preflight 캐싱 `setMaxAge(3600L)` 추가 — 브라우저가 OPTIONS 응답을 1시간 캐싱하여 반복 preflight 스킵
- READ rate limit 기본값 90 → 120 동기화 — 운영 env 및 api-spec.md와 일치
- `HttpMessageNotReadable` 핸들러 추가 — 잘못된 JSON 요청 시 `ErrorBody` 포맷으로 응답
- 공지 content에 `whitespace-pre-line` 적용 — DB `\n`이 줄바꿈으로 렌더링

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- `SecurityConfig.java`, `application.yaml`, `GlobalExceptionHandler.java`, `AnnouncementBanner.tsx`