### PR TITLE
fix: 프로덕션 JVM Metaspace 상한 상향 및 OOM 자동 복구 옵션 추가

### DIFF
--- a/.env.prod.sample
+++ b/.env.prod.sample
@@ -60,6 +60,7 @@ LOG_LEVEL=INFO
 
 # JVM
 # MaxMetaspaceSize: Spring Boot 3.5 + Security + OAuth2 + Springdoc 베이스라인 기준 256m 이상 필요
-# ExitOnOutOfMemoryError: OOM 발생 시 JVM 즉시 종료 → docker restart 정책이 자동 복구 (좀비 상태 방지)
-# HeapDumpOnOutOfMemoryError: OOM 진단용 힙 덤프 생성 (컨테이너 재시작 시 소실됨, 사후 분석 시 docker cp로 회수)
-JAVA_OPTS=-Xms256m -Xmx512m -XX:+UseG1GC -XX:MaxMetaspaceSize=256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof
+# ExitOnOutOfMemoryError: OOM 발생 시 JVM 즉시 종료 -> docker restart 정책(unless-stopped)이 자동 복구 (좀비 상태 방지)
+# HeapDumpOnOutOfMemoryError: OOM 진단용 힙 덤프 생성
+# HeapDumpPath: /data/dumps는 docker-compose.prod.yml에서 호스트의 ./dumps에 마운트된 전용 볼륨이라 재시작 후에도 보존
+JAVA_OPTS=-Xms256m -Xmx512m -XX:+UseG1GC -XX:MaxMetaspaceSize=256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/data/dumps/heapdump.hprof

--- a/.env.prod.sample
+++ b/.env.prod.sample
@@ -59,4 +59,7 @@ FORWARD_HEADERS_STRATEGY=native
 LOG_LEVEL=INFO
 
 # JVM
-JAVA_OPTS=-Xms256m -Xmx512m -XX:+UseG1GC -XX:MaxMetaspaceSize=128m
+# MaxMetaspaceSize: Spring Boot 3.5 + Security + OAuth2 + Springdoc 베이스라인 기준 256m 이상 필요
+# ExitOnOutOfMemoryError: OOM 발생 시 JVM 즉시 종료 → docker restart 정책이 자동 복구 (좀비 상태 방지)
+# HeapDumpOnOutOfMemoryError: OOM 진단용 힙 덤프 생성 (컨테이너 재시작 시 소실됨, 사후 분석 시 docker cp로 회수)
+JAVA_OPTS=-Xms256m -Xmx512m -XX:+UseG1GC -XX:MaxMetaspaceSize=256m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -74,6 +74,7 @@ services:
       - "127.0.0.1:${SERVER_PORT}:8080"
     volumes:
       - ./uploads:/data/uploads
+      - ./dumps:/data/dumps
     env_file: .env.prod
     networks:
       - internal


### PR DESCRIPTION
## 관련 이슈

Closes #131

## 변경 사항

- `.env.prod.sample`의 `JAVA_OPTS`에서 `MaxMetaspaceSize`를 128m에서 256m로 상향. Spring Boot 3.5 + Security + OAuth2 + Springdoc 베이스라인이 128m에 근접해 39시간 운영 후 첫 Google OAuth2 로그인의 TLS 클래스 로딩 시 OOM이 발생한 실제 장애에 대응
- `-XX:+ExitOnOutOfMemoryError` 추가. OOM 발생 시 JVM을 즉시 종료시켜 `restart: unless-stopped` 정책이 자동 복구하도록 변경. 이번 장애에서 JVM이 죽지 않아 3시간 동안 좀비 상태로 502만 반환한 현상 재발 방지
- `-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof` 추가. 차후 OOM 발생 시 힙 덤프를 남겨 실제 누수 여부를 사후 분석 가능
- 각 옵션의 의도를 `.env.prod.sample`에 주석으로 병기

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (JVM 옵션 유효성은 로컬 JDK 21 Temurin에서 `java` 기동 확인. 실제 장애 재현/복구 검증은 프로덕션 배포 이후 진행)
- [x] 불필요한 코드나 주석을 제거했다 (추가한 주석은 옵션 선택 근거를 남기기 위한 의도적 기록)
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다 (애플리케이션 코드 미변경, `.env.prod.sample`은 배포 템플릿으로 CI/테스트 영향 없음)