### PR TITLE
chore: 어드민 DTO 검증 + USED enum + 접근성 개선

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/AnnouncementCreateRequest.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/AnnouncementCreateRequest.java
@@ -2,12 +2,13 @@ package com.gakkaweo.backend.admin.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
 
 public record AnnouncementCreateRequest(
     @NotBlank @Size(max = 200) String title,
-    String content,
-    @NotBlank String type,
+    @Size(max = 5000) String content,
+    @NotBlank @Pattern(regexp = "INFO|MAINTENANCE|WARNING") String type,
     @NotNull Instant startsAt,
     Instant endsAt) {}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/AnnouncementUpdateRequest.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/AnnouncementUpdateRequest.java
@@ -1,12 +1,13 @@
 package com.gakkaweo.backend.admin.dto;
 
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.Instant;
 
 public record AnnouncementUpdateRequest(
     @Size(max = 200) String title,
-    String content,
-    String type,
+    @Size(max = 5000) String content,
+    @Pattern(regexp = "INFO|MAINTENANCE|WARNING") String type,
     Boolean active,
     Instant startsAt,
     Instant endsAt) {}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/DuplicateCheckRequest.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/DuplicateCheckRequest.java
@@ -1,5 +1,6 @@
 package com.gakkaweo.backend.admin.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
-public record DuplicateCheckRequest(@NotBlank String sentence) {}
+public record DuplicateCheckRequest(@NotBlank @Size(max = 500) String sentence) {}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/RoleChangeRequest.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/RoleChangeRequest.java
@@ -1,5 +1,6 @@
 package com.gakkaweo.backend.admin.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
-public record RoleChangeRequest(@NotBlank String role) {}
+public record RoleChangeRequest(@NotBlank @Pattern(regexp = "USER|ADMIN") String role) {}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/SimilarityTestRequest.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/SimilarityTestRequest.java
@@ -1,5 +1,7 @@
 package com.gakkaweo.backend.admin.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
-public record SimilarityTestRequest(@NotBlank String sentence, @NotBlank String guessText) {}
+public record SimilarityTestRequest(
+    @NotBlank @Size(max = 500) String sentence, @NotBlank @Size(max = 200) String guessText) {}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -151,6 +151,10 @@ public class AdminSentenceService {
 
   @Transactional
   public SentenceResponse schedule(UUID publicId, ScheduleRequest request) {
+    if (request.date().isBefore(LocalDate.now(KST))) {
+      throw new BusinessException(ErrorCode.VALIDATION_FAILED);
+    }
+
     DailySentence entity = findByPublicIdOrThrow(publicId);
 
     if (entity.getUsedAt() != null) {

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -232,11 +232,14 @@ public class AdminSentenceService {
               DailySentence reloadedNew = findByPublicIdOrThrow(newSentence.getPublicId());
 
               reloadedCurrent.setUsedAt(null);
-              if (!request.returnOldToPool()) {
+              if (request.returnOldToPool()) {
+                reloadedCurrent.setStatus(DailySentenceStatus.ACTIVE);
+              } else {
                 reloadedCurrent.setStatus(DailySentenceStatus.DISABLED);
               }
 
               reloadedNew.setUsedAt(today);
+              reloadedNew.setStatus(DailySentenceStatus.USED);
               reloadedNew.setScheduledAt(null);
 
               log.info(

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -95,6 +95,7 @@ public class AdminSystemService {
   public AnnouncementResponse createAnnouncement(
       AnnouncementCreateRequest request, UUID adminPublicId) {
     AnnouncementType type = parseAnnouncementType(request.type());
+    validateAnnouncementDates(request.startsAt(), request.endsAt());
 
     AnnouncementResponse response =
         transactionTemplate.execute(
@@ -148,6 +149,7 @@ public class AdminSystemService {
               if (request.endsAt() != null) {
                 announcement.setEndsAt(request.endsAt());
               }
+              validateAnnouncementDates(announcement.getStartsAt(), announcement.getEndsAt());
               announcementRepository.save(announcement);
               return AnnouncementResponse.from(announcement);
             });
@@ -252,6 +254,12 @@ public class AdminSystemService {
     return memberRepository
         .findByPublicId(publicId)
         .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+  }
+
+  private void validateAnnouncementDates(Instant startsAt, Instant endsAt) {
+    if (endsAt != null && endsAt.isBefore(startsAt)) {
+      throw new BusinessException(ErrorCode.VALIDATION_FAILED);
+    }
   }
 
   private AnnouncementType parseAnnouncementType(String type) {

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentenceStatus.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentenceStatus.java
@@ -2,5 +2,6 @@ package com.gakkaweo.backend.domain.game.entity;
 
 public enum DailySentenceStatus {
   ACTIVE,
+  USED,
   DISABLED
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.game.scheduler;
 import static com.gakkaweo.backend.common.time.TimeConstants.KST;
 
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
 import com.gakkaweo.backend.domain.game.entity.GameSession;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
 import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
@@ -150,6 +151,7 @@ public class DailySentenceScheduler {
 
     boolean wasScheduled = sentence.getScheduledAt() != null;
     sentence.setUsedAt(today);
+    sentence.setStatus(DailySentenceStatus.USED);
     sentence.setScheduledAt(null);
     dailySentenceRepository.save(sentence);
     log.info(

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -53,6 +53,10 @@ public class DailyGameService {
   private final GameProperties gameProperties;
   private final ApplicationEventPublisher eventPublisher;
 
+  private static boolean isPerfect(BigDecimal similarity) {
+    return similarity.compareTo(new BigDecimal("100")) >= 0;
+  }
+
   @Transactional(readOnly = true)
   public TodayResponse getToday() {
     DailySentence sentence = findTodaySentence();
@@ -266,10 +270,6 @@ public class DailyGameService {
     return memberRepository
         .findByPublicId(publicId)
         .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-  }
-
-  private static boolean isPerfect(BigDecimal similarity) {
-    return similarity.compareTo(new BigDecimal("100")) >= 0;
   }
 
   private void validateGuessAllowed(GameSession session) {

--- a/backend/src/main/resources/db/migration/V14__add_used_sentence_status.sql
+++ b/backend/src/main/resources/db/migration/V14__add_used_sentence_status.sql
@@ -1,0 +1,4 @@
+UPDATE daily_sentences
+SET status = 'USED'
+WHERE used_at IS NOT NULL
+  AND status = 'ACTIVE';

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -609,7 +609,7 @@
 
 #### `GET /admin/sentences` — 문장 목록
 
-- **쿼리**: `status` (선택, ACTIVE/DISABLED), `page` (기본 0), `size` (기본 20)
+- **쿼리**: `status` (선택, ACTIVE/USED/DISABLED), `page` (기본 0), `size` (기본 20)
 - **응답**: `{sentences: [...], page, size, totalElements, totalPages}`
 
 #### `POST /admin/sentences` — 문장 등록

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -282,7 +282,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **사이드바**: `border-4 shadow-brutal`. 탭: 대시보드/문장/사용자/시스템. 활성 탭 `bg-yellow-300 text-black`
 - **테이블**: `border-4 shadow-brutal` 래퍼. 헤더 `border-b-4 bg-gray-100 dark:bg-gray-800`. 행 `border-b-2 border-black/20` + hover `bg-yellow-50`
 - **위젯 카드**: `border-4 shadow-brutal-sm`. 라벨 `text-xs uppercase tracking-wide`. 수치 `text-3xl font-black tabular-nums`
-- **상태 배지**: `px-2 py-0.5 text-xs font-black border-2`. ACTIVE=green, DISABLED=gray, ADMIN=red, USER=blue, 차단=gray-800
+- **상태 배지**: `px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white`. ACTIVE=green-400, USED=blue-300, DISABLED=gray-300, ADMIN=red, USER=blue, 차단=gray-800
 - **다이얼로그**: `border-4 shadow-brutal max-w-lg`. 헤더 `border-b-4 px-6 py-5`. 푸터 `border-t-4`. `role="dialog" aria-modal="true"` + Escape 닫기 필수
 - **텍스트 링크 액션**: 테이블 행 내 액션은 `text-indigo-600 dark:text-indigo-400 font-black text-xs hover:underline`
 - **Pagination**: `Button sm secondary` 이전/다음 + `tabular-nums` 페이지 표시

--- a/frontend/src/app/layout/SettingsModal.tsx
+++ b/frontend/src/app/layout/SettingsModal.tsx
@@ -140,7 +140,9 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                       : "bg-white dark:bg-gray-900 text-black dark:text-white shadow-brutal-sm hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]",
                   ].join(" ")}
                 >
-                  <span className="block text-lg">{icon}</span>
+                  <span className="block text-lg" aria-hidden="true">
+                    {icon}
+                  </span>
                   <span className="block mt-1">{label}</span>
                 </button>
               ))}
@@ -152,9 +154,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               사운드
             </h3>
             <div className="flex items-center gap-3">
-              <span className="text-lg shrink-0">{volume === 0 ? "🔇" : "🔊"}</span>
+              <span className="text-lg shrink-0" aria-hidden="true">
+                {volume === 0 ? "🔇" : "🔊"}
+              </span>
               <input
                 type="range"
+                aria-label="사운드 볼륨"
                 min="0"
                 max="1"
                 step="0.1"

--- a/frontend/src/features/admin/components/AdminSidebar.tsx
+++ b/frontend/src/features/admin/components/AdminSidebar.tsx
@@ -11,7 +11,10 @@ export function AdminSidebar() {
   const { pathname } = useLocation();
 
   return (
-    <nav className="w-56 shrink-0 border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal">
+    <nav
+      aria-label="관리 메뉴"
+      className="w-56 shrink-0 border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal"
+    >
       <div className="border-b-4 border-black dark:border-white px-5 py-4">
         <h2 className="text-lg font-black tracking-tight">관리 패널</h2>
       </div>
@@ -29,7 +32,9 @@ export function AdminSidebar() {
                     : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-black dark:hover:text-white",
                 ].join(" ")}
               >
-                <span className="text-base leading-none">{tab.icon}</span>
+                <span className="text-base leading-none" aria-hidden="true">
+                  {tab.icon}
+                </span>
                 {tab.label}
               </Link>
             </li>

--- a/frontend/src/features/admin/components/SentenceTab.tsx
+++ b/frontend/src/features/admin/components/SentenceTab.tsx
@@ -14,7 +14,7 @@ function StatusBadge({ status }: { status: string }) {
     status === "ACTIVE"
       ? "bg-green-400 text-black"
       : status === "USED"
-        ? "bg-blue-300 text-black border-blue-500"
+        ? "bg-blue-300 text-black"
         : "bg-gray-300 dark:bg-gray-600 text-black dark:text-white";
   return (
     <span className={`inline-block px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white ${color}`}>

--- a/frontend/src/features/admin/components/SentenceTab.tsx
+++ b/frontend/src/features/admin/components/SentenceTab.tsx
@@ -11,7 +11,11 @@ import { ApiError } from "@/shared/api/client";
 
 function StatusBadge({ status }: { status: string }) {
   const color =
-    status === "ACTIVE" ? "bg-green-400 text-black" : "bg-gray-300 dark:bg-gray-600 text-black dark:text-white";
+    status === "ACTIVE"
+      ? "bg-green-400 text-black"
+      : status === "USED"
+        ? "bg-blue-300 text-black border-blue-500"
+        : "bg-gray-300 dark:bg-gray-600 text-black dark:text-white";
   return (
     <span className={`inline-block px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white ${color}`}>
       {status}
@@ -70,6 +74,7 @@ export function SentenceTab() {
         >
           <option value="">전체</option>
           <option value="ACTIVE">ACTIVE</option>
+          <option value="USED">USED</option>
           <option value="DISABLED">DISABLED</option>
         </select>
       </div>

--- a/frontend/src/features/admin/types.ts
+++ b/frontend/src/features/admin/types.ts
@@ -3,7 +3,7 @@
 export interface SentenceResponse {
   publicId: string;
   sentence: string;
-  status: "ACTIVE" | "DISABLED";
+  status: "ACTIVE" | "USED" | "DISABLED";
   usedAt: string | null;
   scheduledAt: string | null;
   totalPlayers: number | null;

--- a/frontend/src/features/ranking/components/RankingEntryRow.tsx
+++ b/frontend/src/features/ranking/components/RankingEntryRow.tsx
@@ -22,7 +22,7 @@ const TOP_RANK_STYLES: Record<number, { bg: string; shadowVar: string }> = {
 
 function TrophyIcon() {
   return (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" className="text-black">
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" className="text-black" aria-hidden="true">
       <path d="M5 3h14v7c0 3.9-3.1 7-7 7s-7-3.1-7-7V3z" />
       <path d="M5 5H2.5c0 3.5 1.5 5.5 2.5 6" />
       <path d="M19 5h2.5c0 3.5-1.5 5.5-2.5 6" />
@@ -35,7 +35,14 @@ function TrophyIcon() {
 function DefaultAvatar() {
   return (
     <div className="w-7 h-7 border-2 border-black dark:border-white bg-gray-200 dark:bg-gray-800 flex items-center justify-center shrink-0">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" className="text-gray-400 dark:text-gray-500">
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="text-gray-400 dark:text-gray-500"
+        aria-hidden="true"
+      >
         <circle cx="12" cy="9" r="3.5" />
         <path d="M12 14c-4.42 0-8 2.24-8 5v1h16v-1c0-2.76-3.58-5-8-5z" />
       </svg>

--- a/frontend/src/shared/config/providerIcons.tsx
+++ b/frontend/src/shared/config/providerIcons.tsx
@@ -1,6 +1,6 @@
 export function KakaoIcon({ size = 20 }: { size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
       <path d="M12 3C6.48 3 2 6.42 2 10.6c0 2.7 1.74 5.06 4.36 6.4-.14.52-.92 3.36-.95 3.57 0 0-.02.16.08.22.1.06.22.03.22.03.29-.04 3.37-2.2 3.9-2.57.77.11 1.57.17 2.39.17 5.52 0 10-3.42 10-7.63S17.52 3 12 3z" />
     </svg>
   );
@@ -8,7 +8,7 @@ export function KakaoIcon({ size = 20 }: { size?: number }) {
 
 export function GoogleIcon({ size = 20 }: { size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24">
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
       <path
         d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
         fill="#4285F4"
@@ -31,7 +31,7 @@ export function GoogleIcon({ size = 20 }: { size?: number }) {
 
 export function NaverIcon({ size = 20 }: { size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
       <path d="M16.27 3v8.86L7.73 3H3v18h4.73v-8.86L16.27 21H21V3h-4.73z" />
     </svg>
   );
@@ -39,7 +39,7 @@ export function NaverIcon({ size = 20 }: { size?: number }) {
 
 export function GakkaweoIcon({ size = 20 }: { size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
       <path
         fillRule="evenodd"
         clipRule="evenodd"


### PR DESCRIPTION
## 관련 이슈

Closes #119

## 변경 사항

### DTO 검증 보강
- `AnnouncementCreate/UpdateRequest`: `content @Size(max=5000)`, `type @Pattern(INFO|MAINTENANCE|WARNING)`
- `RoleChangeRequest`: `role @Pattern(USER|ADMIN)`
- `DuplicateCheckRequest`: `sentence @Size(max=500)`
- `SimilarityTestRequest`: `sentence @Size(max=500)`, `guessText @Size(max=200)`

### 서비스 레이어 무결성 검증
- `AdminSystemService`: 공지 `endsAt < startsAt` 검증 (create/update)
- `AdminSentenceService.schedule`: 스케줄 날짜 KST 기준 과거 차단

### 문장 상태 USED enum 추가
- `V14__add_used_sentence_status.sql`: 기존 출제 문장 `ACTIVE → USED` DML 마이그레이션
- `DailySentenceStatus`: `USED` 상태 추가
- `DailySentenceScheduler`: 자정 문장 선정 시 `USED` 설정
- `AdminSentenceService.emergencyReplace`: 새 문장 `USED`, `returnOldToPool=true` 시 이전 문장 `ACTIVE` 복원
- FE `types.ts` / `SentenceTab`: `USED` 타입 / 필터 옵션 / 파란색 배지 반영

### 접근성(a11y) 개선
- `AdminSidebar`: `<nav aria-label="관리 메뉴">`, 탭 아이콘 `aria-hidden`
- `SettingsModal`: 테마/음소거 아이콘 `aria-hidden`, 볼륨 슬라이더 `aria-label`
- `RankingEntryRow`: `TrophyIcon` / `DefaultAvatar` SVG `aria-hidden`
- `providerIcons`: Kakao/Google/Naver/Gakkaweo SVG `aria-hidden`

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료