### PR TITLE
fix: 입력창 브라우저 맞춤법 검사 비활성화

### DIFF
--- a/frontend/src/shared/ui/Input.tsx
+++ b/frontend/src/shared/ui/Input.tsx
@@ -8,6 +8,7 @@ export function Input({ className = "", ref, ...rest }: InputProps) {
   return (
     <input
       ref={ref}
+      spellCheck={false}
       className={[
         "border-4 border-black dark:border-white rounded-none shadow-brutal bg-white dark:bg-gray-900",
         "text-black dark:text-white px-4 py-3 font-medium text-lg w-full",


### PR DESCRIPTION
## 관련 이슈

Closes #117

## 변경 사항

- 공용 `Input` 컴포넌트에 `spellCheck={false}` 추가 — 브라우저 맞춤법 검사로 인한 빨간 밑줄 방지

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- `frontend/src/shared/ui/Input.tsx`