### PR TITLE
test: 백엔드 통합 테스트 도입 및 커버리지 보강

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - run: ./gradlew spotlessCheck
 
-      - run: ./gradlew build -x test
+      - run: ./gradlew build
 
   ai-service:
     name: AI Service

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'com.redis:testcontainers-redis:2.2.2'
+    testImplementation 'org.wiremock:wiremock-standalone:3.9.2'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -101,6 +102,7 @@ jacocoTestReport {
                     '**/dto/**',
                     '**/config/openapi/**',
                     '**/BackendApplication.class',
+                    '**/InitialDataSeeder.class',
                     '**/*Properties.class',
                     '**/*Event.class',
                     '**/*Request.class',

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '3.5.11'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '8.4.0'
@@ -50,6 +51,11 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'com.redis:testcontainers-redis:2.2.2'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
@@ -75,4 +81,33 @@ openApi {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = '0.8.12'
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        html.required = true
+        xml.required = true
+    }
+    afterEvaluate {
+        classDirectories.setFrom(
+            files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: [
+                    '**/dto/**',
+                    '**/config/openapi/**',
+                    '**/BackendApplication.class',
+                    '**/*Properties.class',
+                    '**/*Event.class',
+                    '**/*Request.class',
+                    '**/*Response.class',
+                    '**/*Projection.class',
+                ])
+            })
+        )
+    }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminDashboardService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminDashboardService.java
@@ -22,6 +22,7 @@ import com.gakkaweo.backend.ranking.dto.RankingResponse;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import com.gakkaweo.backend.ranking.sse.SseConnectionManager;
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -42,10 +43,11 @@ public class AdminDashboardService {
   private final MemberRepository memberRepository;
   private final RankingService rankingService;
   private final SseConnectionManager sseConnectionManager;
+  private final Clock clock;
 
   @Transactional(readOnly = true)
   public TodayWidgetResponse getTodayWidget() {
-    LocalDate today = LocalDate.now(KST);
+    LocalDate today = LocalDate.now(clock);
     DailySentence sentence =
         dailySentenceRepository
             .findByUsedAt(today)
@@ -73,7 +75,7 @@ public class AdminDashboardService {
 
   public FullRankingResponse getFullRanking(LocalDate date) {
     if (date == null) {
-      date = LocalDate.now(KST);
+      date = LocalDate.now(clock);
     }
     RankingResponse ranking = rankingService.getFullRankingsForDate(date);
 
@@ -100,7 +102,7 @@ public class AdminDashboardService {
 
   @Transactional(readOnly = true)
   public TrendDataResponse getTrends(int days) {
-    LocalDate today = LocalDate.now(KST);
+    LocalDate today = LocalDate.now(clock);
     List<DailyTrend> trends = new ArrayList<>();
 
     for (int i = days - 1; i >= 0; i--) {

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -1,7 +1,6 @@
 package com.gakkaweo.backend.admin.service;
 
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
-import static com.gakkaweo.backend.common.time.TimeConstants.KST;
 
 import com.gakkaweo.backend.admin.dto.DuplicateCheckRequest;
 import com.gakkaweo.backend.admin.dto.DuplicateCheckResponse;
@@ -24,6 +23,7 @@ import com.gakkaweo.backend.domain.game.repository.GuessHistoryRepository;
 import com.gakkaweo.backend.infra.ai.service.SimilarityClient;
 import com.gakkaweo.backend.ranking.event.DayChangeEvent;
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +52,7 @@ public class AdminSentenceService {
   private final StringRedisTemplate redisTemplate;
   private final ApplicationEventPublisher eventPublisher;
   private final TransactionTemplate transactionTemplate;
+  private final Clock clock;
 
   @Transactional(readOnly = true)
   public SentenceListResponse getSentences(String status, int page, int size) {
@@ -151,7 +152,7 @@ public class AdminSentenceService {
 
   @Transactional
   public SentenceResponse schedule(UUID publicId, ScheduleRequest request) {
-    if (request.date().isBefore(LocalDate.now(KST))) {
+    if (request.date().isBefore(LocalDate.now(clock))) {
       throw new BusinessException(ErrorCode.VALIDATION_FAILED);
     }
 
@@ -204,7 +205,7 @@ public class AdminSentenceService {
   }
 
   public SentenceResponse emergencyReplace(EmergencyReplaceRequest request) {
-    LocalDate today = LocalDate.now(KST);
+    LocalDate today = LocalDate.now(clock);
 
     UUID newPublicId =
         transactionTemplate.execute(

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -3,7 +3,6 @@ package com.gakkaweo.backend.admin.service;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
-import static com.gakkaweo.backend.common.time.TimeConstants.KST;
 
 import com.gakkaweo.backend.admin.dto.AnnouncementCreateRequest;
 import com.gakkaweo.backend.admin.dto.AnnouncementResponse;
@@ -29,6 +28,7 @@ import com.gakkaweo.backend.ranking.sse.SseConnectionManager;
 import com.gakkaweo.backend.ratelimit.filter.BucketStore;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -64,6 +64,7 @@ public class AdminSystemService {
   private final StringRedisTemplate redisTemplate;
   private final ApplicationEventPublisher eventPublisher;
   private final TransactionTemplate transactionTemplate;
+  private final Clock clock;
 
   private static Specification<AuditLog> auditLogFilters(
       String action, Instant dateFrom, Instant dateTo) {
@@ -155,7 +156,7 @@ public class AdminSystemService {
             });
 
     if (response != null && response.active()) {
-      Instant now = Instant.now();
+      Instant now = clock.instant();
       if (!response.startsAt().isAfter(now)
           && (response.endsAt() == null || !response.endsAt().isBefore(now))) {
         AnnouncementType type = AnnouncementType.valueOf(response.type());
@@ -204,7 +205,7 @@ public class AdminSystemService {
   }
 
   public void resetRankingCache() {
-    LocalDate today = LocalDate.now(KST);
+    LocalDate today = LocalDate.now(clock);
     String rankingKey = RANKING_KEY_PREFIX + today;
 
     Set<String> members = redisTemplate.opsForZSet().range(rankingKey, 0, -1);
@@ -271,7 +272,7 @@ public class AdminSystemService {
   }
 
   private boolean isCurrentlyActiveByTime(Instant startsAt, Instant endsAt) {
-    Instant now = Instant.now();
+    Instant now = clock.instant();
     if (startsAt.isAfter(now)) {
       return false;
     }

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -3,7 +3,6 @@ package com.gakkaweo.backend.admin.service;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
-import static com.gakkaweo.backend.common.time.TimeConstants.KST;
 
 import com.gakkaweo.backend.admin.dto.AdminUserResponse;
 import com.gakkaweo.backend.admin.dto.ForceNicknameRequest;
@@ -28,7 +27,7 @@ import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
 import com.gakkaweo.backend.domain.member.validation.NicknameValidator;
 import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
 import jakarta.persistence.criteria.Predicate;
-import java.time.Instant;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +61,7 @@ public class AdminUserService {
   private final NicknameValidator nicknameValidator;
   private final StringRedisTemplate redisTemplate;
   private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
 
   private static Specification<Member> memberFilters(String nickname, Boolean banned) {
     return (root, query, cb) -> {
@@ -152,7 +152,7 @@ public class AdminUserService {
 
     Member reloaded = findMember(targetPublicId);
     reloaded.setBanned(true);
-    reloaded.setBannedAt(Instant.now());
+    reloaded.setBannedAt(clock.instant());
 
     log.info("사용자 차단: publicId={}", targetPublicId);
   }
@@ -186,7 +186,7 @@ public class AdminUserService {
 
   public void cleanupRedisAfterDelete(UUID publicId) {
     try {
-      LocalDate today = LocalDate.now(KST);
+      LocalDate today = LocalDate.now(clock);
       String rankingKey = RANKING_KEY_PREFIX + today;
       String memberKey = RANKING_MEMBER_PREFIX + publicId;
       String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
@@ -231,7 +231,7 @@ public class AdminUserService {
 
   public void syncNicknameToRedis(UUID publicId, String nickname) {
     try {
-      LocalDate today = LocalDate.now(KST);
+      LocalDate today = LocalDate.now(clock);
       String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
 
       if (redisTemplate.hasKey(detailKey)) {
@@ -258,7 +258,7 @@ public class AdminUserService {
 
   private void syncProfileUrlToRedis(UUID publicId, String profileUrl) {
     try {
-      LocalDate today = LocalDate.now(KST);
+      LocalDate today = LocalDate.now(clock);
       String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
 
       if (redisTemplate.hasKey(detailKey)) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/jwt/JwtProvider.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import java.time.Clock;
 import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
@@ -16,15 +17,17 @@ public class JwtProvider {
 
   private final SecretKey secretKey;
   private final long accessExpirationMillis;
+  private final Clock clock;
 
-  public JwtProvider(JwtProperties jwtProperties) {
+  public JwtProvider(JwtProperties jwtProperties, Clock clock) {
     byte[] keyBytes = Base64.getDecoder().decode(jwtProperties.getAccessSecret());
     this.secretKey = Keys.hmacShaKeyFor(keyBytes);
     this.accessExpirationMillis = jwtProperties.getAccessExpiration().toMillis();
+    this.clock = clock;
   }
 
   public String createAccessToken(UUID publicId, String role) {
-    Date now = new Date();
+    Date now = Date.from(clock.instant());
     Date expiry = new Date(now.getTime() + accessExpirationMillis);
 
     return Jwts.builder()

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
@@ -3,7 +3,6 @@ package com.gakkaweo.backend.auth.service;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
-import static com.gakkaweo.backend.common.time.TimeConstants.KST;
 
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
@@ -15,6 +14,7 @@ import com.gakkaweo.backend.domain.member.repository.LocalAccountRepository;
 import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
 import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +38,7 @@ public class AccountService {
   private final AuthService authService;
   private final StringRedisTemplate redisTemplate;
   private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
 
   @Transactional
   public void deleteAccount(UUID publicId) {
@@ -67,7 +68,7 @@ public class AccountService {
         authService.logout(accessToken);
       }
 
-      LocalDate today = LocalDate.now(KST);
+      LocalDate today = LocalDate.now(clock);
       String rankingKey = RANKING_KEY_PREFIX + today;
       String memberKey = RANKING_MEMBER_PREFIX + publicId;
       String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
@@ -3,7 +3,6 @@ package com.gakkaweo.backend.auth.service;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.BLACKLIST_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
-import static com.gakkaweo.backend.common.time.TimeConstants.KST;
 
 import com.gakkaweo.backend.auth.dto.AuthResponse;
 import com.gakkaweo.backend.auth.dto.TokenPair;
@@ -16,6 +15,7 @@ import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import com.gakkaweo.backend.domain.member.validation.NicknameValidator;
 import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
 import io.jsonwebtoken.Claims;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.util.Objects;
@@ -39,6 +39,7 @@ public class AuthService {
   private final NicknameValidator nicknameValidator;
   private final StringRedisTemplate redisTemplate;
   private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
 
   @Transactional
   public TokenPair issueTokens(Member member) {
@@ -69,7 +70,7 @@ public class AuthService {
   public void logout(String accessToken) {
     Claims claims = jwtProvider.parseAccessToken(accessToken);
     String jti = claims.getId();
-    long remainingMillis = claims.getExpiration().getTime() - System.currentTimeMillis();
+    long remainingMillis = claims.getExpiration().getTime() - clock.millis();
 
     if (remainingMillis > 0) {
       redisTemplate
@@ -132,7 +133,7 @@ public class AuthService {
 
   public void syncProfileUrlToRedis(UUID publicId, String profileUrl) {
     try {
-      LocalDate today = LocalDate.now(KST);
+      LocalDate today = LocalDate.now(clock);
       String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
 
       if (redisTemplate.hasKey(detailKey)) {
@@ -146,7 +147,7 @@ public class AuthService {
 
   public void syncNicknameToRedis(UUID publicId, String nickname) {
     try {
-      LocalDate today = LocalDate.now(KST);
+      LocalDate today = LocalDate.now(clock);
       String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
 
       if (redisTemplate.hasKey(detailKey)) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
@@ -9,29 +9,46 @@ import com.gakkaweo.backend.domain.member.entity.Member;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class RefreshTokenService {
 
   private final RefreshTokenRepository refreshTokenRepository;
   private final JwtProperties jwtProperties;
+  private final Clock clock;
+  private final TransactionTemplate newTxTemplate;
+
+  public RefreshTokenService(
+      RefreshTokenRepository refreshTokenRepository,
+      JwtProperties jwtProperties,
+      Clock clock,
+      PlatformTransactionManager txManager) {
+    this.refreshTokenRepository = refreshTokenRepository;
+    this.jwtProperties = jwtProperties;
+    this.clock = clock;
+    TransactionTemplate template = new TransactionTemplate(txManager);
+    template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    this.newTxTemplate = template;
+  }
 
   @Transactional
   public String createRefreshToken(Member member) {
     String rawToken = UUID.randomUUID().toString();
     String tokenHash = hashToken(rawToken);
     UUID familyId = UUID.randomUUID();
-    Instant expiresAt = Instant.now().plus(jwtProperties.getRefreshExpiration());
+    Instant expiresAt = clock.instant().plus(jwtProperties.getRefreshExpiration());
 
     RefreshToken refreshToken = new RefreshToken(member, tokenHash, familyId, expiresAt);
     refreshTokenRepository.save(refreshToken);
@@ -49,11 +66,13 @@ public class RefreshTokenService {
 
     if (existing.isRevoked()) {
       log.warn("Refresh Token 재사용 감지: familyId={}", existing.getFamilyId());
-      revokeFamily(existing.getFamilyId());
+      UUID familyId = existing.getFamilyId();
+      // 상위 TX 롤백과 무관하게 family revoke를 즉시 commit (REQUIRES_NEW)
+      newTxTemplate.executeWithoutResult(status -> revokeFamilyInternal(familyId));
       throw new BusinessException(ErrorCode.REFRESH_TOKEN_REUSE_DETECTED);
     }
 
-    if (existing.getExpiresAt().isBefore(Instant.now())) {
+    if (existing.getExpiresAt().isBefore(clock.instant())) {
       log.warn("만료된 Refresh Token 사용 시도: familyId={}", existing.getFamilyId());
       existing.setRevoked(true);
       throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
@@ -63,20 +82,13 @@ public class RefreshTokenService {
 
     String newRawToken = UUID.randomUUID().toString();
     String newTokenHash = hashToken(newRawToken);
-    Instant expiresAt = Instant.now().plus(jwtProperties.getRefreshExpiration());
+    Instant expiresAt = clock.instant().plus(jwtProperties.getRefreshExpiration());
 
     RefreshToken newRefreshToken =
         new RefreshToken(existing.getMember(), newTokenHash, existing.getFamilyId(), expiresAt);
     refreshTokenRepository.save(newRefreshToken);
 
     return newRawToken;
-  }
-
-  @Transactional
-  public void revokeFamily(UUID familyId) {
-    List<RefreshToken> tokens = refreshTokenRepository.findByFamilyId(familyId);
-    tokens.forEach(token -> token.setRevoked(true));
-    log.info("Token Family 폐기: familyId={}, count={}", familyId, tokens.size());
   }
 
   @Transactional(readOnly = true)
@@ -95,5 +107,11 @@ public class RefreshTokenService {
     } catch (NoSuchAlgorithmException e) {
       throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다", e);
     }
+  }
+
+  private void revokeFamilyInternal(UUID familyId) {
+    List<RefreshToken> tokens = refreshTokenRepository.findByFamilyId(familyId);
+    tokens.forEach(token -> token.setRevoked(true));
+    log.info("Token Family 폐기: familyId={}, count={}", familyId, tokens.size());
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/config/ClockConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/ClockConfig.java
@@ -1,0 +1,16 @@
+package com.gakkaweo.backend.config;
+
+import static com.gakkaweo.backend.common.time.TimeConstants.KST;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+  @Bean
+  public Clock clock() {
+    return Clock.system(KST);
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -82,15 +82,15 @@ public class GameSession {
     }
   }
 
-  public void updateClearedAt() {
+  public void updateClearedAt(Instant now) {
     if (this.bestSimilarity.compareTo(new BigDecimal("100")) < 0) {
-      this.clearedAt = Instant.now();
+      this.clearedAt = now;
     }
   }
 
-  public void markCleared() {
+  public void markCleared(Instant now) {
     this.status = GameSessionStatus.CLEARED;
-    this.clearedAt = Instant.now();
+    this.clearedAt = now;
   }
 
   public boolean isInProgress() {

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -1,7 +1,5 @@
 package com.gakkaweo.backend.game.scheduler;
 
-import static com.gakkaweo.backend.common.time.TimeConstants.KST;
-
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
 import com.gakkaweo.backend.domain.game.entity.GameSession;
@@ -10,6 +8,7 @@ import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
 import com.gakkaweo.backend.ranking.dto.RankingSnapshot;
 import com.gakkaweo.backend.ranking.event.DayChangeEvent;
 import com.gakkaweo.backend.ranking.service.RankingService;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,11 +35,12 @@ public class DailySentenceScheduler {
   private final RankingService rankingService;
   private final TransactionTemplate transactionTemplate;
   private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
 
   @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
   public void executeMidnightJob() {
     log.info("일일 스케줄러 시작");
-    LocalDate today = LocalDate.now(KST);
+    LocalDate today = LocalDate.now(clock);
     LocalDate yesterday = today.minusDays(1);
 
     try {
@@ -81,7 +81,7 @@ public class DailySentenceScheduler {
 
   @EventListener(ApplicationReadyEvent.class)
   public void onApplicationReady() {
-    LocalDate today = LocalDate.now(KST);
+    LocalDate today = LocalDate.now(clock);
     if (dailySentenceRepository.findByUsedAt(today).isEmpty()) {
       log.info("오늘 날짜 기준으로 선택된 문장이 없어 즉시 선정을 진행합니다.");
       executeMidnightJob();

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -25,6 +25,7 @@ import com.gakkaweo.backend.infra.ai.service.SimilarityClient;
 import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -52,6 +53,7 @@ public class DailyGameService {
   private final HintMaskGenerator hintMaskGenerator;
   private final GameProperties gameProperties;
   private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
 
   private static boolean isPerfect(BigDecimal similarity) {
     return similarity.compareTo(new BigDecimal("100")) >= 0;
@@ -62,9 +64,9 @@ public class DailyGameService {
     DailySentence sentence = findTodaySentence();
     HintMaskGenerator.HintMask hint = hintMaskGenerator.generate(sentence.getSentence());
 
-    Instant expiresAt = LocalDate.now(KST).plusDays(1).atStartOfDay(KST).toInstant();
+    Instant expiresAt = LocalDate.now(clock).plusDays(1).atStartOfDay(KST).toInstant();
 
-    LocalDate yesterday = LocalDate.now(KST).minusDays(1);
+    LocalDate yesterday = LocalDate.now(clock).minusDays(1);
     String yesterdaySentence =
         dailySentenceRepository
             .findByUsedAt(yesterday)
@@ -97,14 +99,15 @@ public class DailyGameService {
     boolean isCorrect = similarity.compareTo(gameProperties.getSimilarityThreshold()) >= 0;
 
     BigDecimal previousBest = session.getBestSimilarity();
+    Instant now = clock.instant();
 
     if (session.isInProgress()) {
       session.incrementAttempt();
       if (isCorrect) {
-        session.markCleared();
+        session.markCleared(now);
       }
     } else if (session.isCleared() && isPerfect(similarity)) {
-      session.updateClearedAt();
+      session.updateClearedAt(now);
     }
     session.updateBestSimilarity(similarity);
 
@@ -128,11 +131,7 @@ public class DailyGameService {
         isCorrect);
 
     return new GuessResponse(
-        similarity,
-        session.getAttemptCount(),
-        isCorrect,
-        session.getStatus().name(),
-        Instant.now());
+        similarity, session.getAttemptCount(), isCorrect, session.getStatus().name(), now);
   }
 
   @Transactional(readOnly = true)
@@ -145,7 +144,7 @@ public class DailyGameService {
 
     boolean isCorrect = similarity.compareTo(gameProperties.getSimilarityThreshold()) >= 0;
 
-    return new GuessResponse(similarity, null, isCorrect, null, Instant.now());
+    return new GuessResponse(similarity, null, isCorrect, null, clock.instant());
   }
 
   @Transactional(readOnly = true)
@@ -241,14 +240,14 @@ public class DailyGameService {
   }
 
   private Duration remainingTtl() {
-    ZonedDateTime now = ZonedDateTime.now(KST);
+    ZonedDateTime now = ZonedDateTime.now(clock);
     ZonedDateTime midnight = now.toLocalDate().plusDays(1).atStartOfDay(KST);
     Duration remaining = Duration.between(now, midnight);
     return remaining.isNegative() || remaining.isZero() ? Duration.ofMinutes(1) : remaining;
   }
 
   private DailySentence findTodaySentence() {
-    LocalDate today = LocalDate.now(KST);
+    LocalDate today = LocalDate.now(clock);
     return dailySentenceRepository
         .findByUsedAt(today)
         .orElseThrow(() -> new BusinessException(ErrorCode.SENTENCE_NOT_FOUND));
@@ -259,7 +258,7 @@ public class DailyGameService {
         dailySentenceRepository
             .findByPublicId(publicId)
             .orElseThrow(() -> new BusinessException(ErrorCode.SENTENCE_NOT_FOUND));
-    LocalDate today = LocalDate.now(KST);
+    LocalDate today = LocalDate.now(clock);
     if (!today.equals(sentence.getUsedAt())) {
       throw new BusinessException(ErrorCode.SENTENCE_NOT_FOUND);
     }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/seeding/InitialDataSeeder.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/seeding/InitialDataSeeder.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.Ordered;
@@ -32,6 +33,7 @@ import org.springframework.util.StringUtils;
 @Component
 @Slf4j
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.seed.enabled", havingValue = "true", matchIfMissing = true)
 public class InitialDataSeeder {
 
   private static final String SEED_SENTENCES_PATH = "seed/sentences.txt";

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -18,6 +18,7 @@ import com.gakkaweo.backend.ranking.dto.RankingResponse.MyRank;
 import com.gakkaweo.backend.ranking.dto.RankingResponse.RankingEntry;
 import com.gakkaweo.backend.ranking.dto.RankingSnapshot;
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -48,16 +49,17 @@ public class RankingService {
   private final DailySentenceRepository dailySentenceRepository;
   private final GameSessionRepository gameSessionRepository;
   private final MemberRepository memberRepository;
+  private final Clock clock;
 
   public Integer updateRanking(GameSession session, Member member) {
     try {
-      LocalDate today = LocalDate.now(KST);
+      LocalDate today = LocalDate.now(clock);
       String rankingKey = buildRankingKey(today);
       String memberKey = RANKING_MEMBER_PREFIX + member.getPublicId();
       String detailKey = buildDetailKey(today, member.getPublicId());
 
       ZonedDateTime startOfDay = today.atStartOfDay(KST);
-      long elapsedSeconds = Duration.between(startOfDay, ZonedDateTime.now(KST)).getSeconds();
+      long elapsedSeconds = Duration.between(startOfDay, ZonedDateTime.now(clock)).getSeconds();
       Long clearedAtSeconds = calculateClearedAtSeconds(session, startOfDay);
       double score =
           encodeScore(
@@ -91,7 +93,7 @@ public class RankingService {
 
   public RankingResponse getRankings() {
     try {
-      LocalDate today = LocalDate.now(KST);
+      LocalDate today = LocalDate.now(clock);
       return getRankingsForDate(today);
     } catch (Exception e) {
       log.warn("랭킹 목록 조회 실패: {}", e.getMessage(), e);
@@ -102,7 +104,7 @@ public class RankingService {
   @Transactional(readOnly = true)
   public RankingResponse getRankingsForUser(UUID memberPublicId) {
     try {
-      LocalDate today = LocalDate.now(KST);
+      LocalDate today = LocalDate.now(clock);
       RankingResponse base = getRankingsForDate(today);
 
       MyRank myRank = lookupMyRank(today, memberPublicId);

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
@@ -13,21 +13,27 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class SseConnectionManager {
 
-  private static final int MAX_CONNECTIONS = 500;
   private static final long HEARTBEAT_INTERVAL_SECONDS = 10;
 
   private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
   private final RankingService rankingService;
+  private final int maxConnections;
+
+  public SseConnectionManager(
+      RankingService rankingService, @Value("${app.sse.max-connections:500}") int maxConnections) {
+    this.rankingService = rankingService;
+    this.maxConnections = maxConnections;
+  }
+
   private final ScheduledExecutorService heartbeatExecutor =
       Executors.newSingleThreadScheduledExecutor(
           r -> {
@@ -53,7 +59,7 @@ public class SseConnectionManager {
   }
 
   public synchronized SseEmitter register() {
-    if (emitters.size() >= MAX_CONNECTIONS) {
+    if (emitters.size() >= maxConnections) {
       throw new BusinessException(ErrorCode.SSE_MAX_CONNECTIONS);
     }
 

--- a/backend/src/main/java/com/gakkaweo/backend/service/AnnouncementService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/service/AnnouncementService.java
@@ -2,7 +2,7 @@ package com.gakkaweo.backend.service;
 
 import com.gakkaweo.backend.domain.admin.entity.Announcement;
 import com.gakkaweo.backend.domain.admin.repository.AnnouncementRepository;
-import java.time.Instant;
+import java.time.Clock;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,9 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnnouncementService {
 
   private final AnnouncementRepository announcementRepository;
+  private final Clock clock;
 
   @Transactional(readOnly = true)
   public List<Announcement> getActiveAnnouncements() {
-    return announcementRepository.findActiveAnnouncements(Instant.now());
+    return announcementRepository.findActiveAnnouncements(clock.instant());
   }
 }

--- a/backend/src/test/java/com/gakkaweo/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/gakkaweo/backend/BackendApplicationTests.java
@@ -1,10 +1,9 @@
 package com.gakkaweo.backend;
 
+import com.gakkaweo.backend.support.IntegrationTestBase;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
-class BackendApplicationTests {
+class BackendApplicationTests extends IntegrationTestBase {
 
   @Test
   void contextLoads() {}

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditRecordingTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditRecordingTest.java
@@ -1,0 +1,107 @@
+package com.gakkaweo.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.admin.dto.RoleChangeRequest;
+import com.gakkaweo.backend.admin.dto.SentenceCreateRequest;
+import com.gakkaweo.backend.domain.admin.entity.AuditLog;
+import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+@DisplayName("Admin 감사 로그 기록 통합 테스트")
+class AdminAuditRecordingTest extends IntegrationTestBase {
+
+  @Autowired AuditLogRepository auditLogRepository;
+
+  @Test
+  @DisplayName("역할 변경 → ROLE_CHANGE 기록")
+  void 역할변경_감사() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = authedJson(admin);
+
+    restTemplate.exchange(
+        url("/admin/users/" + target.getPublicId() + "/role"),
+        HttpMethod.PATCH,
+        new HttpEntity<>(new RoleChangeRequest("ADMIN"), headers),
+        Void.class);
+
+    AuditLog logged = assertSingleLog("ROLE_CHANGE");
+    assertThat(logged.getTargetType()).isEqualTo("MEMBER");
+    assertThat(logged.getTargetId()).isEqualTo(target.getPublicId().toString());
+    assertThat(logged.getDetail()).contains("ADMIN");
+  }
+
+  @Test
+  @DisplayName("차단 → USER_BAN 기록")
+  void 차단_감사() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    restTemplate.exchange(
+        url("/admin/users/" + target.getPublicId() + "/ban"),
+        HttpMethod.POST,
+        new HttpEntity<>(headers),
+        Void.class);
+
+    AuditLog logged = assertSingleLog("USER_BAN");
+    assertThat(logged.getTargetId()).isEqualTo(target.getPublicId().toString());
+  }
+
+  @Test
+  @DisplayName("문장 등록 → SENTENCE_CREATE 기록")
+  void 문장등록_감사() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+
+    restTemplate.exchange(
+        url("/admin/sentences"),
+        HttpMethod.POST,
+        new HttpEntity<>(new SentenceCreateRequest("테스트 문장"), headers),
+        Void.class);
+
+    AuditLog logged = assertSingleLog("SENTENCE_CREATE");
+    assertThat(logged.getTargetType()).isEqualTo("SENTENCE");
+    assertThat(logged.getDetail()).isEqualTo("테스트 문장");
+  }
+
+  @Test
+  @DisplayName("랭킹 캐시 리셋 → RANKING_CACHE_RESET 기록")
+  void 랭킹리셋_감사() {
+    testAuthHelper.createTodaySentence("오늘 문장");
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    restTemplate.exchange(
+        url("/admin/system/ranking-cache/reset"),
+        HttpMethod.POST,
+        new HttpEntity<>(headers),
+        Void.class);
+
+    AuditLog logged = assertSingleLog("RANKING_CACHE_RESET");
+    assertThat(logged.getTargetType()).isEqualTo("SYSTEM");
+  }
+
+  private AuditLog assertSingleLog(String action) {
+    List<AuditLog> logs =
+        auditLogRepository.findAll().stream().filter(l -> action.equals(l.getAction())).toList();
+    assertThat(logs).hasSize(1);
+    return logs.get(0);
+  }
+
+  private HttpHeaders authedJson(Member admin) {
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditServiceTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditServiceTest.java
@@ -1,0 +1,61 @@
+package com.gakkaweo.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gakkaweo.backend.admin.service.AdminAuditService;
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.admin.entity.AuditLog;
+import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("AdminAuditService 오버로드 테스트")
+class AdminAuditServiceTest extends IntegrationTestBase {
+
+  @Autowired AdminAuditService adminAuditService;
+  @Autowired AuditLogRepository auditLogRepository;
+
+  @Test
+  @DisplayName("log(Member, ...) - 이미 조회된 Member 직접 호출")
+  void log_member_직접호출() {
+    Member admin = testAuthHelper.createAdmin();
+
+    adminAuditService.log(admin, "TEST_ACTION", "TARGET", "t-1", "detail", "127.0.0.1");
+
+    AuditLog saved = auditLogRepository.findAll().get(0);
+    assertThat(saved.getAction()).isEqualTo("TEST_ACTION");
+    assertThat(saved.getTargetType()).isEqualTo("TARGET");
+    assertThat(saved.getTargetId()).isEqualTo("t-1");
+    assertThat(saved.getIpAddress()).isEqualTo("127.0.0.1");
+  }
+
+  @Test
+  @DisplayName("log(UUID, ...) - 존재하지 않는 publicId MEMBER_NOT_FOUND")
+  void log_publicId_미존재() {
+    UUID unknown = UUID.randomUUID();
+
+    assertThatThrownBy(
+            () -> adminAuditService.log(unknown, "ACTION", "TARGET", "t-1", null, "127.0.0.1"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("log(UUID, ...) - 유효한 adminPublicId는 Member 조회 후 저장")
+  void log_publicId_유효() {
+    Member admin = testAuthHelper.createAdmin();
+
+    adminAuditService.log(admin.getPublicId(), "VALID_ACTION", "TARGET", "t-1", null, "127.0.0.1");
+
+    assertThat(auditLogRepository.findAll())
+        .extracting(AuditLog::getAction)
+        .contains("VALID_ACTION");
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminDashboardIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminDashboardIntegrationTest.java
@@ -1,0 +1,139 @@
+package com.gakkaweo.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.admin.dto.DateStatsResponse;
+import com.gakkaweo.backend.admin.dto.FullRankingResponse;
+import com.gakkaweo.backend.admin.dto.GuessLogResponse;
+import com.gakkaweo.backend.admin.dto.TodayWidgetResponse;
+import com.gakkaweo.backend.admin.dto.TrendDataResponse;
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.time.Clock;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("Admin 대시보드 통합 테스트")
+class AdminDashboardIntegrationTest extends IntegrationTestBase {
+
+  @Autowired Clock dashClock;
+
+  @Test
+  @DisplayName("오늘 위젯 - 문장 있을 때 통계 반환")
+  void 오늘_위젯() {
+    testAuthHelper.createTodaySentence("오늘 문장");
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<TodayWidgetResponse> response =
+        restTemplate.exchange(
+            url("/admin/dashboard/today"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            TodayWidgetResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().sentence()).isEqualTo("오늘 문장");
+    assertThat(response.getBody().totalParticipants()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("오늘 위젯 - 문장 없을 때 SENTENCE_NOT_FOUND")
+  void 오늘_위젯_문장없음() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/dashboard/today"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_NOT_FOUND");
+  }
+
+  @Test
+  @DisplayName("전체 랭킹 - 오늘 날짜 (기본)")
+  void 전체_랭킹() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<FullRankingResponse> response =
+        restTemplate.exchange(
+            url("/admin/dashboard/ranking"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            FullRankingResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().rankings()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("날짜별 통계 - 문장 존재 시 200")
+  void 날짜별_통계() {
+    testAuthHelper.createTodaySentence("오늘 문장");
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    LocalDate today = LocalDate.now(dashClock);
+
+    ResponseEntity<DateStatsResponse> response =
+        restTemplate.exchange(
+            url("/admin/dashboard/stats/" + today),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            DateStatsResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().sentence()).isEqualTo("오늘 문장");
+    assertThat(response.getBody().date()).isEqualTo(today);
+  }
+
+  @Test
+  @DisplayName("추이 - 7일")
+  void 추이_7일() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<TrendDataResponse> response =
+        restTemplate.exchange(
+            url("/admin/dashboard/trends?days=7"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            TrendDataResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().trends()).hasSize(7);
+  }
+
+  @Test
+  @DisplayName("추측 로그 - 문장 있을 때 빈 목록")
+  void 추측로그() {
+    testAuthHelper.createTodaySentence("오늘 문장");
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    LocalDate today = LocalDate.now(dashClock);
+
+    ResponseEntity<GuessLogResponse> response =
+        restTemplate.exchange(
+            url("/admin/dashboard/guess-log?date=" + today),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            GuessLogResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().logs()).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSentenceIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSentenceIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gakkaweo.backend.admin.dto.DuplicateCheckRequest;
 import com.gakkaweo.backend.admin.dto.DuplicateCheckResponse;
+import com.gakkaweo.backend.admin.dto.EmergencyReplaceRequest;
 import com.gakkaweo.backend.admin.dto.ScheduleRequest;
 import com.gakkaweo.backend.admin.dto.SentenceCreateRequest;
 import com.gakkaweo.backend.admin.dto.SentenceListResponse;
@@ -15,11 +16,14 @@ import com.gakkaweo.backend.admin.dto.SimilarityTestResponse;
 import com.gakkaweo.backend.admin.dto.UnusedCountResponse;
 import com.gakkaweo.backend.common.exception.ErrorBody;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.ranking.event.DayChangeEvent;
 import com.gakkaweo.backend.support.IntegrationTestBase;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,11 +33,13 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @DisplayName("Admin 문장 관리 통합 테스트")
 class AdminSentenceIntegrationTest extends IntegrationTestBase {
 
   @Autowired DailySentenceRepository dailySentenceRepository;
+  @Autowired TransactionTemplate transactionTemplate;
 
   @Test
   @DisplayName("등록 - 201 + SENTENCE_DUPLICATE(409)")
@@ -295,6 +301,142 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
   }
 
   @Test
+  @DisplayName("목록 조회 - 잘못된 status 400")
+  void 목록_status_잘못됨_400() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences?status=INVALID&page=0&size=20"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+  }
+
+  @Test
+  @DisplayName("목록 조회 - 상태 필터 빈 문자열은 status=null과 동일하게 전체 반환")
+  void 목록_공백status() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createActiveSentence("빈 status A");
+    testAuthHelper.createTodaySentence("오늘 문장");
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<SentenceListResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences?status=&page=0&size=20"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            SentenceListResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().sentences()).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("수정 - 동일 문장으로 업데이트는 중복 체크 건너뜀")
+  void 수정_동일_문장() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createActiveSentence("그대로 유지");
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<SentenceResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId()),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new SentenceUpdateRequest("그대로 유지"), headers),
+            SentenceResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().sentence()).isEqualTo("그대로 유지");
+  }
+
+  @Test
+  @DisplayName("수정 - 다른 문장이지만 이미 존재하면 SENTENCE_DUPLICATE(409)")
+  void 수정_중복_409() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createActiveSentence("기존 문장");
+    DailySentence target = testAuthHelper.createActiveSentence("변경 대상");
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + target.getPublicId()),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new SentenceUpdateRequest("기존 문장"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_DUPLICATE");
+  }
+
+  @Test
+  @DisplayName("중복 검사 - 유사도 낮으면 hasDuplicate=false")
+  void 중복_검사_없음() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createActiveSentence("전혀 다른 문장 하나");
+    testSimilarityClient.setDefaultScore(new BigDecimal("30.0"));
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<DuplicateCheckResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/duplicate-check"),
+            HttpMethod.POST,
+            new HttpEntity<>(new DuplicateCheckRequest("새 문장"), headers),
+            DuplicateCheckResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().hasDuplicate()).isFalse();
+    assertThat(response.getBody().similarEntries()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("스케줄 - 이미 사용된 문장 SENTENCE_ALREADY_USED")
+  void 스케줄_사용됨_400() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createTodaySentence("사용된 문장");
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId() + "/schedule"),
+            HttpMethod.POST,
+            new HttpEntity<>(new ScheduleRequest(LocalDate.now(clock).plusDays(1)), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_ALREADY_USED");
+  }
+
+  @Test
+  @DisplayName("스케줄 - 동일 문장의 동일 날짜 재지정은 200")
+  void 스케줄_재지정_동일날짜() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createActiveSentence("동일날짜 재지정");
+    LocalDate tomorrow = LocalDate.now(clock).plusDays(1);
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<SentenceResponse> first =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId() + "/schedule"),
+            HttpMethod.POST,
+            new HttpEntity<>(new ScheduleRequest(tomorrow), headers),
+            SentenceResponse.class);
+    assertThat(first.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<SentenceResponse> second =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId() + "/schedule"),
+            HttpMethod.POST,
+            new HttpEntity<>(new ScheduleRequest(tomorrow), headers),
+            SentenceResponse.class);
+    assertThat(second.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
   @DisplayName("unschedule - 스케줄 해제")
   void 스케줄_해제() {
     Member admin = testAuthHelper.createAdmin();
@@ -312,6 +454,145 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody().scheduledAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("emergencyReplace - returnOldToPool=true (이전 문장 ACTIVE 복귀, DayChangeEvent 발행)")
+  void 긴급교체_풀복귀() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence old = testAuthHelper.createTodaySentence("교체 대상 (기존)");
+    DailySentence replacement = testAuthHelper.createActiveSentence("교체 후보 (새 문장)");
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<SentenceResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/emergency-replace"),
+            HttpMethod.POST,
+            new HttpEntity<>(new EmergencyReplaceRequest(replacement.getPublicId(), true), headers),
+            SentenceResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().publicId()).isEqualTo(replacement.getPublicId());
+
+    DailySentence reloadedOld = dailySentenceRepository.findById(old.getId()).orElseThrow();
+    assertThat(reloadedOld.getUsedAt()).isNull();
+    assertThat(reloadedOld.getStatus()).isEqualTo(DailySentenceStatus.ACTIVE);
+
+    DailySentence reloadedNew = dailySentenceRepository.findById(replacement.getId()).orElseThrow();
+    assertThat(reloadedNew.getStatus()).isEqualTo(DailySentenceStatus.USED);
+
+    assertThat(testEventCollector.getDayChangeEvents())
+        .extracting(DayChangeEvent::newSentenceId)
+        .contains(replacement.getPublicId());
+  }
+
+  @Test
+  @DisplayName("emergencyReplace - returnOldToPool=false (이전 문장 DISABLED)")
+  void 긴급교체_비활성처리() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence old = testAuthHelper.createTodaySentence("교체 대상 2");
+    DailySentence replacement = testAuthHelper.createActiveSentence("교체 후보 2");
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<SentenceResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/emergency-replace"),
+            HttpMethod.POST,
+            new HttpEntity<>(
+                new EmergencyReplaceRequest(replacement.getPublicId(), false), headers),
+            SentenceResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    DailySentence reloadedOld = dailySentenceRepository.findById(old.getId()).orElseThrow();
+    assertThat(reloadedOld.getStatus()).isEqualTo(DailySentenceStatus.DISABLED);
+  }
+
+  @Test
+  @DisplayName("emergencyReplace - 오늘 문장 없으면 SENTENCE_NOT_FOUND")
+  void 긴급교체_오늘문장없음() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence replacement = testAuthHelper.createActiveSentence("후보");
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences/emergency-replace"),
+            HttpMethod.POST,
+            new HttpEntity<>(new EmergencyReplaceRequest(replacement.getPublicId(), true), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_NOT_FOUND");
+  }
+
+  @Test
+  @DisplayName("emergencyReplace - 존재하지 않는 newSentencePublicId SENTENCE_NOT_FOUND")
+  void 긴급교체_없는문장() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createTodaySentence("오늘");
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences/emergency-replace"),
+            HttpMethod.POST,
+            new HttpEntity<>(new EmergencyReplaceRequest(UUID.randomUUID(), true), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_NOT_FOUND");
+  }
+
+  @Test
+  @DisplayName("emergencyReplace - newSentence가 이미 사용됨이면 SENTENCE_ALREADY_USED")
+  void 긴급교체_이미사용() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createTodaySentence("오늘");
+    DailySentence alreadyUsed =
+        transactionTemplate.execute(
+            status -> {
+              DailySentence s = new DailySentence("이미 사용된 과거 문장");
+              s.setUsedAt(java.time.LocalDate.now(clock).minusDays(7));
+              s.setStatus(DailySentenceStatus.USED);
+              return dailySentenceRepository.save(s);
+            });
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences/emergency-replace"),
+            HttpMethod.POST,
+            new HttpEntity<>(new EmergencyReplaceRequest(alreadyUsed.getPublicId(), true), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_ALREADY_USED");
+  }
+
+  @Test
+  @DisplayName("emergencyReplace - newSentence가 DISABLED면 SENTENCE_NOT_FOUND")
+  void 긴급교체_비활성문장() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createTodaySentence("오늘");
+    DailySentence disabled =
+        transactionTemplate.execute(
+            status -> {
+              DailySentence s = new DailySentence("비활성 후보");
+              s.setStatus(DailySentenceStatus.DISABLED);
+              return dailySentenceRepository.save(s);
+            });
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences/emergency-replace"),
+            HttpMethod.POST,
+            new HttpEntity<>(new EmergencyReplaceRequest(disabled.getPublicId(), true), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_NOT_FOUND");
   }
 
   private HttpHeaders authedJson(Member admin) {

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSentenceIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSentenceIntegrationTest.java
@@ -1,0 +1,322 @@
+package com.gakkaweo.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.admin.dto.DuplicateCheckRequest;
+import com.gakkaweo.backend.admin.dto.DuplicateCheckResponse;
+import com.gakkaweo.backend.admin.dto.ScheduleRequest;
+import com.gakkaweo.backend.admin.dto.SentenceCreateRequest;
+import com.gakkaweo.backend.admin.dto.SentenceListResponse;
+import com.gakkaweo.backend.admin.dto.SentenceResponse;
+import com.gakkaweo.backend.admin.dto.SentenceStatsResponse;
+import com.gakkaweo.backend.admin.dto.SentenceUpdateRequest;
+import com.gakkaweo.backend.admin.dto.SimilarityTestRequest;
+import com.gakkaweo.backend.admin.dto.SimilarityTestResponse;
+import com.gakkaweo.backend.admin.dto.UnusedCountResponse;
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("Admin 문장 관리 통합 테스트")
+class AdminSentenceIntegrationTest extends IntegrationTestBase {
+
+  @Autowired DailySentenceRepository dailySentenceRepository;
+
+  @Test
+  @DisplayName("등록 - 201 + SENTENCE_DUPLICATE(409)")
+  void 등록_중복() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<SentenceResponse> created =
+        restTemplate.exchange(
+            url("/admin/sentences"),
+            HttpMethod.POST,
+            new HttpEntity<>(new SentenceCreateRequest("새 문장 하나"), headers),
+            SentenceResponse.class);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+    ResponseEntity<ErrorBody> dup =
+        restTemplate.exchange(
+            url("/admin/sentences"),
+            HttpMethod.POST,
+            new HttpEntity<>(new SentenceCreateRequest("새 문장 하나"), headers),
+            ErrorBody.class);
+    assertThat(dup.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(dup.getBody().code()).isEqualTo("SENTENCE_DUPLICATE");
+  }
+
+  @Test
+  @DisplayName("수정 - 출제된 문장은 SENTENCE_ALREADY_USED(400)")
+  void 수정_출제후_불가() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createTodaySentence("오늘 문장");
+
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId()),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new SentenceUpdateRequest("수정된 문장"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_ALREADY_USED");
+  }
+
+  @Test
+  @DisplayName("수정 - 미출제 문장은 성공")
+  void 수정_성공() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createActiveSentence("미출제 문장");
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<SentenceResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId()),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new SentenceUpdateRequest("바뀐 문장"), headers),
+            SentenceResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().sentence()).isEqualTo("바뀐 문장");
+  }
+
+  @Test
+  @DisplayName("삭제 - 미출제만 가능")
+  void 삭제_미출제() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createActiveSentence("삭제 대상");
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId()),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(dailySentenceRepository.findByPublicId(sentence.getPublicId())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("삭제 - 출제된 문장은 SENTENCE_ALREADY_USED")
+  void 삭제_출제됨_400() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createTodaySentence("출제된 문장");
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId()),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_ALREADY_USED");
+  }
+
+  @Test
+  @DisplayName("스케줄 지정 - 성공 + SENTENCE_ALREADY_SCHEDULED(409)")
+  void 스케줄_중복() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence a = testAuthHelper.createActiveSentence("A 문장");
+    DailySentence b = testAuthHelper.createActiveSentence("B 문장");
+
+    LocalDate tomorrow = LocalDate.now(clock).plusDays(1);
+
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<SentenceResponse> first =
+        restTemplate.exchange(
+            url("/admin/sentences/" + a.getPublicId() + "/schedule"),
+            HttpMethod.POST,
+            new HttpEntity<>(new ScheduleRequest(tomorrow), headers),
+            SentenceResponse.class);
+    assertThat(first.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<ErrorBody> conflict =
+        restTemplate.exchange(
+            url("/admin/sentences/" + b.getPublicId() + "/schedule"),
+            HttpMethod.POST,
+            new HttpEntity<>(new ScheduleRequest(tomorrow), headers),
+            ErrorBody.class);
+
+    assertThat(conflict.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(conflict.getBody().code()).isEqualTo("SENTENCE_ALREADY_SCHEDULED");
+  }
+
+  @Test
+  @DisplayName("스케줄 지정 - 과거 날짜는 VALIDATION_FAILED(400)")
+  void 과거날짜_400() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createActiveSentence("스케줄용");
+
+    LocalDate yesterday = LocalDate.now(clock).minusDays(1);
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId() + "/schedule"),
+            HttpMethod.POST,
+            new HttpEntity<>(new ScheduleRequest(yesterday), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+  }
+
+  @Test
+  @DisplayName("목록 조회 - 상태 필터 ACTIVE")
+  void 목록_ACTIVE_필터() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createActiveSentence("활성 A");
+    testAuthHelper.createActiveSentence("활성 B");
+    testAuthHelper.createTodaySentence("오늘 문장");
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    ResponseEntity<SentenceListResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences?status=ACTIVE&page=0&size=20"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            SentenceListResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().sentences()).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("상세 조회 - 존재 시 200")
+  void 상세_200() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createActiveSentence("상세 대상");
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    ResponseEntity<SentenceResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId()),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            SentenceResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().sentence()).isEqualTo("상세 대상");
+  }
+
+  @Test
+  @DisplayName("상세 통계 - 0 참여")
+  void 상세_통계() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createActiveSentence("통계 대상");
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    ResponseEntity<SentenceStatsResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId() + "/stats"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            SentenceStatsResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().totalSessions()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("미사용 문장 수 조회")
+  void 미사용_수() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createActiveSentence("A");
+    testAuthHelper.createActiveSentence("B");
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    ResponseEntity<UnusedCountResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/unused-count"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            UnusedCountResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().count()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("similarity 테스트 - TestSimilarityClient 기반 점수 반환")
+  void 유사도_테스트() {
+    Member admin = testAuthHelper.createAdmin();
+    testSimilarityClient.program("바람", new BigDecimal("77.7"));
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<SimilarityTestResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/similarity-test"),
+            HttpMethod.POST,
+            new HttpEntity<>(new SimilarityTestRequest("하늘", "바람"), headers),
+            SimilarityTestResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().similarity()).isEqualByComparingTo("77.7");
+  }
+
+  @Test
+  @DisplayName("중복 검사 - 80% 이상 유사한 문장 반환")
+  void 중복_검사() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createActiveSentence("비슷한 문장 있음");
+    testSimilarityClient.program("새 문장 검사", new BigDecimal("85.0"));
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<DuplicateCheckResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/duplicate-check"),
+            HttpMethod.POST,
+            new HttpEntity<>(new DuplicateCheckRequest("새 문장 검사"), headers),
+            DuplicateCheckResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().hasDuplicate()).isTrue();
+  }
+
+  @Test
+  @DisplayName("unschedule - 스케줄 해제")
+  void 스케줄_해제() {
+    Member admin = testAuthHelper.createAdmin();
+    DailySentence sentence = testAuthHelper.createActiveSentence("해제 대상");
+    sentence.setScheduledAt(LocalDate.now(clock).plusDays(1));
+    dailySentenceRepository.save(sentence);
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    ResponseEntity<SentenceResponse> response =
+        restTemplate.exchange(
+            url("/admin/sentences/" + sentence.getPublicId() + "/schedule"),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            SentenceResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().scheduledAt()).isNull();
+  }
+
+  private HttpHeaders authedJson(Member admin) {
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSystemIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSystemIntegrationTest.java
@@ -6,25 +6,34 @@ import com.gakkaweo.backend.admin.dto.AnnouncementCreateRequest;
 import com.gakkaweo.backend.admin.dto.AnnouncementResponse;
 import com.gakkaweo.backend.admin.dto.AuditLogListResponse;
 import com.gakkaweo.backend.admin.dto.SystemStatusResponse;
+import com.gakkaweo.backend.admin.event.AnnouncementEvent;
 import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.admin.entity.AuditLog;
+import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.support.IntegrationTestBase;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @DisplayName("Admin 시스템 관리 통합 테스트")
 class AdminSystemIntegrationTest extends IntegrationTestBase {
 
   @Autowired Clock clock;
+  @Autowired AuditLogRepository auditLogRepository;
+  @Autowired TransactionTemplate transactionTemplate;
 
   @Test
   @DisplayName("공지 등록 - 201 + 목록 조회")
@@ -133,6 +142,313 @@ class AdminSystemIntegrationTest extends IntegrationTestBase {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody().content()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("공지 등록 - 활성 기간(현재 포함)이면 AnnouncementEvent 발행")
+  void 공지등록_활성기간_이벤트발행() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+    Instant now = clock.instant();
+
+    AnnouncementCreateRequest request =
+        new AnnouncementCreateRequest(
+            "진행중", "내용", "MAINTENANCE", now.minusSeconds(60), now.plus(Duration.ofHours(1)));
+
+    ResponseEntity<AnnouncementResponse> created =
+        restTemplate.exchange(
+            url("/admin/system/announcements"),
+            HttpMethod.POST,
+            new HttpEntity<>(request, headers),
+            AnnouncementResponse.class);
+
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(testEventCollector.getAnnouncementEvents())
+        .extracting(AnnouncementEvent::title)
+        .contains("진행중");
+  }
+
+  @Test
+  @DisplayName("공지 등록 - 종료일 없음이면 endsAt null 분기로 이벤트 발행")
+  void 공지등록_종료없음_이벤트발행() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+
+    AnnouncementCreateRequest request =
+        new AnnouncementCreateRequest("무기한", null, "INFO", clock.instant().minusSeconds(60), null);
+
+    restTemplate.exchange(
+        url("/admin/system/announcements"),
+        HttpMethod.POST,
+        new HttpEntity<>(request, headers),
+        AnnouncementResponse.class);
+
+    assertThat(testEventCollector.getAnnouncementEvents())
+        .extracting(AnnouncementEvent::title)
+        .contains("무기한");
+  }
+
+  @Test
+  @DisplayName("공지 등록 - 미래 시작이면 이벤트 없음")
+  void 공지등록_미래시작_이벤트없음() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+    Instant future = clock.instant().plus(Duration.ofHours(1));
+
+    AnnouncementCreateRequest request =
+        new AnnouncementCreateRequest("예약", "내용", "INFO", future, future.plus(Duration.ofHours(2)));
+
+    restTemplate.exchange(
+        url("/admin/system/announcements"),
+        HttpMethod.POST,
+        new HttpEntity<>(request, headers),
+        AnnouncementResponse.class);
+
+    assertThat(testEventCollector.getAnnouncementEvents()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("공지 등록 - 종료일이 이미 지남이면 이벤트 없음")
+  void 공지등록_종료지남_이벤트없음() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+    Instant past = clock.instant().minus(Duration.ofDays(2));
+
+    AnnouncementCreateRequest request =
+        new AnnouncementCreateRequest(
+            "지난 공지", "내용", "WARNING", past, clock.instant().minus(Duration.ofDays(1)));
+
+    restTemplate.exchange(
+        url("/admin/system/announcements"),
+        HttpMethod.POST,
+        new HttpEntity<>(request, headers),
+        AnnouncementResponse.class);
+
+    assertThat(testEventCollector.getAnnouncementEvents()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("공지 등록 - endsAt이 startsAt보다 이전이면 400 VALIDATION_FAILED")
+  void 공지등록_역순날짜_400() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+    Instant now = clock.instant();
+
+    AnnouncementCreateRequest request =
+        new AnnouncementCreateRequest("역순", null, "INFO", now, now.minusSeconds(60));
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/system/announcements"),
+            HttpMethod.POST,
+            new HttpEntity<>(request, headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+  }
+
+  @Test
+  @DisplayName("공지 수정 - title/content/type/active/startsAt/endsAt 개별 patch")
+  void 공지수정_필드별_patch() {
+    AnnouncementResponse created = createAnnouncement("원본", "INFO");
+
+    patch(created.id(), "{\"title\":\"새 제목\"}");
+    patch(created.id(), "{\"content\":\"새 내용\"}");
+    patch(created.id(), "{\"type\":\"WARNING\"}");
+    patch(created.id(), "{\"active\":false}");
+    Instant newStart = clock.instant().minusSeconds(30);
+    Instant newEnd = newStart.plus(Duration.ofHours(3));
+    patch(created.id(), "{\"startsAt\":\"" + newStart + "\"}");
+    patch(created.id(), "{\"endsAt\":\"" + newEnd + "\"}");
+
+    List<AnnouncementResponse> list = fetchAnnouncements();
+    AnnouncementResponse updated =
+        list.stream().filter(a -> a.id().equals(created.id())).findFirst().orElseThrow();
+    assertThat(updated.title()).isEqualTo("새 제목");
+    assertThat(updated.content()).isEqualTo("새 내용");
+    assertThat(updated.type()).isEqualTo("WARNING");
+    assertThat(updated.active()).isFalse();
+  }
+
+  @Test
+  @DisplayName("공지 수정 - active=true + 현재 기간이면 이벤트 발행")
+  void 공지수정_활성기간_이벤트발행() {
+    AnnouncementResponse created = createAnnouncement("원본", "INFO");
+    testEventCollector.reset();
+
+    patch(created.id(), "{\"content\":\"수정된 내용\"}");
+
+    assertThat(testEventCollector.getAnnouncementEvents())
+        .extracting(AnnouncementEvent::id)
+        .contains(created.id());
+  }
+
+  @Test
+  @DisplayName("공지 수정 - active=false면 이벤트 없음")
+  void 공지수정_비활성_이벤트없음() {
+    AnnouncementResponse created = createAnnouncement("원본", "INFO");
+    testEventCollector.reset();
+
+    patch(created.id(), "{\"active\":false}");
+
+    assertThat(testEventCollector.getAnnouncementEvents()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("공지 수정 - 미래 시작으로 변경 시 이벤트 없음")
+  void 공지수정_미래시작_이벤트없음() {
+    AnnouncementResponse created = createAnnouncement("원본", "INFO");
+    testEventCollector.reset();
+
+    Instant future = clock.instant().plus(Duration.ofHours(1));
+    Instant futureEnd = future.plus(Duration.ofHours(1));
+    patch(created.id(), "{\"startsAt\":\"" + future + "\",\"endsAt\":\"" + futureEnd + "\"}");
+
+    assertThat(testEventCollector.getAnnouncementEvents()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("공지 수정 - 역순 날짜 400")
+  void 공지수정_역순날짜_400() {
+    AnnouncementResponse created = createAnnouncement("원본", "INFO");
+    Instant past = clock.instant().minusSeconds(3600);
+
+    ResponseEntity<ErrorBody> response =
+        patchExpectError(created.id(), "{\"endsAt\":\"" + past + "\"}");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+  }
+
+  @Test
+  @DisplayName("공지 삭제 - AnnouncementEvent 발행")
+  void 공지삭제_이벤트발행() {
+    AnnouncementResponse created = createAnnouncement("삭제대상", "INFO");
+    testEventCollector.reset();
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/system/announcements/" + created.id()),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(testEventCollector.getAnnouncementEvents())
+        .extracting(AnnouncementEvent::id)
+        .contains(created.id());
+  }
+
+  @Test
+  @DisplayName("공지 목록 조회 - admin fetch join 경로 실행")
+  void 공지목록_조회() {
+    createAnnouncement("목록 첫번째", "INFO");
+    createAnnouncement("목록 두번째", "WARNING");
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    List<AnnouncementResponse> list = fetchAnnouncements();
+    assertThat(list).hasSizeGreaterThanOrEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("감사 로그 조회 - action 필터 일치 항목만 반환")
+  void 감사로그_action_필터() {
+    Member admin = testAuthHelper.createAdmin();
+    seedAuditLog(admin, "ACTION_A", clock.instant());
+    seedAuditLog(admin, "ACTION_B", clock.instant());
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<AuditLogListResponse> response =
+        restTemplate.exchange(
+            url("/admin/system/audit-logs?action=ACTION_A"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            AuditLogListResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().content())
+        .allSatisfy(entry -> assertThat(entry.action()).isEqualTo("ACTION_A"));
+    assertThat(response.getBody().totalElements()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("감사 로그 조회 - dateFrom/dateTo 필터")
+  void 감사로그_날짜_필터() {
+    Member admin = testAuthHelper.createAdmin();
+    seedAuditLog(admin, "ANY", clock.instant());
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    Instant from = Instant.now().minus(Duration.ofMinutes(5));
+    Instant to = Instant.now().plus(Duration.ofMinutes(5));
+
+    ResponseEntity<AuditLogListResponse> response =
+        restTemplate.exchange(
+            url("/admin/system/audit-logs?dateFrom=" + from + "&dateTo=" + to + "&action=ANY"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            AuditLogListResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().totalElements()).isGreaterThanOrEqualTo(1L);
+  }
+
+  private AnnouncementResponse createAnnouncement(String title, String type) {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+    Instant now = clock.instant();
+    AnnouncementCreateRequest request =
+        new AnnouncementCreateRequest(
+            title, "body", type, now.minusSeconds(60), now.plus(Duration.ofHours(1)));
+    return restTemplate
+        .exchange(
+            url("/admin/system/announcements"),
+            HttpMethod.POST,
+            new HttpEntity<>(request, headers),
+            AnnouncementResponse.class)
+        .getBody();
+  }
+
+  private void patch(Long id, String body) {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<AnnouncementResponse> response =
+        restTemplate.exchange(
+            url("/admin/system/announcements/" + id),
+            HttpMethod.PATCH,
+            new HttpEntity<>(body, headers),
+            AnnouncementResponse.class);
+    assertThat(response.getStatusCode().is2xxSuccessful()).as("PATCH body=%s", body).isTrue();
+  }
+
+  private ResponseEntity<ErrorBody> patchExpectError(Long id, String body) {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+    return restTemplate.exchange(
+        url("/admin/system/announcements/" + id),
+        HttpMethod.PATCH,
+        new HttpEntity<>(body, headers),
+        ErrorBody.class);
+  }
+
+  private List<AnnouncementResponse> fetchAnnouncements() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    return restTemplate
+        .exchange(
+            url("/admin/system/announcements"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            new ParameterizedTypeReference<List<AnnouncementResponse>>() {})
+        .getBody();
+  }
+
+  private void seedAuditLog(Member admin, String action, Instant ignored) {
+    transactionTemplate.executeWithoutResult(
+        status ->
+            auditLogRepository.save(new AuditLog(admin, action, "TEST", null, null, "127.0.0.1")));
   }
 
   private HttpHeaders authedJson(Member admin) {

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSystemIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSystemIntegrationTest.java
@@ -1,0 +1,143 @@
+package com.gakkaweo.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.admin.dto.AnnouncementCreateRequest;
+import com.gakkaweo.backend.admin.dto.AnnouncementResponse;
+import com.gakkaweo.backend.admin.dto.AuditLogListResponse;
+import com.gakkaweo.backend.admin.dto.SystemStatusResponse;
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.time.Clock;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("Admin 시스템 관리 통합 테스트")
+class AdminSystemIntegrationTest extends IntegrationTestBase {
+
+  @Autowired Clock clock;
+
+  @Test
+  @DisplayName("공지 등록 - 201 + 목록 조회")
+  void 공지_CRUD() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+
+    AnnouncementCreateRequest request =
+        new AnnouncementCreateRequest(
+            "테스트 공지", "내용", "INFO", clock.instant(), clock.instant().plus(Duration.ofDays(1)));
+
+    ResponseEntity<AnnouncementResponse> created =
+        restTemplate.exchange(
+            url("/admin/system/announcements"),
+            HttpMethod.POST,
+            new HttpEntity<>(request, headers),
+            AnnouncementResponse.class);
+
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(created.getBody().title()).isEqualTo("테스트 공지");
+    assertThat(created.getBody().type()).isEqualTo("INFO");
+  }
+
+  @Test
+  @DisplayName("공지 수정 - 존재하지 않는 ID 404 ANNOUNCEMENT_NOT_FOUND")
+  void 공지없음_404() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+
+    String body = "{\"title\":\"바뀐 제목\"}";
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/system/announcements/99999"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(body, headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody().code()).isEqualTo("ANNOUNCEMENT_NOT_FOUND");
+  }
+
+  @Test
+  @DisplayName("시스템 상태 조회 - sseConnectionCount 등 반환")
+  void 시스템상태() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<SystemStatusResponse> response =
+        restTemplate.exchange(
+            url("/admin/system/status"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            SystemStatusResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().sseConnectionCount()).isGreaterThanOrEqualTo(0);
+    assertThat(response.getBody().redisHealthy()).isTrue();
+  }
+
+  @Test
+  @DisplayName("랭킹 캐시 리셋 - 200")
+  void 랭킹캐시_리셋() {
+    testAuthHelper.createTodaySentence("오늘 문장");
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/system/ranking-cache/reset"),
+            HttpMethod.POST,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("Rate Limit 리셋 - 200")
+  void 레이트리밋_리셋() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/system/rate-limit/reset"),
+            HttpMethod.POST,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("감사 로그 조회 - 페이지네이션")
+  void 감사로그_조회() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<AuditLogListResponse> response =
+        restTemplate.exchange(
+            url("/admin/system/audit-logs?page=0&size=10"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            AuditLogListResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().content()).isNotNull();
+  }
+
+  private HttpHeaders authedJson(Member admin) {
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminUserIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminUserIntegrationTest.java
@@ -1,0 +1,242 @@
+package com.gakkaweo.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.admin.dto.AdminUserResponse;
+import com.gakkaweo.backend.admin.dto.ForceNicknameRequest;
+import com.gakkaweo.backend.admin.dto.RoleChangeRequest;
+import com.gakkaweo.backend.admin.dto.UserDetailResponse;
+import com.gakkaweo.backend.admin.dto.UserGameHistoryResponse;
+import com.gakkaweo.backend.admin.dto.UserListResponse;
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("Admin 사용자 관리 통합 테스트")
+class AdminUserIntegrationTest extends IntegrationTestBase {
+
+  @Autowired MemberRepository memberRepository;
+
+  @Test
+  @DisplayName("역할 변경 - USER → ADMIN 성공")
+  void 역할변경_성공() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<AdminUserResponse> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/role"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new RoleChangeRequest("ADMIN"), headers),
+            AdminUserResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().role()).isEqualTo("ADMIN");
+  }
+
+  @Test
+  @DisplayName("역할 변경 - 자기 자신 400 ADMIN_SELF_ACTION")
+  void 자기자신_400() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + admin.getPublicId() + "/role"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new RoleChangeRequest("USER"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("ADMIN_SELF_ACTION");
+  }
+
+  @Test
+  @DisplayName("역할 변경 - 이미 동일 400 ROLE_ALREADY_ASSIGNED")
+  void 동일역할_400() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/role"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new RoleChangeRequest("USER"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("ROLE_ALREADY_ASSIGNED");
+  }
+
+  @Test
+  @DisplayName("차단 - 차단 상태 true + bannedAt 기록")
+  void 차단_성공() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/ban"),
+            HttpMethod.POST,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    Member reloaded = memberRepository.findByPublicId(target.getPublicId()).orElseThrow();
+    assertThat(reloaded.getBanned()).isTrue();
+    assertThat(reloaded.getBannedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("차단 해제 - banned=false + bannedAt=null")
+  void 차단해제() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createBannedMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/ban"),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    Member reloaded = memberRepository.findByPublicId(target.getPublicId()).orElseThrow();
+    assertThat(reloaded.getBanned()).isFalse();
+    assertThat(reloaded.getBannedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("강제 탈퇴 - 사용자 삭제")
+  void 강제탈퇴() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId()),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(memberRepository.findByPublicId(target.getPublicId())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("닉네임 강제 변경 - 중복 409 NICKNAME_DUPLICATED")
+  void 닉네임_중복() {
+    Member admin = testAuthHelper.createAdmin();
+    Member existing = testAuthHelper.createMember();
+    Member target = testAuthHelper.createMember();
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/nickname"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new ForceNicknameRequest(existing.getNickname()), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody().code()).isEqualTo("NICKNAME_DUPLICATED");
+  }
+
+  @Test
+  @DisplayName("프로필 이미지 강제 삭제 - 200 + profileUrl null")
+  void 프로필_강제삭제() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    target.setProfileUrl("/uploads/profile.webp");
+    memberRepository.save(target);
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/profile-image"),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    Member reloaded = memberRepository.findByPublicId(target.getPublicId()).orElseThrow();
+    assertThat(reloaded.getProfileUrl()).isNull();
+  }
+
+  @Test
+  @DisplayName("사용자 목록 조회 - 닉네임 필터")
+  void 목록_닉네임_필터() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<UserListResponse> response =
+        restTemplate.exchange(
+            url("/admin/users?page=0&size=20"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            UserListResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().users()).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("사용자 상세 조회 - ActivitySummary 포함")
+  void 상세_200() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<UserDetailResponse> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId()),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            UserDetailResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().publicId()).isEqualTo(target.getPublicId());
+    assertThat(response.getBody().activity()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("사용자 게임 이력 조회 - 세션 없으면 빈 목록")
+  void 게임이력_빈() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<UserGameHistoryResponse> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/history"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            UserGameHistoryResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().history()).isEmpty();
+  }
+
+  private HttpHeaders authedJson(Member admin) {
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminUserIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminUserIntegrationTest.java
@@ -10,7 +10,10 @@ import com.gakkaweo.backend.admin.dto.UserGameHistoryResponse;
 import com.gakkaweo.backend.admin.dto.UserListResponse;
 import com.gakkaweo.backend.common.exception.ErrorBody;
 import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.entity.SocialAccount;
+import com.gakkaweo.backend.domain.member.entity.SocialProvider;
 import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
 import com.gakkaweo.backend.support.IntegrationTestBase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,11 +24,14 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @DisplayName("Admin 사용자 관리 통합 테스트")
 class AdminUserIntegrationTest extends IntegrationTestBase {
 
   @Autowired MemberRepository memberRepository;
+  @Autowired SocialAccountRepository socialAccountRepository;
+  @Autowired TransactionTemplate transactionTemplate;
 
   @Test
   @DisplayName("역할 변경 - USER → ADMIN 성공")
@@ -232,6 +238,105 @@ class AdminUserIntegrationTest extends IntegrationTestBase {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody().history()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("목록 조회 - nickname 필터 매칭")
+  void 목록_nickname_필터() {
+    Member admin = testAuthHelper.createAdmin();
+    Member match = testAuthHelper.createMember();
+    testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<UserListResponse> response =
+        restTemplate.exchange(
+            url("/admin/users?nickname=" + match.getNickname() + "&page=0&size=20"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            UserListResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().users())
+        .extracting(AdminUserResponse::nickname)
+        .contains(match.getNickname());
+  }
+
+  @Test
+  @DisplayName("목록 조회 - banned=true 필터")
+  void 목록_banned_필터() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createBannedMember();
+    testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<UserListResponse> response =
+        restTemplate.exchange(
+            url("/admin/users?banned=true&page=0&size=20"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            UserListResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().users()).allSatisfy(user -> assertThat(user.banned()).isTrue());
+  }
+
+  @Test
+  @DisplayName("닉네임 강제 변경 - 정상 200")
+  void 닉네임_변경_성공() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<AdminUserResponse> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/nickname"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new ForceNicknameRequest("새닉네임"), headers),
+            AdminUserResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().nickname()).isEqualTo("새닉네임");
+  }
+
+  @Test
+  @DisplayName("사용자 상세 - 소셜 계정 provider=KAKAO")
+  void 상세_소셜() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    transactionTemplate.executeWithoutResult(
+        status ->
+            socialAccountRepository.save(
+                new SocialAccount(target, SocialProvider.KAKAO, "kakao-test-id")));
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    ResponseEntity<UserDetailResponse> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId()),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            UserDetailResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().provider()).isEqualTo("KAKAO");
+  }
+
+  @Test
+  @DisplayName("사용자 상세 - 로컬 계정 provider=LOCAL")
+  void 상세_로컬() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    testAuthHelper.createLocalAccount(target, "localuser", "pass1234!");
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    ResponseEntity<UserDetailResponse> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId()),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            UserDetailResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().provider()).isEqualTo("LOCAL");
   }
 
   private HttpHeaders authedJson(Member admin) {

--- a/backend/src/test/java/com/gakkaweo/backend/announcement/AnnouncementPublicEndpointTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/announcement/AnnouncementPublicEndpointTest.java
@@ -1,0 +1,130 @@
+package com.gakkaweo.backend.announcement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.domain.admin.entity.Announcement;
+import com.gakkaweo.backend.domain.admin.entity.AnnouncementType;
+import com.gakkaweo.backend.domain.admin.repository.AnnouncementRepository;
+import com.gakkaweo.backend.dto.ActiveAnnouncementResponse;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import com.gakkaweo.backend.support.TestClock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@DisplayName("공지 공개 엔드포인트 통합 테스트")
+class AnnouncementPublicEndpointTest extends IntegrationTestBase {
+
+  @Autowired AnnouncementRepository announcementRepository;
+  @Autowired TransactionTemplate transactionTemplate;
+
+  private static final ParameterizedTypeReference<List<ActiveAnnouncementResponse>> RESPONSE_TYPE =
+      new ParameterizedTypeReference<>() {};
+
+  @Test
+  @DisplayName("미인증 호출 - 200 + 활성 공지 반환")
+  void 미인증_200() {
+    Instant now = clock.instant();
+    saveAnnouncement("활성 공지", AnnouncementType.INFO, true, now.minusSeconds(60), null);
+
+    ResponseEntity<List<ActiveAnnouncementResponse>> response =
+        restTemplate.exchange(url("/announcements/active"), HttpMethod.GET, null, RESPONSE_TYPE);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).hasSize(1);
+    ActiveAnnouncementResponse body = response.getBody().get(0);
+    assertThat(body.title()).isEqualTo("활성 공지");
+    assertThat(body.type()).isEqualTo("INFO");
+    assertThat(body.content()).isNull();
+  }
+
+  @Test
+  @DisplayName("시작 시각 미래 - 제외")
+  void 시작시각_미래_제외() {
+    Instant now = clock.instant();
+    saveAnnouncement("미래 공지", AnnouncementType.INFO, true, now.plusSeconds(3600), null);
+
+    List<ActiveAnnouncementResponse> body = fetchActive();
+
+    assertThat(body).isEmpty();
+  }
+
+  @Test
+  @DisplayName("종료 시각 과거 - 제외")
+  void 종료시각_과거_제외() {
+    Instant now = clock.instant();
+    saveAnnouncement(
+        "만료 공지",
+        AnnouncementType.WARNING,
+        true,
+        now.minus(Duration.ofDays(2)),
+        now.minusSeconds(60));
+
+    List<ActiveAnnouncementResponse> body = fetchActive();
+
+    assertThat(body).isEmpty();
+  }
+
+  @Test
+  @DisplayName("endsAt null - 포함")
+  void endsAt_null_포함() {
+    Instant now = clock.instant();
+    saveAnnouncement("무기한 공지", AnnouncementType.MAINTENANCE, true, now.minusSeconds(60), null);
+
+    List<ActiveAnnouncementResponse> body = fetchActive();
+
+    assertThat(body).hasSize(1);
+    assertThat(body.get(0).type()).isEqualTo("MAINTENANCE");
+    assertThat(body.get(0).endsAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("active=false - 제외")
+  void 비활성_제외() {
+    Instant now = clock.instant();
+    saveAnnouncement("꺼진 공지", AnnouncementType.INFO, false, now.minusSeconds(60), null);
+
+    List<ActiveAnnouncementResponse> body = fetchActive();
+
+    assertThat(body).isEmpty();
+  }
+
+  @Test
+  @DisplayName("여러 공지 - createdAt DESC 정렬")
+  void 정렬_검증() {
+    Instant now = clock.instant();
+    saveAnnouncement("먼저", AnnouncementType.INFO, true, now.minusSeconds(120), null);
+    if (clock instanceof TestClock testClock) {
+      testClock.advanceBy(Duration.ofSeconds(1));
+    }
+    saveAnnouncement("나중", AnnouncementType.INFO, true, now.minusSeconds(60), null);
+
+    List<ActiveAnnouncementResponse> body = fetchActive();
+
+    assertThat(body).extracting(ActiveAnnouncementResponse::title).containsExactly("나중", "먼저");
+  }
+
+  private List<ActiveAnnouncementResponse> fetchActive() {
+    return restTemplate
+        .exchange(url("/announcements/active"), HttpMethod.GET, null, RESPONSE_TYPE)
+        .getBody();
+  }
+
+  private void saveAnnouncement(
+      String title, AnnouncementType type, boolean active, Instant startsAt, Instant endsAt) {
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          Announcement announcement = new Announcement(null, title, null, type, startsAt, endsAt);
+          announcement.setActive(active);
+          announcementRepository.save(announcement);
+        });
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/AccountDeletionTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/AccountDeletionTest.java
@@ -1,0 +1,62 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.auth.dto.TokenPair;
+import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.repository.LocalAccountRepository;
+import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("회원 탈퇴 통합 테스트")
+class AccountDeletionTest extends IntegrationTestBase {
+
+  @Autowired MemberRepository memberRepository;
+  @Autowired LocalAccountRepository localAccountRepository;
+  @Autowired RefreshTokenRepository refreshTokenRepository;
+
+  @Test
+  @DisplayName("탈퇴 - 200 + 쿠키 삭제 + cascade 삭제")
+  void 탈퇴_성공() {
+    Member member = testAuthHelper.createMember();
+    testAuthHelper.createLocalAccount(member, "deluser", "password123");
+    TokenPair tokens = testAuthHelper.issueTokens(member);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(
+        HttpHeaders.COOKIE,
+        "access_token="
+            + tokens.accessToken()
+            + "; refresh_token="
+            + tokens.refreshToken()
+            + "; has_session=1");
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/auth/account"), HttpMethod.DELETE, new HttpEntity<>(headers), Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    // 쿠키 삭제(MaxAge=0) 3종
+    List<String> cookies = response.getHeaders().get(HttpHeaders.SET_COOKIE);
+    assertThat(cookies).isNotNull();
+    assertThat(cookies.stream().filter(c -> c.contains("Max-Age=0")).count())
+        .isGreaterThanOrEqualTo(3);
+
+    UUID publicId = member.getPublicId();
+    assertThat(memberRepository.findByPublicId(publicId)).isEmpty();
+    assertThat(localAccountRepository.existsByMember(member)).isFalse();
+    assertThat(refreshTokenRepository.findByMemberId(member.getId())).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/AuthIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/AuthIntegrationTest.java
@@ -1,0 +1,173 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.auth.dto.AuthResponse;
+import com.gakkaweo.backend.auth.dto.LoginRequest;
+import com.gakkaweo.backend.auth.dto.RegisterRequest;
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("인증 플로우 통합 테스트")
+class AuthIntegrationTest extends IntegrationTestBase {
+
+  @Nested
+  @DisplayName("회원가입")
+  class Register {
+
+    @Test
+    @DisplayName("성공 - 201 + 쿠키 3종 발급")
+    void 성공_201() {
+      RegisterRequest request = new RegisterRequest("testuser", "password123");
+
+      ResponseEntity<AuthResponse> response =
+          restTemplate.postForEntity(url("/auth/register"), request, AuthResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody().role()).isEqualTo("USER");
+
+      java.util.List<String> cookies = response.getHeaders().get(HttpHeaders.SET_COOKIE);
+      assertThat(cookies).isNotNull();
+      assertThat(cookies.stream().anyMatch(c -> c.startsWith("access_token="))).isTrue();
+      assertThat(cookies.stream().anyMatch(c -> c.startsWith("refresh_token="))).isTrue();
+      assertThat(cookies.stream().anyMatch(c -> c.startsWith("has_session="))).isTrue();
+    }
+
+    @Test
+    @DisplayName("중복 아이디 - 409 DUPLICATE_USERNAME")
+    void 중복_409() {
+      RegisterRequest request = new RegisterRequest("dupuser", "password123");
+      restTemplate.postForEntity(url("/auth/register"), request, AuthResponse.class);
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.postForEntity(url("/auth/register"), request, ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+      assertThat(response.getBody().code()).isEqualTo("DUPLICATE_USERNAME");
+    }
+
+    @Test
+    @DisplayName("유효성 실패 - 400 VALIDATION_FAILED")
+    void 검증실패_400() {
+      RegisterRequest request = new RegisterRequest("1badstart", "password123");
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.postForEntity(url("/auth/register"), request, ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+    }
+  }
+
+  @Nested
+  @DisplayName("로그인")
+  class Login {
+
+    @Test
+    @DisplayName("성공 - 200 + 쿠키")
+    void 성공_200() {
+      Member member = testAuthHelper.createMember();
+      testAuthHelper.createLocalAccount(member, "loginuser", "password123");
+
+      ResponseEntity<AuthResponse> response =
+          restTemplate.postForEntity(
+              url("/auth/login"), new LoginRequest("loginuser", "password123"), AuthResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().publicId()).isEqualTo(member.getPublicId());
+    }
+
+    @Test
+    @DisplayName("비밀번호 오류 - 401 INVALID_CREDENTIALS")
+    void 비밀번호오류_401() {
+      Member member = testAuthHelper.createMember();
+      testAuthHelper.createLocalAccount(member, "wronguser", "password123");
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.postForEntity(
+              url("/auth/login"), new LoginRequest("wronguser", "wrongpassword"), ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+      assertThat(response.getBody().code()).isEqualTo("INVALID_CREDENTIALS");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 계정 - 401 INVALID_CREDENTIALS")
+    void 미존재_401() {
+      ResponseEntity<ErrorBody> response =
+          restTemplate.postForEntity(
+              url("/auth/login"), new LoginRequest("ghost", "password123"), ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+      assertThat(response.getBody().code()).isEqualTo("INVALID_CREDENTIALS");
+    }
+
+    @Test
+    @DisplayName("차단 계정 - 403 MEMBER_BANNED")
+    void 차단계정_403() {
+      Member member = testAuthHelper.createBannedMember();
+      testAuthHelper.createLocalAccount(member, "banneduser", "password123");
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.postForEntity(
+              url("/auth/login"), new LoginRequest("banneduser", "password123"), ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+      assertThat(response.getBody().code()).isEqualTo("MEMBER_BANNED");
+    }
+  }
+
+  @Nested
+  @DisplayName("내 정보 조회 / 로그아웃")
+  class MeLogout {
+
+    @Test
+    @DisplayName("쿠키 인증 me - 200")
+    void me_200() {
+      Member member = testAuthHelper.createMember();
+      HttpHeaders headers = testAuthHelper.cookieHeaderFor(member);
+
+      ResponseEntity<AuthResponse> response =
+          restTemplate.exchange(
+              url("/auth/me"), HttpMethod.GET, new HttpEntity<>(headers), AuthResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().publicId()).isEqualTo(member.getPublicId());
+    }
+
+    @Test
+    @DisplayName("미인증 me - 401")
+    void me_401() {
+      ResponseEntity<ErrorBody> response =
+          restTemplate.getForEntity(url("/auth/me"), ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("로그아웃 - 200 + 쿠키 삭제(MaxAge=0)")
+    void 로그아웃_200() {
+      Member member = testAuthHelper.createMember();
+      HttpHeaders headers = testAuthHelper.cookieHeaderFor(member);
+
+      ResponseEntity<Void> response =
+          restTemplate.exchange(
+              url("/auth/logout"), HttpMethod.POST, new HttpEntity<>(headers), Void.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      java.util.List<String> cookies = response.getHeaders().get(HttpHeaders.SET_COOKIE);
+      assertThat(cookies).isNotNull();
+      assertThat(cookies.stream().anyMatch(c -> c.contains("Max-Age=0"))).isTrue();
+    }
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/CookieAttributeTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/CookieAttributeTest.java
@@ -1,0 +1,59 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.auth.dto.AuthResponse;
+import com.gakkaweo.backend.auth.dto.RegisterRequest;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("쿠키 속성 통합 테스트")
+class CookieAttributeTest extends IntegrationTestBase {
+
+  @Test
+  @DisplayName("회원가입 시 access/refresh/has_session 쿠키 속성 검증")
+  void 쿠키속성_검증() {
+    ResponseEntity<AuthResponse> response =
+        restTemplate.postForEntity(
+            url("/auth/register"),
+            new RegisterRequest("cookieuser", "password123"),
+            AuthResponse.class);
+
+    List<String> cookies = response.getHeaders().get(HttpHeaders.SET_COOKIE);
+    assertThat(cookies).isNotNull();
+
+    Map<String, String> byName = indexByName(cookies);
+
+    String access = byName.get("access_token");
+    assertThat(access).isNotNull();
+    assertThat(access).containsIgnoringCase("HttpOnly");
+    assertThat(access).contains("Path=/");
+    assertThat(access).containsIgnoringCase("SameSite=Lax");
+
+    String refresh = byName.get("refresh_token");
+    assertThat(refresh).isNotNull();
+    assertThat(refresh).containsIgnoringCase("HttpOnly");
+    assertThat(refresh).contains("Path=/auth/refresh");
+    assertThat(refresh).containsIgnoringCase("SameSite=Lax");
+
+    String session = byName.get("has_session");
+    assertThat(session).isNotNull();
+    assertThat(session).doesNotContainIgnoringCase("HttpOnly");
+    assertThat(session).contains("Path=/");
+  }
+
+  private Map<String, String> indexByName(List<String> setCookieHeaders) {
+    return setCookieHeaders.stream()
+        .collect(
+            java.util.stream.Collectors.toMap(
+                h -> h.substring(0, h.indexOf('=')),
+                h -> h,
+                (a, b) -> a,
+                java.util.LinkedHashMap::new));
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/CookieAuthorizationRequestRepositoryTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/CookieAuthorizationRequestRepositoryTest.java
@@ -1,0 +1,192 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gakkaweo.backend.auth.config.CookieProperties;
+import com.gakkaweo.backend.auth.oauth2.CookieAuthorizationRequestRepository;
+import jakarta.servlet.http.Cookie;
+import java.net.HttpCookie;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+@DisplayName("CookieAuthorizationRequestRepository 단위 테스트")
+class CookieAuthorizationRequestRepositoryTest {
+
+  private static final String COOKIE_NAME = "oauth2_auth_request";
+
+  private CookieAuthorizationRequestRepository repository;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    repository =
+        new CookieAuthorizationRequestRepository(
+            new CookieProperties(true, "example.com"), objectMapper);
+  }
+
+  @Test
+  @DisplayName("쿠키 없음 - load null 반환")
+  void 쿠키_없음_null() {
+    OAuth2AuthorizationRequest loaded =
+        repository.loadAuthorizationRequest(new MockHttpServletRequest());
+
+    assertThat(loaded).isNull();
+  }
+
+  @Test
+  @DisplayName("다른 쿠키만 존재 - load null 반환")
+  void 다른_쿠키만_null() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setCookies(new Cookie("unrelated", "value"));
+
+    OAuth2AuthorizationRequest loaded = repository.loadAuthorizationRequest(request);
+
+    assertThat(loaded).isNull();
+  }
+
+  @Test
+  @DisplayName("save 후 load - 라운드트립 복원")
+  void 라운드트립() {
+    OAuth2AuthorizationRequest original = sampleRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    repository.saveAuthorizationRequest(original, new MockHttpServletRequest(), response);
+
+    HttpCookie parsed = firstSetCookie(response);
+    assertThat(parsed.getName()).isEqualTo(COOKIE_NAME);
+    assertThat(parsed.getMaxAge()).isEqualTo(300);
+    assertThat(parsed.getSecure()).isTrue();
+    assertThat(parsed.isHttpOnly()).isTrue();
+
+    MockHttpServletRequest loadRequest = new MockHttpServletRequest();
+    loadRequest.setCookies(new Cookie(parsed.getName(), parsed.getValue()));
+    OAuth2AuthorizationRequest loaded = repository.loadAuthorizationRequest(loadRequest);
+
+    assertThat(loaded).isNotNull();
+    assertThat(loaded.getAuthorizationUri()).isEqualTo(original.getAuthorizationUri());
+    assertThat(loaded.getClientId()).isEqualTo(original.getClientId());
+    assertThat(loaded.getRedirectUri()).isEqualTo(original.getRedirectUri());
+    assertThat(loaded.getState()).isEqualTo(original.getState());
+    assertThat(loaded.getScopes()).containsExactlyInAnyOrderElementsOf(original.getScopes());
+  }
+
+  @Test
+  @DisplayName("save null 인자 - 쿠키 삭제 헤더 발급")
+  void save_null_삭제() {
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    repository.saveAuthorizationRequest(null, new MockHttpServletRequest(), response);
+
+    HttpCookie parsed = firstSetCookie(response);
+    assertThat(parsed.getMaxAge()).isZero();
+    assertThat(parsed.getValue()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("remove - 저장된 값 반환 후 삭제 쿠키 발급")
+  void remove_반환_후_삭제() {
+    OAuth2AuthorizationRequest original = sampleRequest();
+    MockHttpServletResponse saveResponse = new MockHttpServletResponse();
+    repository.saveAuthorizationRequest(original, new MockHttpServletRequest(), saveResponse);
+    HttpCookie saved = firstSetCookie(saveResponse);
+
+    MockHttpServletRequest removeRequest = new MockHttpServletRequest();
+    removeRequest.setCookies(new Cookie(saved.getName(), saved.getValue()));
+    MockHttpServletResponse removeResponse = new MockHttpServletResponse();
+
+    OAuth2AuthorizationRequest removed =
+        repository.removeAuthorizationRequest(removeRequest, removeResponse);
+
+    assertThat(removed).isNotNull();
+    assertThat(removed.getState()).isEqualTo(original.getState());
+
+    HttpCookie deleted = firstSetCookie(removeResponse);
+    assertThat(deleted.getMaxAge()).isZero();
+  }
+
+  @Test
+  @DisplayName("remove - 쿠키 없을 때 null 반환 + 삭제 쿠키 발급 안 함")
+  void remove_쿠키없음() {
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    OAuth2AuthorizationRequest removed =
+        repository.removeAuthorizationRequest(new MockHttpServletRequest(), response);
+
+    assertThat(removed).isNull();
+    assertThat(response.getHeaders(HttpHeaders.SET_COOKIE)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("deleteCookie - 단독 호출 시 만료 헤더 발급")
+  void deleteCookie_단독() {
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    repository.deleteCookie(response);
+
+    HttpCookie parsed = firstSetCookie(response);
+    assertThat(parsed.getMaxAge()).isZero();
+  }
+
+  @Test
+  @DisplayName("잘못된 쿠키 값 - IllegalStateException")
+  void 역직렬화_실패() {
+    // Base64 URL-safe 디코딩은 성공하지만 JSON 역직렬화 단계에서 IOException 유발
+    String invalidJsonBase64 =
+        Base64.getUrlEncoder().encodeToString("not-json-content".getBytes(StandardCharsets.UTF_8));
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setCookies(new Cookie(COOKIE_NAME, invalidJsonBase64));
+
+    assertThatThrownBy(() -> repository.loadAuthorizationRequest(request))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("역직렬화 실패");
+  }
+
+  @Test
+  @DisplayName("secure=false 설정 - 쿠키 secure 플래그 미설정")
+  void secure_false() {
+    CookieAuthorizationRequestRepository insecureRepository =
+        new CookieAuthorizationRequestRepository(
+            new CookieProperties(false, "example.com"), objectMapper);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    insecureRepository.saveAuthorizationRequest(
+        sampleRequest(), new MockHttpServletRequest(), response);
+
+    HttpCookie parsed = firstSetCookie(response);
+    assertThat(parsed.getSecure()).isFalse();
+  }
+
+  private OAuth2AuthorizationRequest sampleRequest() {
+    return OAuth2AuthorizationRequest.authorizationCode()
+        .authorizationUri("https://provider.example/authorize")
+        .clientId("client-1")
+        .redirectUri("https://gakkaweo.example/callback")
+        .scopes(Set.of("profile", "email"))
+        .state("state-xyz")
+        .additionalParameters(Map.of("nonce", "n-1"))
+        .authorizationRequestUri("https://provider.example/authorize?state=state-xyz")
+        .attributes(attrs -> attrs.put("registration_id", "kakao"))
+        .build();
+  }
+
+  private HttpCookie firstSetCookie(MockHttpServletResponse response) {
+    String header = response.getHeader(HttpHeaders.SET_COOKIE);
+    assertThat(header).as("Set-Cookie header").isNotNull();
+    List<HttpCookie> parsed = HttpCookie.parse(header);
+    assertThat(parsed).isNotEmpty();
+    return parsed.stream().filter(c -> COOKIE_NAME.equals(c.getName())).findFirst().orElseThrow();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/CookieUtilsTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/CookieUtilsTest.java
@@ -1,0 +1,82 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.auth.config.CookieProperties;
+import com.gakkaweo.backend.auth.config.JwtProperties;
+import com.gakkaweo.backend.auth.util.CookieUtils;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+
+@DisplayName("CookieUtils 단위 테스트")
+class CookieUtilsTest {
+
+  private static final JwtProperties jwtProperties =
+      new JwtProperties("secret", Duration.ofMinutes(30), Duration.ofDays(7));
+
+  @Test
+  @DisplayName("createAccessTokenCookie - HttpOnly, Path=/, Secure=false")
+  void access_기본속성() {
+    CookieUtils utils = new CookieUtils(jwtProperties, new CookieProperties(false, ""));
+    ResponseCookie cookie = utils.createAccessTokenCookie("token-value");
+
+    assertThat(cookie.getName()).isEqualTo("access_token");
+    assertThat(cookie.getValue()).isEqualTo("token-value");
+    assertThat(cookie.isHttpOnly()).isTrue();
+    assertThat(cookie.getPath()).isEqualTo("/");
+    assertThat(cookie.isSecure()).isFalse();
+    assertThat(cookie.getMaxAge()).isEqualTo(Duration.ofMinutes(30));
+  }
+
+  @Test
+  @DisplayName("createRefreshTokenCookie - Path=/auth/refresh")
+  void refresh_path() {
+    CookieUtils utils = new CookieUtils(jwtProperties, new CookieProperties(false, ""));
+    ResponseCookie cookie = utils.createRefreshTokenCookie("rt-value");
+
+    assertThat(cookie.getPath()).isEqualTo("/auth/refresh");
+    assertThat(cookie.isHttpOnly()).isTrue();
+  }
+
+  @Test
+  @DisplayName("createSessionIndicatorCookie - HttpOnly=false, Path=/")
+  void session_indicator() {
+    CookieUtils utils = new CookieUtils(jwtProperties, new CookieProperties(false, ""));
+    ResponseCookie cookie = utils.createSessionIndicatorCookie();
+
+    assertThat(cookie.getName()).isEqualTo("has_session");
+    assertThat(cookie.isHttpOnly()).isFalse();
+    assertThat(cookie.getPath()).isEqualTo("/");
+  }
+
+  @Test
+  @DisplayName("deleteXxxCookie - MaxAge=0")
+  void delete_max_age_0() {
+    CookieUtils utils = new CookieUtils(jwtProperties, new CookieProperties(false, ""));
+
+    assertThat(utils.deleteAccessTokenCookie().getMaxAge().getSeconds()).isEqualTo(0);
+    assertThat(utils.deleteRefreshTokenCookie().getMaxAge().getSeconds()).isEqualTo(0);
+    assertThat(utils.deleteSessionIndicatorCookie().getMaxAge().getSeconds()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("domain 설정 - 도메인 값이 쿠키에 반영")
+  void domain_적용() {
+    CookieUtils utils = new CookieUtils(jwtProperties, new CookieProperties(true, "example.com"));
+    ResponseCookie cookie = utils.createAccessTokenCookie("t");
+
+    assertThat(cookie.getDomain()).isEqualTo("example.com");
+    assertThat(cookie.isSecure()).isTrue();
+  }
+
+  @Test
+  @DisplayName("domain 빈 문자열 - 쿠키에 domain 미설정")
+  void domain_빈_문자열() {
+    CookieUtils utils = new CookieUtils(jwtProperties, new CookieProperties(false, ""));
+    ResponseCookie cookie = utils.createAccessTokenCookie("t");
+
+    assertThat(cookie.getDomain()).isNull();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/CustomOAuth2UserServiceTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,148 @@
+package com.gakkaweo.backend.auth;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.gakkaweo.backend.auth.oauth2.CustomOAuth2User;
+import com.gakkaweo.backend.auth.oauth2.dto.OAuthAttributes;
+import com.gakkaweo.backend.auth.oauth2.service.CustomOAuth2UserService;
+import com.gakkaweo.backend.auth.oauth2.service.OAuthMemberService;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@DisplayName("CustomOAuth2UserService 단위 테스트")
+class CustomOAuth2UserServiceTest {
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance()
+          .options(WireMockConfiguration.wireMockConfig().dynamicPort())
+          .build();
+
+  private OAuthMemberService oAuthMemberService;
+  private CustomOAuth2UserService service;
+
+  @BeforeEach
+  void setUp() {
+    oAuthMemberService = Mockito.mock(OAuthMemberService.class);
+    service = new CustomOAuth2UserService(oAuthMemberService);
+  }
+
+  @Test
+  @DisplayName("kakao 정상 로드 - CustomOAuth2User 반환")
+  void kakao_정상() {
+    wireMock.stubFor(
+        get(urlEqualTo("/userinfo"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        """
+                        {
+                          "id": 98765,
+                          "kakao_account": {"email": "user@kakao.com"}
+                        }
+                        """)));
+    Member member = new Member("tester");
+    when(oAuthMemberService.findOrCreateMember(any(OAuthAttributes.class))).thenReturn(member);
+
+    OAuth2User result = service.loadUser(userRequest("kakao", "id"));
+
+    assertThat(result).isInstanceOf(CustomOAuth2User.class);
+    assertThat(((CustomOAuth2User) result).getMember()).isSameAs(member);
+    assertThat(result.getAttributes()).containsKey("kakao_account");
+  }
+
+  @Test
+  @DisplayName("google 정상 로드 - CustomOAuth2User 반환")
+  void google_정상() {
+    wireMock.stubFor(
+        get(urlEqualTo("/userinfo"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        """
+                        {"sub": "g-123", "email": "user@google.com"}
+                        """)));
+    Member member = new Member("tester");
+    when(oAuthMemberService.findOrCreateMember(any(OAuthAttributes.class))).thenReturn(member);
+
+    OAuth2User result = service.loadUser(userRequest("google", "sub"));
+
+    assertThat(result).isInstanceOf(CustomOAuth2User.class);
+    assertThat(((CustomOAuth2User) result).getMember()).isSameAs(member);
+  }
+
+  @Test
+  @DisplayName("banned 회원 - OAuth2AuthenticationException(member_banned)")
+  void banned_예외() {
+    wireMock.stubFor(
+        get(urlEqualTo("/userinfo"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        """
+                        {
+                          "id": 11111,
+                          "kakao_account": {"email": "banned@kakao.com"}
+                        }
+                        """)));
+    Member banned = new Member("banned");
+    banned.setBanned(true);
+    banned.setBannedAt(Instant.now());
+    when(oAuthMemberService.findOrCreateMember(any(OAuthAttributes.class))).thenReturn(banned);
+
+    assertThatThrownBy(() -> service.loadUser(userRequest("kakao", "id")))
+        .isInstanceOf(OAuth2AuthenticationException.class)
+        .hasMessageContaining("차단된 계정입니다");
+  }
+
+  private OAuth2UserRequest userRequest(String registrationId, String userNameAttribute) {
+    ClientRegistration registration =
+        ClientRegistration.withRegistrationId(registrationId)
+            .clientId("test-client")
+            .clientSecret("test-secret")
+            .clientAuthenticationMethod(
+                org.springframework.security.oauth2.core.ClientAuthenticationMethod
+                    .CLIENT_SECRET_BASIC)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .scope("profile")
+            .authorizationUri("http://localhost/authorize")
+            .tokenUri("http://localhost/token")
+            .userInfoUri(wireMock.baseUrl() + "/userinfo")
+            .userNameAttributeName(userNameAttribute)
+            .build();
+
+    OAuth2AccessToken token =
+        new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            "fake-token",
+            Instant.now(),
+            Instant.now().plusSeconds(3600));
+    return new OAuth2UserRequest(registration, token);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/CustomOAuth2UserTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/CustomOAuth2UserTest.java
@@ -1,0 +1,61 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.auth.oauth2.CustomOAuth2User;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.entity.MemberRole;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CustomOAuth2User 단위 테스트")
+class CustomOAuth2UserTest {
+
+  @Test
+  @DisplayName("getAuthorities - USER role → ROLE_USER")
+  void user_권한() {
+    Member member = new Member("tester");
+    CustomOAuth2User user = new CustomOAuth2User(member, Map.of("id", "1"));
+
+    assertThat(user.getAuthorities()).extracting("authority").containsExactly("ROLE_USER");
+  }
+
+  @Test
+  @DisplayName("getAuthorities - ADMIN role → ROLE_ADMIN")
+  void admin_권한() {
+    Member member = new Member("admin");
+    member.setRole(MemberRole.ADMIN);
+    CustomOAuth2User user = new CustomOAuth2User(member, Map.of("id", "1"));
+
+    assertThat(user.getAuthorities()).extracting("authority").containsExactly("ROLE_ADMIN");
+  }
+
+  @Test
+  @DisplayName("getName - publicId 문자열")
+  void getName() {
+    Member member = new Member("tester");
+    CustomOAuth2User user = new CustomOAuth2User(member, Map.of("id", "1"));
+
+    assertThat(user.getName()).isEqualTo(member.getPublicId().toString());
+  }
+
+  @Test
+  @DisplayName("getAttributes - 생성자 인자 그대로 반환")
+  void attributes() {
+    Member member = new Member("tester");
+    Map<String, Object> attrs = Map.of("id", "1", "email", "user@example.com");
+    CustomOAuth2User user = new CustomOAuth2User(member, attrs);
+
+    assertThat(user.getAttributes()).isEqualTo(attrs);
+  }
+
+  @Test
+  @DisplayName("getMember - 생성자 인자 Member 반환")
+  void getMember() {
+    Member member = new Member("tester");
+    CustomOAuth2User user = new CustomOAuth2User(member, Map.of());
+
+    assertThat(user.getMember()).isSameAs(member);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/CustomUserDetailsTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/CustomUserDetailsTest.java
@@ -1,0 +1,45 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.auth.security.CustomUserDetails;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CustomUserDetails 단위 테스트")
+class CustomUserDetailsTest {
+
+  @Test
+  @DisplayName("USER role - ROLE_USER authority")
+  void user_권한() {
+    CustomUserDetails details = new CustomUserDetails(UUID.randomUUID(), "USER");
+
+    assertThat(details.getAuthorities()).extracting("authority").containsExactly("ROLE_USER");
+  }
+
+  @Test
+  @DisplayName("ADMIN role - ROLE_ADMIN authority")
+  void admin_권한() {
+    CustomUserDetails details = new CustomUserDetails(UUID.randomUUID(), "ADMIN");
+
+    assertThat(details.getAuthorities()).extracting("authority").containsExactly("ROLE_ADMIN");
+  }
+
+  @Test
+  @DisplayName("getPassword - null 반환")
+  void password_null() {
+    CustomUserDetails details = new CustomUserDetails(UUID.randomUUID(), "USER");
+
+    assertThat(details.getPassword()).isNull();
+  }
+
+  @Test
+  @DisplayName("getUsername - publicId 문자열 반환")
+  void username_publicId() {
+    UUID id = UUID.randomUUID();
+    CustomUserDetails details = new CustomUserDetails(id, "USER");
+
+    assertThat(details.getUsername()).isEqualTo(id.toString());
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/NicknameValidationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/NicknameValidationTest.java
@@ -1,0 +1,108 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.auth.dto.AuthResponse;
+import com.gakkaweo.backend.auth.dto.NicknameUpdateRequest;
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.service.NicknameGenerator;
+import com.gakkaweo.backend.domain.member.validation.NicknameValidator;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("닉네임 검증 통합 테스트")
+class NicknameValidationTest extends IntegrationTestBase {
+
+  @Autowired NicknameValidator nicknameValidator;
+  @Autowired NicknameGenerator nicknameGenerator;
+
+  @Test
+  @DisplayName("정상 닉네임 변경 - 200")
+  void 정상변경_200() {
+    Member member = testAuthHelper.createMember();
+    ResponseEntity<AuthResponse> response = patchNickname(member, "새닉네임");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().nickname()).isEqualTo("새닉네임");
+  }
+
+  @Test
+  @DisplayName("현재와 동일 - 400 NICKNAME_UNCHANGED")
+  void 동일닉네임_400() {
+    Member member = testAuthHelper.createMember();
+    ResponseEntity<ErrorBody> response = patchNicknameExpectError(member, member.getNickname());
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("NICKNAME_UNCHANGED");
+  }
+
+  @Test
+  @DisplayName("중복 닉네임 - 409 NICKNAME_DUPLICATED")
+  void 중복_409() {
+    testAuthHelper.createMember(); // 기존 회원
+    Member existing = testAuthHelper.createMember();
+    Member me = testAuthHelper.createMember();
+
+    ResponseEntity<ErrorBody> response = patchNicknameExpectError(me, existing.getNickname());
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody().code()).isEqualTo("NICKNAME_DUPLICATED");
+  }
+
+  @Test
+  @DisplayName("금칙어 - 400 NICKNAME_FORBIDDEN")
+  void 금칙어_400() {
+    Member member = testAuthHelper.createMember();
+    ResponseEntity<ErrorBody> response = patchNicknameExpectError(member, "관리자");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("NICKNAME_FORBIDDEN");
+  }
+
+  @Test
+  @DisplayName("NicknameValidator - 금칙어/길이 검증")
+  void validator_단위검증() {
+    nicknameValidator.validate("정상닉네임");
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> nicknameValidator.validate("a"))
+        .hasMessageContaining("요청 검증");
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> nicknameValidator.validate("admin"))
+        .hasMessageContaining("사용할 수 없는 닉네임");
+  }
+
+  @Test
+  @DisplayName("NicknameGenerator - 생성된 닉네임이 validator 통과")
+  void generator_유효성() {
+    for (int i = 0; i < 10; i++) {
+      String nickname = nicknameGenerator.generate();
+      nicknameValidator.validate(nickname);
+      assertThat(nickname).isNotBlank();
+    }
+  }
+
+  private ResponseEntity<AuthResponse> patchNickname(Member member, String nickname) {
+    return exchange(member, nickname, AuthResponse.class);
+  }
+
+  private ResponseEntity<ErrorBody> patchNicknameExpectError(Member member, String nickname) {
+    return exchange(member, nickname, ErrorBody.class);
+  }
+
+  private <T> ResponseEntity<T> exchange(Member member, String nickname, Class<T> type) {
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(member);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<NicknameUpdateRequest> request =
+        new HttpEntity<>(new NicknameUpdateRequest(nickname), headers);
+    return restTemplate.exchange(url("/auth/nickname"), HttpMethod.PATCH, request, type);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/OAuth2LoginHandlerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/OAuth2LoginHandlerTest.java
@@ -1,0 +1,161 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gakkaweo.backend.auth.config.CookieProperties;
+import com.gakkaweo.backend.auth.config.JwtProperties;
+import com.gakkaweo.backend.auth.config.OAuth2Properties;
+import com.gakkaweo.backend.auth.dto.TokenPair;
+import com.gakkaweo.backend.auth.oauth2.CookieAuthorizationRequestRepository;
+import com.gakkaweo.backend.auth.oauth2.CustomOAuth2User;
+import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginFailureHandler;
+import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginSuccessHandler;
+import com.gakkaweo.backend.auth.service.AuthService;
+import com.gakkaweo.backend.auth.util.CookieUtils;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import java.net.HttpCookie;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+@DisplayName("OAuth2 로그인 Handler 단위 테스트")
+class OAuth2LoginHandlerTest {
+
+  private static final String REDIRECT_URI = "https://gakkaweo.example/oauth/callback";
+
+  private AuthService authService;
+  private CookieUtils cookieUtils;
+  private OAuth2Properties oAuth2Properties;
+  private CookieAuthorizationRequestRepository authorizationRequestRepository;
+
+  @BeforeEach
+  void setUp() {
+    authService = Mockito.mock(AuthService.class);
+    JwtProperties jwtProperties =
+        new JwtProperties(
+            "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=",
+            Duration.ofMinutes(30),
+            Duration.ofDays(14));
+    CookieProperties cookieProperties = new CookieProperties(true, "");
+    cookieUtils = new CookieUtils(jwtProperties, cookieProperties);
+    oAuth2Properties = new OAuth2Properties(REDIRECT_URI);
+    authorizationRequestRepository =
+        new CookieAuthorizationRequestRepository(cookieProperties, new ObjectMapper());
+  }
+
+  @Nested
+  @DisplayName("SuccessHandler")
+  class SuccessHandler {
+
+    @Test
+    @DisplayName("인증 성공 - access/refresh/has_session 3종 쿠키 + 리다이렉트")
+    void 성공_쿠키_리다이렉트() throws Exception {
+      OAuth2LoginSuccessHandler handler =
+          new OAuth2LoginSuccessHandler(
+              authService, cookieUtils, oAuth2Properties, authorizationRequestRepository);
+      Member member = new Member("tester");
+      when(authService.issueTokens(any(Member.class)))
+          .thenReturn(new TokenPair("access-value", "refresh-value"));
+
+      Authentication authentication =
+          new UsernamePasswordAuthenticationToken(
+              new CustomOAuth2User(member, Map.of("id", "1")), null);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      handler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
+
+      List<HttpCookie> setCookies = allSetCookies(response);
+      assertThat(setCookies)
+          .extracting(HttpCookie::getName)
+          .contains("access_token", "refresh_token", "has_session");
+      assertThat(findCookie(setCookies, "access_token").getValue()).isEqualTo("access-value");
+      assertThat(findCookie(setCookies, "refresh_token").getValue()).isEqualTo("refresh-value");
+      assertThat(findCookie(setCookies, "has_session").getValue()).isEqualTo("1");
+      assertThat(response.getRedirectedUrl()).isEqualTo(REDIRECT_URI);
+    }
+  }
+
+  @Nested
+  @DisplayName("FailureHandler")
+  class FailureHandler {
+
+    @Test
+    @DisplayName("예외 메시지 있음 - URLEncoded error 파라미터 포함 리다이렉트")
+    void 메시지_있음() throws Exception {
+      OAuth2LoginFailureHandler handler =
+          new OAuth2LoginFailureHandler(oAuth2Properties, authorizationRequestRepository);
+      AuthenticationException exception =
+          new OAuth2AuthenticationException(new OAuth2Error("member_banned", "차단된 계정입니다", null));
+
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      handler.onAuthenticationFailure(new MockHttpServletRequest(), response, exception);
+
+      String encoded = URLEncoder.encode("차단된 계정입니다", StandardCharsets.UTF_8);
+      assertThat(response.getRedirectedUrl()).isEqualTo(REDIRECT_URI + "?error=" + encoded);
+    }
+
+    @Test
+    @DisplayName("예외 메시지 null - 기본 메시지로 리다이렉트")
+    void 메시지_null() throws Exception {
+      OAuth2LoginFailureHandler handler =
+          new OAuth2LoginFailureHandler(oAuth2Properties, authorizationRequestRepository);
+      AuthenticationException exception = new NullMessageAuthenticationException();
+
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      handler.onAuthenticationFailure(new MockHttpServletRequest(), response, exception);
+
+      String encoded = URLEncoder.encode("로그인에 실패했습니다", StandardCharsets.UTF_8);
+      assertThat(response.getRedirectedUrl()).isEqualTo(REDIRECT_URI + "?error=" + encoded);
+    }
+
+    @Test
+    @DisplayName("실패 - oauth2 인증 요청 삭제 쿠키 발급")
+    void 인증요청_삭제쿠키() throws Exception {
+      OAuth2LoginFailureHandler handler =
+          new OAuth2LoginFailureHandler(oAuth2Properties, authorizationRequestRepository);
+      AuthenticationException exception =
+          new OAuth2AuthenticationException(new OAuth2Error("invalid_request", "bad", null));
+
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      handler.onAuthenticationFailure(new MockHttpServletRequest(), response, exception);
+
+      HttpCookie authReq = findCookie(allSetCookies(response), "oauth2_auth_request");
+      assertThat(authReq).isNotNull();
+      assertThat(authReq.getMaxAge()).isZero();
+    }
+  }
+
+  private static List<HttpCookie> allSetCookies(MockHttpServletResponse response) {
+    return response.getHeaders(HttpHeaders.SET_COOKIE).stream()
+        .flatMap(header -> HttpCookie.parse(header).stream())
+        .toList();
+  }
+
+  private static HttpCookie findCookie(List<HttpCookie> cookies, String name) {
+    return cookies.stream().filter(c -> name.equals(c.getName())).findFirst().orElse(null);
+  }
+
+  private static class NullMessageAuthenticationException extends AuthenticationException {
+    NullMessageAuthenticationException() {
+      super(null);
+    }
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/OAuthIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/OAuthIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gakkaweo.backend.auth.oauth2.dto.OAuthAttributes;
+import com.gakkaweo.backend.auth.oauth2.service.OAuthMemberService;
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.entity.SocialProvider;
+import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("OAuth 통합 테스트")
+class OAuthIntegrationTest extends IntegrationTestBase {
+
+  @Autowired OAuthMemberService oAuthMemberService;
+  @Autowired MemberRepository memberRepository;
+  @Autowired SocialAccountRepository socialAccountRepository;
+
+  @Test
+  @DisplayName("신규 소셜 계정 - Member + SocialAccount 생성")
+  void 신규_생성() {
+    OAuthAttributes attributes =
+        new OAuthAttributes(SocialProvider.KAKAO, "kakao-123", "test@kakao.com");
+
+    Member member = oAuthMemberService.findOrCreateMember(attributes);
+
+    assertThat(member.getPublicId()).isNotNull();
+    assertThat(member.getNickname()).isNotBlank();
+    assertThat(
+            socialAccountRepository.findByProviderAndProviderId(SocialProvider.KAKAO, "kakao-123"))
+        .isPresent();
+  }
+
+  @Test
+  @DisplayName("기존 소셜 계정 - 동일 Member 반환 (중복 생성 방지)")
+  void 기존_동일Member_반환() {
+    OAuthAttributes attributes =
+        new OAuthAttributes(SocialProvider.GOOGLE, "google-456", "test@google.com");
+
+    Member first = oAuthMemberService.findOrCreateMember(attributes);
+    Member second = oAuthMemberService.findOrCreateMember(attributes);
+
+    assertThat(second.getPublicId()).isEqualTo(first.getPublicId());
+    assertThat(memberRepository.count()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("다른 provider로 로그인 - 신규 SocialAccount 생성 (별개 Member)")
+  void 다른provider_별개Member() {
+    oAuthMemberService.findOrCreateMember(
+        new OAuthAttributes(SocialProvider.KAKAO, "kakao-1", "a@kakao.com"));
+    oAuthMemberService.findOrCreateMember(
+        new OAuthAttributes(SocialProvider.GOOGLE, "google-2", "b@google.com"));
+
+    assertThat(memberRepository.count()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("이메일 변경 - 기존 SocialAccount 이메일 업데이트")
+  void 이메일_업데이트() {
+    OAuthAttributes initial = new OAuthAttributes(SocialProvider.NAVER, "naver-1", "old@naver.com");
+    oAuthMemberService.findOrCreateMember(initial);
+
+    OAuthAttributes updated = new OAuthAttributes(SocialProvider.NAVER, "naver-1", "new@naver.com");
+    oAuthMemberService.findOrCreateMember(updated);
+
+    String email =
+        socialAccountRepository
+            .findByProviderAndProviderId(SocialProvider.NAVER, "naver-1")
+            .orElseThrow()
+            .getEmail();
+    assertThat(email).isEqualTo("new@naver.com");
+  }
+
+  @Test
+  @DisplayName("OAuthAttributes - 지원하지 않는 provider 예외")
+  void 미지원_provider() {
+    assertThatThrownBy(() -> OAuthAttributes.of("unsupported", Map.of()))
+        .isInstanceOf(BusinessException.class)
+        .hasMessageContaining(ErrorCode.OAUTH_PROVIDER_NOT_SUPPORTED.getMessage());
+  }
+
+  @Test
+  @DisplayName("OAuthAttributes - 카카오 변환")
+  void 카카오_attributes() {
+    OAuthAttributes result =
+        OAuthAttributes.of(
+            "kakao", Map.of("id", 12345L, "kakao_account", Map.of("email", "user@kakao.com")));
+
+    assertThat(result.provider()).isEqualTo(SocialProvider.KAKAO);
+    assertThat(result.providerId()).isEqualTo("12345");
+    assertThat(result.email()).isEqualTo("user@kakao.com");
+  }
+
+  @Test
+  @DisplayName("OAuthAttributes - 구글 변환")
+  void 구글_attributes() {
+    OAuthAttributes result =
+        OAuthAttributes.of("google", Map.of("sub", "abc-123", "email", "user@google.com"));
+
+    assertThat(result.provider()).isEqualTo(SocialProvider.GOOGLE);
+    assertThat(result.providerId()).isEqualTo("abc-123");
+    assertThat(result.email()).isEqualTo("user@google.com");
+  }
+
+  @Test
+  @DisplayName("OAuthAttributes - 네이버 response 누락 예외")
+  void 네이버_response_없음() {
+    assertThatThrownBy(() -> OAuthAttributes.of("naver", Map.of()))
+        .isInstanceOf(BusinessException.class);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/auth/RefreshTokenRotationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/RefreshTokenRotationTest.java
@@ -1,0 +1,121 @@
+package com.gakkaweo.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.auth.dto.TokenPair;
+import com.gakkaweo.backend.auth.service.RefreshTokenService;
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.auth.entity.RefreshToken;
+import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import com.gakkaweo.backend.support.TestClock;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("Refresh Token Rotation 통합 테스트")
+class RefreshTokenRotationTest extends IntegrationTestBase {
+
+  @Autowired RefreshTokenService refreshTokenService;
+  @Autowired RefreshTokenRepository refreshTokenRepository;
+  @Autowired Clock clock;
+
+  @Test
+  @DisplayName("정상 회전 - RT1 revoked, RT2 발급")
+  void 정상_회전() {
+    Member member = testAuthHelper.createMember();
+    TokenPair initial = testAuthHelper.issueTokens(member);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.COOKIE, "refresh_token=" + initial.refreshToken());
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/auth/refresh"), HttpMethod.POST, new HttpEntity<>(headers), Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    RefreshToken old = refreshTokenService.findByRawToken(initial.refreshToken());
+    assertThat(old.isRevoked()).isTrue();
+
+    List<RefreshToken> all = refreshTokenRepository.findByMemberId(member.getId());
+    assertThat(all).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("재사용 감지 - 401 + family 전체 revoke")
+  void 재사용_감지() {
+    Member member = testAuthHelper.createMember();
+    TokenPair initial = testAuthHelper.issueTokens(member);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.COOKIE, "refresh_token=" + initial.refreshToken());
+
+    restTemplate.exchange(
+        url("/auth/refresh"), HttpMethod.POST, new HttpEntity<>(headers), Void.class);
+
+    ResponseEntity<ErrorBody> reuse =
+        restTemplate.exchange(
+            url("/auth/refresh"), HttpMethod.POST, new HttpEntity<>(headers), ErrorBody.class);
+
+    assertThat(reuse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(reuse.getBody().code()).isEqualTo("REFRESH_TOKEN_REUSE_DETECTED");
+
+    List<RefreshToken> all = refreshTokenRepository.findByMemberId(member.getId());
+    assertThat(all).allMatch(RefreshToken::isRevoked);
+  }
+
+  @Test
+  @DisplayName("만료 - Clock 7일 경과 → 401 EXPIRED_TOKEN")
+  void 만료_401() {
+    Member member = testAuthHelper.createMember();
+    TokenPair initial = testAuthHelper.issueTokens(member);
+
+    TestClock testClock = (TestClock) clock;
+    testClock.advanceBy(Duration.ofDays(8));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.COOKIE, "refresh_token=" + initial.refreshToken());
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/auth/refresh"), HttpMethod.POST, new HttpEntity<>(headers), ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getBody().code()).isEqualTo("EXPIRED_TOKEN");
+  }
+
+  @Test
+  @DisplayName("차단 계정 - refresh 시 403 MEMBER_BANNED")
+  void 차단_계정_refresh() {
+    Member member = testAuthHelper.createMember();
+    TokenPair initial = testAuthHelper.issueTokens(member);
+
+    // 차단 처리
+    member.setBanned(true);
+    member.setBannedAt(clock.instant());
+    // 재조회/저장은 TX 밖이지만 영속성 컨텍스트에 남은 엔티티는 직접 flush 어려움 → 직접 DB 조작은 생략
+    // 대신 신규 차단 멤버로 테스트하는 시나리오
+    Member banned = testAuthHelper.createBannedMember();
+    TokenPair bannedTokens = testAuthHelper.issueTokens(banned);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.COOKIE, "refresh_token=" + bannedTokens.refreshToken());
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/auth/refresh"), HttpMethod.POST, new HttpEntity<>(headers), ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("MEMBER_BANNED");
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/common/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/common/GlobalExceptionHandlerTest.java
@@ -1,0 +1,82 @@
+package com.gakkaweo.backend.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("GlobalExceptionHandler 통합 테스트")
+class GlobalExceptionHandlerTest extends IntegrationTestBase {
+
+  @Test
+  @DisplayName("MethodArgumentNotValidException - 400 VALIDATION_FAILED + 필드 메시지")
+  void valid_400() {
+    String invalidJson = "{\"username\":\"\",\"password\":\"\"}";
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/auth/register"),
+            HttpMethod.POST,
+            new HttpEntity<>(invalidJson, headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+    assertThat(response.getBody().message()).contains("username");
+  }
+
+  @Test
+  @DisplayName("HttpMessageNotReadable - 잘못된 JSON 400 VALIDATION_FAILED")
+  void json_400() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/auth/register"),
+            HttpMethod.POST,
+            new HttpEntity<>("{invalid-json", headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+  }
+
+  @Test
+  @DisplayName("METHOD_NOT_ALLOWED - 405")
+  void method_405() {
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/auth/login"),
+            HttpMethod.PUT,
+            new HttpEntity<>(new HttpHeaders()),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+    assertThat(response.getBody().code()).isEqualTo("METHOD_NOT_ALLOWED");
+  }
+
+  @Test
+  @DisplayName("BusinessException 변환 - code/status/message 구조")
+  void business_예외_형식() {
+    ResponseEntity<ErrorBody> response =
+        restTemplate.getForEntity(url("/daily/today"), ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_NOT_FOUND");
+    assertThat(response.getBody().status()).isEqualTo(404);
+    assertThat(response.getBody().message()).isEqualTo("오늘의 문제를 찾을 수 없습니다");
+    assertThat(response.getBody().timestamp()).isNotBlank();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/common/GlobalExceptionHandlerUnitTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/common/GlobalExceptionHandlerUnitTest.java
@@ -1,0 +1,151 @@
+package com.gakkaweo.backend.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.common.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+@DisplayName("GlobalExceptionHandler 단위 테스트 (나머지 분기)")
+class GlobalExceptionHandlerUnitTest {
+
+  private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+  @Test
+  @DisplayName("ObjectOptimisticLockingFailureException - CONCURRENT_MODIFICATION 응답")
+  void 낙관락_충돌() {
+    ObjectOptimisticLockingFailureException ex =
+        new ObjectOptimisticLockingFailureException("GameSession", 1L);
+
+    ResponseEntity<?> response = handler.handleOptimisticLock(ex);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    ErrorBody body = (ErrorBody) response.getBody();
+    assertThat(body.code()).isEqualTo("CONCURRENT_MODIFICATION");
+  }
+
+  @Test
+  @DisplayName("handleUnexpectedException - 500 INTERNAL_SERVER_ERROR 응답")
+  void 예상밖_예외() {
+    Exception ex = new RuntimeException("boom");
+
+    ResponseEntity<?> response = handler.handleUnexpectedException(ex);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    ErrorBody body = (ErrorBody) response.getBody();
+    assertThat(body.code()).isEqualTo("INTERNAL_SERVER_ERROR");
+  }
+
+  @Test
+  @DisplayName("MaxUploadSizeExceededException - FILE_TOO_LARGE 응답")
+  void 업로드_초과() throws Exception {
+    MaxUploadSizeExceededException ex = new MaxUploadSizeExceededException(1024L);
+    ServletWebRequest req = new ServletWebRequest(new MockHttpServletRequest());
+
+    ResponseEntity<Object> response =
+        invokeHandleMaxUploadSizeExceeded(handler, ex, HttpStatus.PAYLOAD_TOO_LARGE, req);
+
+    assertThat(response).isNotNull();
+    ErrorBody body = (ErrorBody) response.getBody();
+    assertThat(body.code()).isEqualTo("FILE_TOO_LARGE");
+  }
+
+  @Test
+  @DisplayName("MissingServletRequestParameterException - MISSING_PARAMETER 응답")
+  void 필수파라미터_누락() throws Exception {
+    MissingServletRequestParameterException ex =
+        new MissingServletRequestParameterException("sentenceId", "String");
+    ServletWebRequest req = new ServletWebRequest(new MockHttpServletRequest());
+
+    ResponseEntity<Object> response =
+        invokeHandleMissingParameter(handler, ex, HttpStatus.BAD_REQUEST, req);
+
+    assertThat(response).isNotNull();
+    ErrorBody body = (ErrorBody) response.getBody();
+    assertThat(body.code()).isEqualTo("MISSING_PARAMETER");
+  }
+
+  @Test
+  @DisplayName("HttpRequestMethodNotSupported - METHOD_NOT_ALLOWED 응답")
+  void 지원안하는_method() throws Exception {
+    HttpRequestMethodNotSupportedException ex = new HttpRequestMethodNotSupportedException("PATCH");
+    ServletWebRequest req = new ServletWebRequest(new MockHttpServletRequest());
+
+    ResponseEntity<Object> response =
+        invokeHandleMethodNotSupported(handler, ex, HttpStatus.METHOD_NOT_ALLOWED, req);
+
+    assertThat(response).isNotNull();
+    ErrorBody body = (ErrorBody) response.getBody();
+    assertThat(body.code()).isEqualTo("METHOD_NOT_ALLOWED");
+  }
+
+  private static ResponseEntity<Object> invokeHandleMaxUploadSizeExceeded(
+      GlobalExceptionHandler handler,
+      MaxUploadSizeExceededException ex,
+      HttpStatus status,
+      ServletWebRequest req)
+      throws Exception {
+    var method =
+        GlobalExceptionHandler.class.getDeclaredMethod(
+            "handleMaxUploadSizeExceededException",
+            MaxUploadSizeExceededException.class,
+            HttpHeaders.class,
+            org.springframework.http.HttpStatusCode.class,
+            org.springframework.web.context.request.WebRequest.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    ResponseEntity<Object> response =
+        (ResponseEntity<Object>) method.invoke(handler, ex, new HttpHeaders(), status, req);
+    return response;
+  }
+
+  private static ResponseEntity<Object> invokeHandleMissingParameter(
+      GlobalExceptionHandler handler,
+      MissingServletRequestParameterException ex,
+      HttpStatus status,
+      ServletWebRequest req)
+      throws Exception {
+    var method =
+        GlobalExceptionHandler.class.getDeclaredMethod(
+            "handleMissingServletRequestParameter",
+            MissingServletRequestParameterException.class,
+            HttpHeaders.class,
+            org.springframework.http.HttpStatusCode.class,
+            org.springframework.web.context.request.WebRequest.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    ResponseEntity<Object> response =
+        (ResponseEntity<Object>) method.invoke(handler, ex, new HttpHeaders(), status, req);
+    return response;
+  }
+
+  private static ResponseEntity<Object> invokeHandleMethodNotSupported(
+      GlobalExceptionHandler handler,
+      HttpRequestMethodNotSupportedException ex,
+      HttpStatus status,
+      ServletWebRequest req)
+      throws Exception {
+    var method =
+        GlobalExceptionHandler.class.getDeclaredMethod(
+            "handleHttpRequestMethodNotSupported",
+            HttpRequestMethodNotSupportedException.class,
+            HttpHeaders.class,
+            org.springframework.http.HttpStatusCode.class,
+            org.springframework.web.context.request.WebRequest.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    ResponseEntity<Object> response =
+        (ResponseEntity<Object>) method.invoke(handler, ex, new HttpHeaders(), status, req);
+    return response;
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/game/ConcurrencyTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/game/ConcurrencyTest.java
@@ -1,0 +1,69 @@
+package com.gakkaweo.backend.game;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.GameSession;
+import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.game.dto.GuessRequest;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.math.BigDecimal;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+@DisplayName("동시성 통합 테스트")
+class ConcurrencyTest extends IntegrationTestBase {
+
+  @Autowired GameSessionRepository gameSessionRepository;
+
+  @Test
+  @DisplayName("같은 사용자 2 스레드 동시 추측 - 하나의 세션으로 수렴")
+  void 동시_추측_단일세션() throws Exception {
+    Member member = testAuthHelper.createMember();
+    DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+    testSimilarityClient.setDefaultScore(new BigDecimal("30.0"));
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(member);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<Integer> a =
+          executor.submit(() -> submitGuess(sentence, "추측A", headers).getStatusCodeValue());
+      Future<Integer> b =
+          executor.submit(() -> submitGuess(sentence, "추측B", headers).getStatusCodeValue());
+
+      int statusA = a.get(10, TimeUnit.SECONDS);
+      int statusB = b.get(10, TimeUnit.SECONDS);
+
+      // 경쟁 결과: 성공 200, 충돌 409, 드물게 500(낙관적 락/unique 위반 변환 실패)
+      // 최소한 하나는 반드시 성공해야 세션이 저장됨
+      assertThat(statusA == 200 || statusB == 200).isTrue();
+    } finally {
+      executor.shutdownNow();
+    }
+
+    java.util.Optional<GameSession> session =
+        gameSessionRepository.findByMemberAndSentence(member, sentence);
+    assertThat(session).isPresent();
+  }
+
+  private org.springframework.http.ResponseEntity<String> submitGuess(
+      DailySentence sentence, String guessText, HttpHeaders headers) {
+    return restTemplate.exchange(
+        url("/daily/guess"),
+        HttpMethod.POST,
+        new HttpEntity<>(new GuessRequest(sentence.getPublicId(), guessText), headers),
+        String.class);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/game/DailyGameBranchTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/game/DailyGameBranchTest.java
@@ -1,0 +1,186 @@
+package com.gakkaweo.backend.game;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
+import com.gakkaweo.backend.domain.game.entity.GameSession;
+import com.gakkaweo.backend.domain.game.entity.GameSessionStatus;
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.game.dto.GuessRequest;
+import com.gakkaweo.backend.game.dto.GuessResponse;
+import com.gakkaweo.backend.game.dto.TodayResponse;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@DisplayName("DailyGameService 분기 커버 보강")
+class DailyGameBranchTest extends IntegrationTestBase {
+
+  @Autowired Clock clock;
+  @Autowired DailySentenceRepository dailySentenceRepository;
+  @Autowired GameSessionRepository gameSessionRepository;
+  @Autowired TransactionTemplate transactionTemplate;
+  @Autowired EntityManager entityManager;
+
+  @Test
+  @DisplayName("오늘 조회 - 어제 문장 존재 시 yesterdaySentence/yesterdayUsedAt 반환")
+  void 오늘_어제문장_포함() {
+    testAuthHelper.createTodaySentence("오늘 문장");
+    createYesterdaySentence("어제 문장");
+
+    ResponseEntity<TodayResponse> response =
+        restTemplate.getForEntity(url("/daily/today"), TodayResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().yesterdaySentence()).isEqualTo("어제 문장");
+    assertThat(response.getBody().yesterdayDate()).isEqualTo(LocalDate.now(clock).minusDays(1));
+  }
+
+  @Test
+  @DisplayName("익명 추측 - 100% 정답 시 isCorrect=true")
+  void 익명_100퍼센트_isCorrect_true() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("안녕");
+    testSimilarityClient.program("안녕", new BigDecimal("100.0"));
+
+    ResponseEntity<GuessResponse> response =
+        restTemplate.postForEntity(
+            url("/daily/guess"),
+            new GuessRequest(sentence.getPublicId(), "안녕"),
+            GuessResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().isCorrect()).isTrue();
+  }
+
+  @Test
+  @DisplayName("CLEARED 세션에서 100% 재추측 - updateClearedAt 호출되지만 bestSimilarity=100이면 변경 안 됨")
+  void cleared_세션_100퍼센트_재추측() {
+    Member member = testAuthHelper.createMember();
+    DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+    testSimilarityClient.program("안녕하세요", new BigDecimal("100.0"));
+    HttpHeaders headers = authedJson(member);
+
+    submit(sentence, "안녕하세요", headers);
+    GameSession first =
+        gameSessionRepository.findByMemberAndSentence(member, sentence).orElseThrow();
+    assertThat(first.getStatus()).isEqualTo(GameSessionStatus.CLEARED);
+
+    submit(sentence, "안녕하세요", headers);
+    GameSession second =
+        gameSessionRepository.findByMemberAndSentence(member, sentence).orElseThrow();
+    assertThat(second.getStatus()).isEqualTo(GameSessionStatus.CLEARED);
+    assertThat(second.getClearedAt()).isEqualTo(first.getClearedAt());
+  }
+
+  @Test
+  @DisplayName("CLEARED 세션에서 100% 미만 재추측 - clearedAt/status 유지")
+  void cleared_세션_미만_재추측() {
+    Member member = testAuthHelper.createMember();
+    DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+    testSimilarityClient.program("안녕하세요", new BigDecimal("100.0"));
+    testSimilarityClient.program("안녕", new BigDecimal("50.0"));
+    HttpHeaders headers = authedJson(member);
+
+    submit(sentence, "안녕하세요", headers);
+    GameSession first =
+        gameSessionRepository.findByMemberAndSentence(member, sentence).orElseThrow();
+
+    submit(sentence, "안녕", headers);
+    GameSession second =
+        gameSessionRepository.findByMemberAndSentence(member, sentence).orElseThrow();
+    assertThat(second.getStatus()).isEqualTo(GameSessionStatus.CLEARED);
+    assertThat(second.getClearedAt()).isEqualTo(first.getClearedAt());
+    assertThat(second.getBestSimilarity()).isEqualByComparingTo("100.0");
+  }
+
+  @Test
+  @DisplayName("오늘이 아닌 sentence publicId - 404 SENTENCE_NOT_FOUND")
+  void 오늘아닌_sentence_404() {
+    testAuthHelper.createTodaySentence("오늘 문장");
+    DailySentence yesterday = createYesterdaySentence("어제 문장");
+    Member member = testAuthHelper.createMember();
+    HttpHeaders headers = authedJson(member);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/daily/guess"),
+            HttpMethod.POST,
+            new HttpEntity<>(new GuessRequest(yesterday.getPublicId(), "추측"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody().code()).isEqualTo("SENTENCE_NOT_FOUND");
+  }
+
+  @Test
+  @DisplayName("EXPIRED 세션 추측 - 409 GAME_EXPIRED")
+  void expired_세션_409() {
+    Member member = testAuthHelper.createMember();
+    DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+    testSimilarityClient.setDefaultScore(new BigDecimal("50.0"));
+    HttpHeaders headers = authedJson(member);
+
+    submit(sentence, "추측", headers);
+    transactionTemplate.executeWithoutResult(
+        status ->
+            entityManager
+                .createQuery(
+                    "UPDATE GameSession s SET s.status ="
+                        + " com.gakkaweo.backend.domain.game.entity.GameSessionStatus.EXPIRED,"
+                        + " s.version = s.version + 1 WHERE s.member.id = :mid")
+                .setParameter("mid", member.getId())
+                .executeUpdate());
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/daily/guess"),
+            HttpMethod.POST,
+            new HttpEntity<>(new GuessRequest(sentence.getPublicId(), "추측2"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody().code()).isEqualTo("GAME_EXPIRED");
+  }
+
+  private DailySentence createYesterdaySentence(String text) {
+    return transactionTemplate.execute(
+        status -> {
+          DailySentence sentence = new DailySentence(text);
+          sentence.setUsedAt(LocalDate.now(clock).minusDays(1));
+          sentence.setStatus(DailySentenceStatus.USED);
+          return dailySentenceRepository.save(sentence);
+        });
+  }
+
+  private void submit(DailySentence sentence, String guessText, HttpHeaders headers) {
+    ResponseEntity<GuessResponse> response =
+        restTemplate.exchange(
+            url("/daily/guess"),
+            HttpMethod.POST,
+            new HttpEntity<>(new GuessRequest(sentence.getPublicId(), guessText), headers),
+            GuessResponse.class);
+    assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+  }
+
+  private HttpHeaders authedJson(Member member) {
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(member);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/game/DailySentenceSchedulerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/game/DailySentenceSchedulerTest.java
@@ -1,0 +1,78 @@
+package com.gakkaweo.backend.game;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
+import com.gakkaweo.backend.domain.game.entity.GameSession;
+import com.gakkaweo.backend.domain.game.entity.GameSessionStatus;
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.game.scheduler.DailySentenceScheduler;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import com.gakkaweo.backend.support.TestClock;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@DisplayName("DailySentenceScheduler 통합 테스트")
+class DailySentenceSchedulerTest extends IntegrationTestBase {
+
+  @Autowired DailySentenceScheduler scheduler;
+  @Autowired DailySentenceRepository dailySentenceRepository;
+  @Autowired GameSessionRepository gameSessionRepository;
+  @Autowired TransactionTemplate transactionTemplate;
+  @Autowired Clock schedulerClock;
+
+  @Test
+  @DisplayName("executeMidnightJob - 전날 세션 EXPIRED + 오늘 문장 USED + DayChangeEvent 발행")
+  void 자정_스케줄러_실행() {
+    TestClock testClock = (TestClock) schedulerClock;
+    LocalDate yesterday = LocalDate.now(testClock);
+
+    Member member = testAuthHelper.createMember();
+    DailySentence yesterdaySentence =
+        transactionTemplate.execute(
+            status -> {
+              DailySentence s = new DailySentence("어제 문장");
+              s.setUsedAt(yesterday);
+              s.setStatus(DailySentenceStatus.USED);
+              dailySentenceRepository.save(s);
+              gameSessionRepository.save(new GameSession(member, s));
+              return s;
+            });
+
+    testAuthHelper.createActiveSentence("미사용 후보");
+
+    testClock.advanceBy(Duration.ofDays(1));
+
+    scheduler.executeMidnightJob();
+
+    LocalDate today = LocalDate.now(testClock);
+
+    GameSession reloaded =
+        gameSessionRepository.findByMemberAndSentence(member, yesterdaySentence).orElseThrow();
+    assertThat(reloaded.getStatus()).isEqualTo(GameSessionStatus.EXPIRED);
+
+    DailySentence todayPicked = dailySentenceRepository.findByUsedAt(today).orElseThrow();
+    assertThat(todayPicked.getStatus()).isEqualTo(DailySentenceStatus.USED);
+
+    assertThat(testEventCollector.getDayChangeEvents()).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("onApplicationReady - 오늘 문장 없으면 즉시 선정")
+  void 앱시작_즉시선정() {
+    testAuthHelper.createActiveSentence("즉시 후보");
+
+    scheduler.onApplicationReady();
+
+    LocalDate today = LocalDate.now(schedulerClock);
+    assertThat(dailySentenceRepository.findByUsedAt(today)).isPresent();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/game/DailySentenceSchedulerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/game/DailySentenceSchedulerTest.java
@@ -10,8 +10,10 @@ import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
 import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.game.scheduler.DailySentenceScheduler;
+import com.gakkaweo.backend.ranking.service.RankingService;
 import com.gakkaweo.backend.support.IntegrationTestBase;
 import com.gakkaweo.backend.support.TestClock;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -28,6 +30,7 @@ class DailySentenceSchedulerTest extends IntegrationTestBase {
   @Autowired GameSessionRepository gameSessionRepository;
   @Autowired TransactionTemplate transactionTemplate;
   @Autowired Clock schedulerClock;
+  @Autowired RankingService rankingService;
 
   @Test
   @DisplayName("executeMidnightJob - 전날 세션 EXPIRED + 오늘 문장 USED + DayChangeEvent 발행")
@@ -74,5 +77,102 @@ class DailySentenceSchedulerTest extends IntegrationTestBase {
 
     LocalDate today = LocalDate.now(schedulerClock);
     assertThat(dailySentenceRepository.findByUsedAt(today)).isPresent();
+  }
+
+  @Test
+  @DisplayName("executeMidnightJob - 랭킹 데이터 있으면 recordFinalRank + totalPlayers 기록")
+  void 스냅샷_저장_경로() {
+    TestClock testClock = (TestClock) schedulerClock;
+    LocalDate yesterday = LocalDate.now(testClock);
+
+    Member member = testAuthHelper.createMember();
+    DailySentence yesterdaySentence =
+        transactionTemplate.execute(
+            status -> {
+              DailySentence s = new DailySentence("어제 정답 문장");
+              s.setUsedAt(yesterday);
+              s.setStatus(DailySentenceStatus.USED);
+              dailySentenceRepository.save(s);
+              GameSession session = new GameSession(member, s);
+              session.updateBestSimilarity(new BigDecimal("100.0"));
+              session.markCleared(testClock.instant());
+              gameSessionRepository.save(session);
+              return s;
+            });
+    GameSession session =
+        gameSessionRepository.findByMemberAndSentence(member, yesterdaySentence).orElseThrow();
+    rankingService.updateRanking(session, member);
+
+    testAuthHelper.createActiveSentence("오늘 후보");
+    testClock.advanceBy(Duration.ofDays(1));
+
+    scheduler.executeMidnightJob();
+
+    DailySentence reloadedYesterday =
+        dailySentenceRepository.findById(yesterdaySentence.getId()).orElseThrow();
+    assertThat(reloadedYesterday.getTotalPlayers()).isGreaterThanOrEqualTo(1);
+
+    GameSession finalSession =
+        gameSessionRepository.findByMemberAndSentence(member, yesterdaySentence).orElseThrow();
+    assertThat(finalSession.getFinalRank()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("executeMidnightJob - 예약 문장(scheduledAt=today)이 우선 선정")
+  void 예약문장_우선선정() {
+    TestClock testClock = (TestClock) schedulerClock;
+    LocalDate today = LocalDate.now(testClock);
+
+    DailySentence scheduled =
+        transactionTemplate.execute(
+            status -> {
+              DailySentence s = new DailySentence("예약된 문장");
+              s.setScheduledAt(today);
+              return dailySentenceRepository.save(s);
+            });
+    testAuthHelper.createActiveSentence("미예약 후보");
+
+    scheduler.executeMidnightJob();
+
+    DailySentence picked = dailySentenceRepository.findByUsedAt(today).orElseThrow();
+    assertThat(picked.getId()).isEqualTo(scheduled.getId());
+    assertThat(picked.getScheduledAt()).isNull();
+    assertThat(picked.getStatus()).isEqualTo(DailySentenceStatus.USED);
+  }
+
+  @Test
+  @DisplayName("executeMidnightJob - 이미 오늘 문장 존재 시 재선정 안 함")
+  void 오늘문장_이미존재() {
+    TestClock testClock = (TestClock) schedulerClock;
+    LocalDate today = LocalDate.now(testClock);
+
+    DailySentence existing = testAuthHelper.createTodaySentence("이미 선정된 문장");
+    testAuthHelper.createActiveSentence("추가 후보");
+
+    scheduler.executeMidnightJob();
+
+    DailySentence picked = dailySentenceRepository.findByUsedAt(today).orElseThrow();
+    assertThat(picked.getId()).isEqualTo(existing.getId());
+  }
+
+  @Test
+  @DisplayName("executeMidnightJob - 사용 가능한 문장이 없어도 예외 로깅 후 흐름 유지")
+  void 후보문장_없음() {
+    scheduler.executeMidnightJob();
+
+    LocalDate today = LocalDate.now(schedulerClock);
+    assertThat(dailySentenceRepository.findByUsedAt(today)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("onApplicationReady - 오늘 문장 이미 있으면 즉시 선정 건너뜀")
+  void 앱시작_이미선정됨() {
+    DailySentence existing = testAuthHelper.createTodaySentence("이미 선정");
+
+    scheduler.onApplicationReady();
+
+    LocalDate today = LocalDate.now(schedulerClock);
+    DailySentence picked = dailySentenceRepository.findByUsedAt(today).orElseThrow();
+    assertThat(picked.getId()).isEqualTo(existing.getId());
   }
 }

--- a/backend/src/test/java/com/gakkaweo/backend/game/GameFlowIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/game/GameFlowIntegrationTest.java
@@ -1,0 +1,334 @@
+package com.gakkaweo.backend.game;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.GameSession;
+import com.gakkaweo.backend.domain.game.entity.GameSessionStatus;
+import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.game.dto.GameStatusResponse;
+import com.gakkaweo.backend.game.dto.GuessHistoryResponse;
+import com.gakkaweo.backend.game.dto.GuessRequest;
+import com.gakkaweo.backend.game.dto.GuessResponse;
+import com.gakkaweo.backend.game.dto.HintResponse;
+import com.gakkaweo.backend.game.dto.TodayResponse;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("게임 흐름 통합 테스트")
+class GameFlowIntegrationTest extends IntegrationTestBase {
+
+  @Autowired GameSessionRepository gameSessionRepository;
+
+  @Nested
+  @DisplayName("오늘 문제 조회")
+  class Today {
+
+    @Test
+    @DisplayName("문장 존재 - 200 + TodayResponse")
+    void 성공_200() {
+      DailySentence sentence = testAuthHelper.createTodaySentence("오늘 날씨가 좋다");
+
+      ResponseEntity<TodayResponse> response =
+          restTemplate.getForEntity(url("/daily/today"), TodayResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().sentenceId()).isEqualTo(sentence.getPublicId());
+      assertThat(response.getBody().hintMask()).isNotBlank();
+      assertThat(response.getBody().wordCount()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("문장 없음 - 404 SENTENCE_NOT_FOUND")
+    void 문장없음_404() {
+      ResponseEntity<ErrorBody> response =
+          restTemplate.getForEntity(url("/daily/today"), ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+      assertThat(response.getBody().code()).isEqualTo("SENTENCE_NOT_FOUND");
+    }
+  }
+
+  @Nested
+  @DisplayName("추측 제출")
+  class Guess {
+
+    @Test
+    @DisplayName("익명 추측 - 200 + attemptNumber=null")
+    void 익명_200() {
+      DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+      testSimilarityClient.program("안녕", new BigDecimal("50.0"));
+
+      ResponseEntity<GuessResponse> response =
+          restTemplate.postForEntity(
+              url("/daily/guess"),
+              new GuessRequest(sentence.getPublicId(), "안녕"),
+              GuessResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().attemptNumber()).isNull();
+      assertThat(response.getBody().gameStatus()).isNull();
+      assertThat(response.getBody().similarity()).isEqualByComparingTo("50.0");
+    }
+
+    @Test
+    @DisplayName("인증 추측 - 세션 생성 + bestSimilarity 갱신")
+    void 인증_세션생성() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+      testSimilarityClient.setDefaultScore(new BigDecimal("60.0"));
+
+      HttpHeaders headers = authedJson(member);
+
+      ResponseEntity<GuessResponse> response =
+          restTemplate.exchange(
+              url("/daily/guess"),
+              HttpMethod.POST,
+              new HttpEntity<>(new GuessRequest(sentence.getPublicId(), "안녕"), headers),
+              GuessResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().attemptNumber()).isEqualTo(1);
+      assertThat(response.getBody().gameStatus()).isEqualTo("IN_PROGRESS");
+    }
+
+    @Test
+    @DisplayName("100% 달성 - CLEARED + clearedAt 기록")
+    void 정답_CLEARED() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+      testSimilarityClient.program("안녕하세요", new BigDecimal("100.0"));
+
+      HttpHeaders headers = authedJson(member);
+
+      ResponseEntity<GuessResponse> response =
+          restTemplate.exchange(
+              url("/daily/guess"),
+              HttpMethod.POST,
+              new HttpEntity<>(new GuessRequest(sentence.getPublicId(), "안녕하세요"), headers),
+              GuessResponse.class);
+
+      assertThat(response.getBody().isCorrect()).isTrue();
+      assertThat(response.getBody().gameStatus()).isEqualTo("CLEARED");
+
+      GameSession session =
+          gameSessionRepository.findByMemberAndSentence(member, sentence).orElseThrow();
+      assertThat(session.getStatus()).isEqualTo(GameSessionStatus.CLEARED);
+      assertThat(session.getClearedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("bestSimilarity - 다회 추측 중 최댓값 유지")
+    void 베스트유사도_유지() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("하늘이 파랗다");
+      testSimilarityClient.program("하늘", new BigDecimal("40.0"));
+      testSimilarityClient.program("파랑", new BigDecimal("70.0"));
+      testSimilarityClient.program("구름", new BigDecimal("30.0"));
+
+      HttpHeaders headers = authedJson(member);
+      submit(sentence.getPublicId(), "하늘", headers);
+      submit(sentence.getPublicId(), "파랑", headers);
+      submit(sentence.getPublicId(), "구름", headers);
+
+      GameSession session =
+          gameSessionRepository.findByMemberAndSentence(member, sentence).orElseThrow();
+      assertThat(session.getBestSimilarity()).isEqualByComparingTo("70.0");
+      assertThat(session.getAttemptCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("SENTENCE_NOT_FOUND - 존재하지 않는 sentenceId")
+    void 미존재_sentence_404() {
+      testAuthHelper.createTodaySentence("안녕하세요");
+      Member member = testAuthHelper.createMember();
+
+      HttpHeaders headers = authedJson(member);
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.exchange(
+              url("/daily/guess"),
+              HttpMethod.POST,
+              new HttpEntity<>(new GuessRequest(UUID.randomUUID(), "안녕"), headers),
+              ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+      assertThat(response.getBody().code()).isEqualTo("SENTENCE_NOT_FOUND");
+    }
+
+    @Test
+    @DisplayName("AI 서비스 장애 - 503 AI_SERVICE_UNAVAILABLE")
+    void AI_장애_503() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+      testSimilarityClient.throwOnNext();
+
+      HttpHeaders headers = authedJson(member);
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.exchange(
+              url("/daily/guess"),
+              HttpMethod.POST,
+              new HttpEntity<>(new GuessRequest(sentence.getPublicId(), "안녕"), headers),
+              ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+      assertThat(response.getBody().code()).isEqualTo("AI_SERVICE_UNAVAILABLE");
+    }
+
+    @Test
+    @DisplayName("INVALID_GUESS_TEXT - 특수문자만 입력 (정규화 후 빈 문자열)")
+    void 유효하지않은추측_400() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+
+      HttpHeaders headers = authedJson(member);
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.exchange(
+              url("/daily/guess"),
+              HttpMethod.POST,
+              new HttpEntity<>(new GuessRequest(sentence.getPublicId(), "!!!"), headers),
+              ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody().code()).isEqualTo("INVALID_GUESS_TEXT");
+    }
+  }
+
+  @Nested
+  @DisplayName("히스토리 / 힌트 / 상태")
+  class Views {
+
+    @Test
+    @DisplayName("히스토리 - 시도 내역 순서대로")
+    void 히스토리_조회() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("하늘");
+      testSimilarityClient.setDefaultScore(new BigDecimal("30.0"));
+
+      HttpHeaders headers = authedJson(member);
+      submit(sentence.getPublicId(), "구름", headers);
+      submit(sentence.getPublicId(), "바람", headers);
+
+      HttpHeaders cookieOnly = testAuthHelper.cookieHeaderFor(member);
+      ResponseEntity<GuessHistoryResponse> response =
+          restTemplate.exchange(
+              url("/daily/history?sentenceId=" + sentence.getPublicId()),
+              HttpMethod.GET,
+              new HttpEntity<>(cookieOnly),
+              GuessHistoryResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().guesses()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("힌트 - 60% 미만 403 HINT_NOT_AVAILABLE")
+    void 힌트_미달_403() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("하늘");
+      testSimilarityClient.setDefaultScore(new BigDecimal("50.0"));
+
+      HttpHeaders headers = authedJson(member);
+      submit(sentence.getPublicId(), "구름", headers);
+
+      HttpHeaders cookieOnly = testAuthHelper.cookieHeaderFor(member);
+      ResponseEntity<ErrorBody> response =
+          restTemplate.exchange(
+              url("/daily/hints?sentenceId=" + sentence.getPublicId()),
+              HttpMethod.GET,
+              new HttpEntity<>(cookieOnly),
+              ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+      assertThat(response.getBody().code()).isEqualTo("HINT_NOT_AVAILABLE");
+    }
+
+    @Test
+    @DisplayName("힌트 - 60% 이상 200 (상대 추측은 비어 있을 수 있음)")
+    void 힌트_가능_200() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("하늘");
+      testSimilarityClient.setDefaultScore(new BigDecimal("70.0"));
+
+      HttpHeaders headers = authedJson(member);
+      submit(sentence.getPublicId(), "구름", headers);
+
+      HttpHeaders cookieOnly = testAuthHelper.cookieHeaderFor(member);
+      ResponseEntity<HintResponse> response =
+          restTemplate.exchange(
+              url("/daily/hints?sentenceId=" + sentence.getPublicId()),
+              HttpMethod.GET,
+              new HttpEntity<>(cookieOnly),
+              HintResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().hints()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("힌트 - 세션 없음 404 SESSION_NOT_FOUND")
+    void 힌트_세션없음_404() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("하늘");
+
+      HttpHeaders cookieOnly = testAuthHelper.cookieHeaderFor(member);
+      ResponseEntity<ErrorBody> response =
+          restTemplate.exchange(
+              url("/daily/hints?sentenceId=" + sentence.getPublicId()),
+              HttpMethod.GET,
+              new HttpEntity<>(cookieOnly),
+              ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+      assertThat(response.getBody().code()).isEqualTo("SESSION_NOT_FOUND");
+    }
+
+    @Test
+    @DisplayName("상태 조회 - 세션 없으면 null 상태")
+    void 상태_세션없음() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("하늘");
+
+      HttpHeaders cookieOnly = testAuthHelper.cookieHeaderFor(member);
+      ResponseEntity<GameStatusResponse> response =
+          restTemplate.exchange(
+              url("/daily/status"),
+              HttpMethod.GET,
+              new HttpEntity<>(cookieOnly),
+              GameStatusResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().sentenceId()).isEqualTo(sentence.getPublicId());
+      assertThat(response.getBody().gameStatus()).isNull();
+    }
+  }
+
+  private HttpHeaders authedJson(Member member) {
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(member);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+
+  private void submit(UUID sentenceId, String guessText, HttpHeaders headers) {
+    restTemplate.exchange(
+        url("/daily/guess"),
+        HttpMethod.POST,
+        new HttpEntity<>(new GuessRequest(sentenceId, guessText), headers),
+        GuessResponse.class);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/infra/ai/AiServiceClientTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/infra/ai/AiServiceClientTest.java
@@ -1,0 +1,110 @@
+package com.gakkaweo.backend.infra.ai;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gakkaweo.backend.infra.ai.client.AiServiceClient;
+import com.gakkaweo.backend.infra.ai.client.dto.SimilarityResponse;
+import com.gakkaweo.backend.infra.ai.exception.AiServiceException;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@DisplayName("AiServiceClient 단위 테스트 (WireMock)")
+class AiServiceClientTest {
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance()
+          .options(WireMockConfiguration.wireMockConfig().dynamicPort())
+          .build();
+
+  private AiServiceClient client;
+
+  @BeforeEach
+  void setUp() {
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(2000);
+    factory.setReadTimeout(2000);
+    RestClient restClient =
+        RestClient.builder().baseUrl(wireMock.baseUrl()).requestFactory(factory).build();
+    client = new AiServiceClient(restClient);
+  }
+
+  @Test
+  @DisplayName("calculateSimilarity - 정상 응답 파싱")
+  void 정상_응답() {
+    wireMock.stubFor(
+        post(urlEqualTo("/similarity"))
+            .withRequestBody(equalToJson("{\"sentence\":\"원문\",\"guess\":\"추측\"}"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"score\": 73.5}")));
+
+    SimilarityResponse response = client.calculateSimilarity("원문", "추측");
+
+    assertThat(response.score()).isEqualTo(73.5);
+  }
+
+  @Test
+  @DisplayName("calculateSimilarity - 5xx 응답 시 AiServiceException")
+  void 서버_오류_예외() {
+    wireMock.stubFor(post(urlEqualTo("/similarity")).willReturn(aResponse().withStatus(500)));
+
+    assertThatThrownBy(() -> client.calculateSimilarity("원문", "추측"))
+        .isInstanceOf(AiServiceException.class)
+        .hasMessageContaining("AI 서비스 요청 실패");
+  }
+
+  @Test
+  @DisplayName("calculateSimilarity - 4xx 응답 시 AiServiceException")
+  void 클라이언트_오류_예외() {
+    wireMock.stubFor(
+        post(urlEqualTo("/similarity"))
+            .willReturn(aResponse().withStatus(400).withBody("bad request")));
+
+    assertThatThrownBy(() -> client.calculateSimilarity("원문", "추측"))
+        .isInstanceOf(AiServiceException.class);
+  }
+
+  @Test
+  @DisplayName("isHealthy - 200 응답 시 true")
+  void isHealthy_true() {
+    wireMock.stubFor(get(urlEqualTo("/health")).willReturn(aResponse().withStatus(200)));
+
+    assertThat(client.isHealthy()).isTrue();
+  }
+
+  @Test
+  @DisplayName("isHealthy - 5xx 응답 시 false")
+  void isHealthy_서버오류() {
+    wireMock.stubFor(get(urlEqualTo("/health")).willReturn(aResponse().withStatus(503)));
+
+    assertThat(client.isHealthy()).isFalse();
+  }
+
+  @Test
+  @DisplayName("isHealthy - 연결 실패 시 false")
+  void isHealthy_연결실패() {
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(300);
+    factory.setReadTimeout(300);
+    RestClient deadClient =
+        RestClient.builder().baseUrl("http://127.0.0.1:1").requestFactory(factory).build();
+    AiServiceClient unreachable = new AiServiceClient(deadClient);
+
+    assertThat(unreachable.isHealthy()).isFalse();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/infra/ai/NoOpSimilarityServiceTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/infra/ai/NoOpSimilarityServiceTest.java
@@ -1,0 +1,29 @@
+package com.gakkaweo.backend.infra.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.infra.ai.service.NoOpSimilarityService;
+import java.math.BigDecimal;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("NoOpSimilarityService 단위 테스트")
+class NoOpSimilarityServiceTest {
+
+  private final NoOpSimilarityService service = new NoOpSimilarityService();
+
+  @Test
+  @DisplayName("testSimilarity - 항상 0")
+  void test_zero() {
+    assertThat(service.testSimilarity("anything", "anything"))
+        .isEqualByComparingTo(BigDecimal.ZERO);
+  }
+
+  @Test
+  @DisplayName("calculateSimilarity - 항상 0")
+  void calc_zero() {
+    assertThat(service.calculateSimilarity(1L, "guess", "sentence", Duration.ofMinutes(1)))
+        .isEqualByComparingTo(BigDecimal.ZERO);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/infra/ai/SimilarityServiceTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/infra/ai/SimilarityServiceTest.java
@@ -1,0 +1,160 @@
+package com.gakkaweo.backend.infra.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.infra.ai.client.AiServiceClient;
+import com.gakkaweo.backend.infra.ai.client.dto.SimilarityResponse;
+import com.gakkaweo.backend.infra.ai.exception.AiServiceException;
+import com.gakkaweo.backend.infra.ai.service.SimilarityService;
+import com.gakkaweo.backend.infra.ai.service.TextNormalizer;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.math.BigDecimal;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@DisplayName("SimilarityService 단위 테스트")
+class SimilarityServiceTest {
+
+  private AiServiceClient aiServiceClient;
+  private StringRedisTemplate redisTemplate;
+  private ValueOperations<String, String> valueOps;
+  private CircuitBreakerRegistry circuitBreakerRegistry;
+  private SimilarityService service;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    aiServiceClient = Mockito.mock(AiServiceClient.class);
+    redisTemplate = Mockito.mock(StringRedisTemplate.class);
+    valueOps = Mockito.mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
+    circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+    service =
+        new SimilarityService(
+            aiServiceClient, new TextNormalizer(), redisTemplate, circuitBreakerRegistry);
+  }
+
+  @Test
+  @DisplayName("testSimilarity - 정상 호출 시 BigDecimal 반환")
+  void testSimilarity_정상() {
+    when(aiServiceClient.calculateSimilarity(anyString(), anyString()))
+        .thenReturn(new SimilarityResponse(73.456));
+
+    BigDecimal score = service.testSimilarity("원문입니다", "추측 입력");
+
+    assertThat(score).isEqualByComparingTo("73.5");
+  }
+
+  @Test
+  @DisplayName("testSimilarity - 정규화 후 빈 문자열이면 INVALID_GUESS_TEXT")
+  void testSimilarity_빈입력() {
+    assertThatThrownBy(() -> service.testSimilarity("원문", "!!!"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_GUESS_TEXT);
+  }
+
+  @Test
+  @DisplayName("calculateSimilarity - 캐시 HIT 시 AI 호출 안 함")
+  void calculate_캐시HIT() {
+    when(valueOps.get(anyString())).thenReturn("88.0");
+
+    BigDecimal score = service.calculateSimilarity(1L, "추측", "원문", Duration.ofMinutes(10));
+
+    assertThat(score).isEqualByComparingTo("88.0");
+    verify(aiServiceClient, never()).calculateSimilarity(anyString(), anyString());
+    verify(valueOps, never()).set(anyString(), anyString(), any(Duration.class));
+  }
+
+  @Test
+  @DisplayName("calculateSimilarity - 캐시 MISS 시 AI 호출 + 캐시 저장")
+  void calculate_캐시MISS() {
+    when(valueOps.get(anyString())).thenReturn(null);
+    when(aiServiceClient.calculateSimilarity(anyString(), anyString()))
+        .thenReturn(new SimilarityResponse(42.1));
+
+    BigDecimal score = service.calculateSimilarity(1L, "추측", "원문", Duration.ofMinutes(10));
+
+    assertThat(score).isEqualByComparingTo("42.1");
+    verify(valueOps).set(anyString(), anyString(), any(Duration.class));
+  }
+
+  @Test
+  @DisplayName("calculateSimilarity - 빈 guess INVALID_GUESS_TEXT")
+  void calculate_빈입력() {
+    assertThatThrownBy(() -> service.calculateSimilarity(1L, "???", "원문", Duration.ofMinutes(10)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_GUESS_TEXT);
+  }
+
+  @Test
+  @DisplayName("calculateSimilarity - AiServiceException 시 AI_SERVICE_UNAVAILABLE")
+  void ai_예외() {
+    when(valueOps.get(anyString())).thenReturn(null);
+    when(aiServiceClient.calculateSimilarity(anyString(), anyString()))
+        .thenThrow(new AiServiceException("다운", new RuntimeException()));
+
+    assertThatThrownBy(() -> service.calculateSimilarity(1L, "추측", "원문", Duration.ofMinutes(10)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.AI_SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  @DisplayName("서킷 OPEN - AI_SERVICE_UNAVAILABLE")
+  void 서킷_OPEN() {
+    CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("aiService");
+    cb.transitionToOpenState();
+    when(valueOps.get(anyString())).thenReturn(null);
+
+    assertThatThrownBy(() -> service.calculateSimilarity(1L, "추측", "원문", Duration.ofMinutes(10)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.AI_SERVICE_UNAVAILABLE);
+    verify(aiServiceClient, never()).calculateSimilarity(anyString(), anyString());
+  }
+
+  @Test
+  @DisplayName("Redis get 실패 - AI 호출 후 정상 반환")
+  void redis_get_실패() {
+    when(valueOps.get(anyString())).thenThrow(new QueryTimeoutException("timeout"));
+    when(aiServiceClient.calculateSimilarity(anyString(), anyString()))
+        .thenReturn(new SimilarityResponse(60.0));
+
+    BigDecimal score = service.calculateSimilarity(1L, "추측", "원문", Duration.ofMinutes(10));
+
+    assertThat(score).isEqualByComparingTo("60.0");
+  }
+
+  @Test
+  @DisplayName("Redis set 실패 - 점수는 정상 반환")
+  void redis_set_실패() {
+    when(valueOps.get(anyString())).thenReturn(null);
+    when(aiServiceClient.calculateSimilarity(anyString(), anyString()))
+        .thenReturn(new SimilarityResponse(55.5));
+    Mockito.doThrow(new QueryTimeoutException("timeout"))
+        .when(valueOps)
+        .set(anyString(), anyString(), any(Duration.class));
+
+    BigDecimal score = service.calculateSimilarity(1L, "추측", "원문", Duration.ofMinutes(10));
+
+    assertThat(score).isEqualByComparingTo("55.5");
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/migration/FlywayMigrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/migration/FlywayMigrationTest.java
@@ -1,0 +1,36 @@
+package com.gakkaweo.backend.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("Flyway 마이그레이션 통합 테스트")
+class FlywayMigrationTest extends IntegrationTestBase {
+
+  @Autowired Flyway flyway;
+
+  @Test
+  @DisplayName("V1~V14 전부 적용 완료")
+  void 마이그레이션_적용완료() {
+    MigrationInfo[] applied = flyway.info().applied();
+    assertThat(applied).hasSize(14);
+    assertThat(applied[applied.length - 1].getVersion().getVersion()).isEqualTo("14");
+  }
+
+  @Test
+  @DisplayName("validate 통과")
+  void validate_통과() {
+    flyway.validate();
+  }
+
+  @Test
+  @DisplayName("pending 마이그레이션 없음")
+  void pending_없음() {
+    assertThat(flyway.info().pending()).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/migration/NativeQueryTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/migration/NativeQueryTest.java
@@ -1,0 +1,53 @@
+package com.gakkaweo.backend.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.domain.game.repository.GuessHistoryRepository;
+import com.gakkaweo.backend.domain.game.repository.HintProjection;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@DisplayName("Native Query 통합 테스트")
+class NativeQueryTest extends IntegrationTestBase {
+
+  @Autowired DailySentenceRepository dailySentenceRepository;
+  @Autowired GuessHistoryRepository guessHistoryRepository;
+  @Autowired TransactionTemplate transactionTemplate;
+
+  @Test
+  @DisplayName("findRandomUnusedSentence - ACTIVE + usedAt null인 문장만 반환")
+  void random_미사용문장() {
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          DailySentence active = new DailySentence("활성 문장");
+          dailySentenceRepository.save(active);
+          DailySentence used = new DailySentence("사용된 문장");
+          used.setStatus(DailySentenceStatus.USED);
+          dailySentenceRepository.save(used);
+        });
+
+    DailySentence picked =
+        dailySentenceRepository
+            .findRandomUnusedSentence()
+            .orElseThrow(() -> new AssertionError("ACTIVE 문장이 있어야 함"));
+
+    assertThat(picked.getStatus()).isEqualTo(DailySentenceStatus.ACTIVE);
+    assertThat(picked.getUsedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("findHints - 빈 결과 (데이터 없음)")
+  void hints_빈결과() {
+    List<HintProjection> hints =
+        guessHistoryRepository.findHints(1L, 1L, new BigDecimal("100.0"), 5);
+    assertThat(hints).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/ranking/RankingScoreEncodingTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/ranking/RankingScoreEncodingTest.java
@@ -1,0 +1,137 @@
+package com.gakkaweo.backend.ranking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.GameSession;
+import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.ranking.dto.RankingResponse;
+import com.gakkaweo.backend.ranking.service.RankingService;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import com.gakkaweo.backend.support.TestClock;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@DisplayName("랭킹 스코어 인코딩 통합 테스트")
+class RankingScoreEncodingTest extends IntegrationTestBase {
+
+  @Autowired RankingService rankingService;
+  @Autowired GameSessionRepository gameSessionRepository;
+  @Autowired TransactionTemplate transactionTemplate;
+  @Autowired Clock clock;
+
+  @Test
+  @DisplayName("100% 달성자가 99%보다 항상 상위")
+  void 정답_우선() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+
+    Member perfect = testAuthHelper.createMember();
+    Member near = testAuthHelper.createMember();
+
+    GameSession perfectSession =
+        prepareSession(perfect, sentence, new BigDecimal("100.0"), 10, true);
+    GameSession nearSession = prepareSession(near, sentence, new BigDecimal("99.9"), 1, false);
+
+    rankingService.updateRanking(nearSession, near);
+    rankingService.updateRanking(perfectSession, perfect);
+
+    ResponseEntity<RankingResponse> response =
+        restTemplate.getForEntity(url("/ranking/today"), RankingResponse.class);
+
+    List<RankingResponse.RankingEntry> rankings = response.getBody().rankings();
+    assertThat(rankings).hasSize(2);
+    assertThat(rankings.get(0).publicId()).isEqualTo(perfect.getPublicId());
+    assertThat(rankings.get(1).publicId()).isEqualTo(near.getPublicId());
+  }
+
+  @Test
+  @DisplayName("100% 간 선착순 - 먼저 clear한 사용자가 상위")
+  void 선착순() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+
+    TestClock testClock = (TestClock) clock;
+    Member first = testAuthHelper.createMember();
+    GameSession firstSession = prepareSession(first, sentence, new BigDecimal("100.0"), 3, true);
+    rankingService.updateRanking(firstSession, first);
+
+    testClock.advanceBy(Duration.ofMinutes(5));
+    Member second = testAuthHelper.createMember();
+    GameSession secondSession = prepareSession(second, sentence, new BigDecimal("100.0"), 5, true);
+    rankingService.updateRanking(secondSession, second);
+
+    ResponseEntity<RankingResponse> response =
+        restTemplate.getForEntity(url("/ranking/today"), RankingResponse.class);
+
+    List<RankingResponse.RankingEntry> rankings = response.getBody().rankings();
+    assertThat(rankings.get(0).publicId()).isEqualTo(first.getPublicId());
+    assertThat(rankings.get(1).publicId()).isEqualTo(second.getPublicId());
+  }
+
+  @Test
+  @DisplayName("95~99.9% - 유사도 > 시도 횟수 우선순위")
+  void 유사도_시도() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+
+    Member high = testAuthHelper.createMember();
+    Member low = testAuthHelper.createMember();
+
+    GameSession highSession = prepareSession(high, sentence, new BigDecimal("99.0"), 20, false);
+    GameSession lowSession = prepareSession(low, sentence, new BigDecimal("95.0"), 3, false);
+
+    rankingService.updateRanking(lowSession, low);
+    rankingService.updateRanking(highSession, high);
+
+    ResponseEntity<RankingResponse> response =
+        restTemplate.getForEntity(url("/ranking/today"), RankingResponse.class);
+
+    List<RankingResponse.RankingEntry> rankings = response.getBody().rankings();
+    assertThat(rankings.get(0).publicId()).isEqualTo(high.getPublicId());
+    assertThat(rankings.get(1).publicId()).isEqualTo(low.getPublicId());
+  }
+
+  @Test
+  @DisplayName("동일 유사도 - 시도 횟수가 적은 쪽이 상위")
+  void 동일유사도_시도() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+
+    Member few = testAuthHelper.createMember();
+    Member many = testAuthHelper.createMember();
+
+    GameSession fewSession = prepareSession(few, sentence, new BigDecimal("90.0"), 3, false);
+    GameSession manySession = prepareSession(many, sentence, new BigDecimal("90.0"), 10, false);
+
+    rankingService.updateRanking(manySession, many);
+    rankingService.updateRanking(fewSession, few);
+
+    ResponseEntity<RankingResponse> response =
+        restTemplate.getForEntity(url("/ranking/today"), RankingResponse.class);
+
+    List<RankingResponse.RankingEntry> rankings = response.getBody().rankings();
+    assertThat(rankings.get(0).publicId()).isEqualTo(few.getPublicId());
+    assertThat(rankings.get(1).publicId()).isEqualTo(many.getPublicId());
+  }
+
+  private GameSession prepareSession(
+      Member member, DailySentence sentence, BigDecimal similarity, int attempts, boolean cleared) {
+    return transactionTemplate.execute(
+        status -> {
+          GameSession session = new GameSession(member, sentence);
+          session.updateBestSimilarity(similarity);
+          for (int i = 0; i < attempts; i++) {
+            session.incrementAttempt();
+          }
+          if (cleared) {
+            session.markCleared(clock.instant());
+          }
+          return gameSessionRepository.save(session);
+        });
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/ranking/RankingServiceIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/ranking/RankingServiceIntegrationTest.java
@@ -1,0 +1,290 @@
+package com.gakkaweo.backend.ranking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.admin.dto.FullRankingResponse;
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
+import com.gakkaweo.backend.domain.game.entity.GameSession;
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import com.gakkaweo.backend.ranking.dto.RankingResponse;
+import com.gakkaweo.backend.ranking.service.RankingService;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@DisplayName("RankingService 통합 테스트 (Redis 데이터 포함 경로)")
+class RankingServiceIntegrationTest extends IntegrationTestBase {
+
+  @Autowired RankingService rankingService;
+  @Autowired MemberRepository memberRepository;
+  @Autowired DailySentenceRepository dailySentenceRepository;
+  @Autowired GameSessionRepository gameSessionRepository;
+  @Autowired TransactionTemplate transactionTemplate;
+  @Autowired Clock rankingClock;
+
+  @Test
+  @DisplayName("GET /ranking/today 미인증 - getRankings 루프 + profileUrl null/empty/값 3분기")
+  void 랭킹_조회_미인증() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("오늘 문장");
+    Member withProfile =
+        seedRanking(sentence, "프로필유저", "/uploads/user.webp", new BigDecimal("100.0"), true);
+    seedRanking(sentence, "빈프로필", "", new BigDecimal("95.0"), false);
+    seedRanking(sentence, "노프로필", null, new BigDecimal("70.0"), false);
+
+    ResponseEntity<RankingResponse> response =
+        restTemplate.getForEntity(url("/ranking/today"), RankingResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().totalPlayers()).isEqualTo(3L);
+    assertThat(response.getBody().rankings()).hasSize(3);
+    assertThat(response.getBody().rankings())
+        .extracting(RankingResponse.RankingEntry::nickname)
+        .containsExactly("프로필유저", "빈프로필", "노프로필");
+    assertThat(response.getBody().rankings().get(0).profileUrl()).isEqualTo("/uploads/user.webp");
+    assertThat(response.getBody().rankings().get(1).profileUrl()).isNull();
+    assertThat(response.getBody().rankings().get(2).profileUrl()).isNull();
+    assertThat(response.getBody().myRank()).isNull();
+    assertThat(withProfile.getNickname()).isEqualTo("프로필유저");
+  }
+
+  @Test
+  @DisplayName("GET /ranking/today 인증 - getRankingsForUser + lookupMyRank")
+  void 랭킹_조회_인증_myRank() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("오늘 문장");
+    Member top = seedRanking(sentence, "1등", null, new BigDecimal("100.0"), true);
+    Member me = seedRanking(sentence, "나", null, new BigDecimal("80.0"), false);
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(me);
+    ResponseEntity<RankingResponse> response =
+        restTemplate.exchange(
+            url("/ranking/today"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            RankingResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().myRank()).isNotNull();
+    assertThat(response.getBody().myRank().rank()).isEqualTo(2);
+    assertThat(response.getBody().myRank().similarity()).isEqualByComparingTo("80.0");
+    assertThat(top.getNickname()).isEqualTo("1등");
+  }
+
+  @Test
+  @DisplayName("GET /ranking/today 인증 - 랭킹 없는 사용자는 myRank null")
+  void 랭킹_조회_인증_myRank_없음() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("오늘 문장");
+    seedRanking(sentence, "1등", null, new BigDecimal("100.0"), true);
+    Member outsider = testAuthHelper.createMember();
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(outsider);
+    ResponseEntity<RankingResponse> response =
+        restTemplate.exchange(
+            url("/ranking/today"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            RankingResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().myRank()).isNull();
+  }
+
+  @Test
+  @DisplayName(
+      "GET /ranking/today 인증 - 어제 세션 + finalRank 세팅 시 yesterdayRank/yesterdayTotalPlayers 반환")
+  void 랭킹_조회_어제기록() {
+    DailySentence todaySentence = testAuthHelper.createTodaySentence("오늘 문장");
+    Member me = seedRanking(todaySentence, "나", null, new BigDecimal("80.0"), false);
+
+    LocalDate yesterday = LocalDate.now(rankingClock).minusDays(1);
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          DailySentence yesterdaySentence = new DailySentence("어제 문장");
+          yesterdaySentence.setUsedAt(yesterday);
+          yesterdaySentence.setStatus(DailySentenceStatus.USED);
+          yesterdaySentence.recordTotalPlayers(5);
+          dailySentenceRepository.save(yesterdaySentence);
+
+          GameSession yesterdaySession = new GameSession(me, yesterdaySentence);
+          yesterdaySession.updateBestSimilarity(new BigDecimal("90.0"));
+          yesterdaySession.recordFinalRank(3);
+          gameSessionRepository.save(yesterdaySession);
+        });
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(me);
+    ResponseEntity<RankingResponse> response =
+        restTemplate.exchange(
+            url("/ranking/today"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            RankingResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().yesterdayRank()).isEqualTo(3);
+    assertThat(response.getBody().yesterdayTotalPlayers()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("GET /ranking/today 인증 - 어제 문장은 있지만 내 세션이 없으면 yesterdayRank null / totalPlayers만 반환")
+  void 랭킹_조회_어제문장만() {
+    DailySentence todaySentence = testAuthHelper.createTodaySentence("오늘 문장");
+    Member me = seedRanking(todaySentence, "나", null, new BigDecimal("80.0"), false);
+
+    LocalDate yesterday = LocalDate.now(rankingClock).minusDays(1);
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          DailySentence yesterdaySentence = new DailySentence("어제 문장");
+          yesterdaySentence.setUsedAt(yesterday);
+          yesterdaySentence.setStatus(DailySentenceStatus.USED);
+          yesterdaySentence.recordTotalPlayers(10);
+          dailySentenceRepository.save(yesterdaySentence);
+        });
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(me);
+    ResponseEntity<RankingResponse> response =
+        restTemplate.exchange(
+            url("/ranking/today"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            RankingResponse.class);
+
+    assertThat(response.getBody().yesterdayTotalPlayers()).isEqualTo(10);
+    assertThat(response.getBody().yesterdayRank()).isNull();
+  }
+
+  @Test
+  @DisplayName("GET /admin/dashboard/ranking - getFullRankingsForDate 전체 랭킹 반환")
+  void 어드민_전체랭킹() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("오늘 문장");
+    seedRanking(sentence, "1등", "/uploads/p1.webp", new BigDecimal("100.0"), true);
+    seedRanking(sentence, "2등", null, new BigDecimal("95.0"), false);
+
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<FullRankingResponse> response =
+        restTemplate.exchange(
+            url("/admin/dashboard/ranking"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            FullRankingResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().totalPlayers()).isEqualTo(2L);
+    assertThat(response.getBody().rankings())
+        .extracting(FullRankingResponse.RankingEntry::nickname)
+        .containsExactly("1등", "2등");
+    assertThat(response.getBody().rankings().get(0).profileUrl()).isEqualTo("/uploads/p1.webp");
+    assertThat(response.getBody().rankings().get(1).profileUrl()).isNull();
+  }
+
+  @Test
+  @DisplayName("GET /admin/dashboard/ranking - 랭킹 없는 날짜는 빈 목록")
+  void 어드민_전체랭킹_빈날짜() {
+    testAuthHelper.createTodaySentence("오늘 문장");
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<FullRankingResponse> response =
+        restTemplate.exchange(
+            url("/admin/dashboard/ranking?date=2020-01-01"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            FullRankingResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().rankings()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("rebuildRankingCache - DB 세션 기반 Redis 재구축")
+  void 랭킹캐시_재구축() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("오늘 문장");
+    Member m1 = seedRanking(sentence, "재구축1", "/uploads/r1.webp", new BigDecimal("100.0"), true);
+    Member m2 = seedRanking(sentence, "재구축2", null, new BigDecimal("80.0"), false);
+
+    LocalDate today = LocalDate.now(rankingClock);
+    int rebuilt = rankingService.rebuildRankingCache(today);
+
+    assertThat(rebuilt).isEqualTo(2);
+    RankingResponse rankings = rankingService.getRankings();
+    assertThat(rankings.totalPlayers()).isEqualTo(2L);
+    assertThat(rankings.rankings())
+        .extracting(RankingResponse.RankingEntry::nickname)
+        .containsExactly("재구축1", "재구축2");
+    assertThat(m1.getNickname()).isEqualTo("재구축1");
+    assertThat(m2.getNickname()).isEqualTo("재구축2");
+  }
+
+  @Test
+  @DisplayName("rebuildRankingCache - 오늘 문장 없으면 SENTENCE_NOT_FOUND")
+  void 랭킹캐시_재구축_문장없음() {
+    LocalDate today = LocalDate.now(rankingClock);
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> rankingService.rebuildRankingCache(today))
+        .isInstanceOf(com.gakkaweo.backend.common.exception.BusinessException.class);
+  }
+
+  @Test
+  @DisplayName("expirePreviousDayRankingKeys - TTL 적용")
+  void 이전날_키만료() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("오늘 문장");
+    seedRanking(sentence, "참여자", null, new BigDecimal("80.0"), false);
+
+    LocalDate today = LocalDate.now(rankingClock);
+    rankingService.expirePreviousDayRankingKeys(today);
+  }
+
+  private Member seedRanking(
+      DailySentence sentence,
+      String nickname,
+      String profileUrl,
+      BigDecimal similarity,
+      boolean perfect) {
+    Member member =
+        transactionTemplate.execute(
+            status -> {
+              Member m = new Member(nickname);
+              if (profileUrl != null) {
+                m.setProfileUrl(profileUrl);
+              }
+              memberRepository.save(m);
+              GameSession session = new GameSession(m, sentence);
+              session.updateBestSimilarity(similarity);
+              if (perfect) {
+                session.markCleared(rankingClock.instant());
+              }
+              gameSessionRepository.save(session);
+              return m;
+            });
+    GameSession session =
+        gameSessionRepository.findByMemberAndSentence(member, sentence).orElseThrow();
+    rankingService.updateRanking(session, member);
+    return member;
+  }
+
+  @SuppressWarnings("unused")
+  private static List<String> nicknames(RankingResponse response) {
+    List<String> result = new ArrayList<>();
+    for (RankingResponse.RankingEntry e : response.rankings()) {
+      result.add(e.nickname());
+    }
+    return result;
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/ranking/SseEventTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/ranking/SseEventTest.java
@@ -1,0 +1,82 @@
+package com.gakkaweo.backend.ranking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.admin.dto.AnnouncementCreateRequest;
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.game.dto.GuessRequest;
+import com.gakkaweo.backend.game.dto.GuessResponse;
+import com.gakkaweo.backend.ranking.sse.SseConnectionManager;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+@DisplayName("SSE 이벤트/연결 통합 테스트")
+class SseEventTest extends IntegrationTestBase {
+
+  @Autowired SseConnectionManager sseConnectionManager;
+  @Autowired Clock clock;
+
+  @Test
+  @DisplayName("추측 제출 → RankingUpdateEvent 발행")
+  void RankingUpdateEvent_발행() {
+    Member member = testAuthHelper.createMember();
+    DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+    testSimilarityClient.setDefaultScore(new BigDecimal("60.0"));
+
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(member);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    restTemplate.exchange(
+        url("/daily/guess"),
+        HttpMethod.POST,
+        new HttpEntity<>(new GuessRequest(sentence.getPublicId(), "안녕"), headers),
+        GuessResponse.class);
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(3))
+        .untilAsserted(() -> assertThat(testEventCollector.getRankingEvents()).isNotEmpty());
+  }
+
+  @Test
+  @DisplayName("공지 등록 → AnnouncementEvent 발행 (활성 기간 내)")
+  void AnnouncementEvent_발행() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    AnnouncementCreateRequest request =
+        new AnnouncementCreateRequest(
+            "점검 공지",
+            "내용",
+            "MAINTENANCE",
+            clock.instant().minusSeconds(60),
+            clock.instant().plus(Duration.ofDays(1)));
+
+    restTemplate.exchange(
+        url("/admin/system/announcements"),
+        HttpMethod.POST,
+        new HttpEntity<>(request, headers),
+        Void.class);
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(3))
+        .untilAsserted(() -> assertThat(testEventCollector.getAnnouncementEvents()).isNotEmpty());
+  }
+
+  @Test
+  @DisplayName("SSE 연결 수 - 초기 0")
+  void 초기_연결수() {
+    assertThat(sseConnectionManager.getConnectionCount()).isEqualTo(0);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/ranking/SseMaxConnectionsTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/ranking/SseMaxConnectionsTest.java
@@ -1,0 +1,32 @@
+package com.gakkaweo.backend.ranking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.ranking.sse.SseConnectionManager;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+@DisplayName("SSE 최대 연결 제한 통합 테스트")
+@TestPropertySource(properties = {"app.sse.max-connections=2"})
+class SseMaxConnectionsTest extends IntegrationTestBase {
+
+  @Autowired SseConnectionManager sseConnectionManager;
+
+  @Test
+  @DisplayName("3번째 연결 시도 → SSE_MAX_CONNECTIONS(503)")
+  void 최대초과_SSE_MAX() {
+    sseConnectionManager.register();
+    sseConnectionManager.register();
+    assertThat(sseConnectionManager.getConnectionCount()).isEqualTo(2);
+
+    assertThatThrownBy(sseConnectionManager::register)
+        .isInstanceOf(BusinessException.class)
+        .hasMessageContaining(ErrorCode.SSE_MAX_CONNECTIONS.getMessage());
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/ranking/SseStreamTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/ranking/SseStreamTest.java
@@ -1,0 +1,87 @@
+package com.gakkaweo.backend.ranking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.ranking.sse.SseConnectionManager;
+import com.gakkaweo.backend.ranking.sse.SseEventType;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("SSE 스트림 end-to-end 통합 테스트")
+class SseStreamTest extends IntegrationTestBase {
+
+  @Autowired SseConnectionManager sseConnectionManager;
+
+  @Test
+  @DisplayName("구독 후 broadcast 이벤트 실제 수신")
+  void 구독_후_broadcast_수신() throws Exception {
+    HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(3)).build();
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(url("/ranking/stream")))
+            .timeout(Duration.ofSeconds(10))
+            .GET()
+            .build();
+
+    CompletableFuture<HttpResponse<Stream<String>>> responseFuture =
+        client.sendAsync(request, HttpResponse.BodyHandlers.ofLines());
+
+    HttpResponse<Stream<String>> response = responseFuture.get(5, TimeUnit.SECONDS);
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.headers().firstValue("Content-Type").orElse(""))
+        .contains("text/event-stream");
+
+    List<String> received = new CopyOnWriteArrayList<>();
+    Thread reader =
+        Executors.defaultThreadFactory()
+            .newThread(
+                () -> {
+                  try {
+                    response.body().limit(40).forEach(received::add);
+                  } catch (Exception ignored) {
+                  }
+                });
+    reader.setDaemon(true);
+    reader.start();
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(sseConnectionManager.getConnectionCount()).isEqualTo(1));
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              String joined = String.join("\n", received);
+              assertThat(joined).contains(SseEventType.HEARTBEAT.name());
+              assertThat(joined).contains(SseEventType.RANKING_UPDATE.name());
+            });
+
+    sseConnectionManager.broadcast(SseEventType.RANKING_UPDATE, "payload-marker");
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              String joined = String.join("\n", received);
+              assertThat(joined).contains("payload-marker");
+            });
+
+    reader.interrupt();
+    client.close();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/ratelimit/EndpointGroupResolverTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/ratelimit/EndpointGroupResolverTest.java
@@ -1,0 +1,84 @@
+package com.gakkaweo.backend.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.ratelimit.filter.EndpointGroup;
+import com.gakkaweo.backend.ratelimit.filter.EndpointGroupResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("EndpointGroupResolver 단위 테스트")
+class EndpointGroupResolverTest {
+
+  private final EndpointGroupResolver resolver = new EndpointGroupResolver();
+
+  @Test
+  @DisplayName("NONE - /health")
+  void none_health() {
+    assertThat(resolver.resolve("GET", "/health")).isEqualTo(EndpointGroup.NONE);
+  }
+
+  @Test
+  @DisplayName("NONE - /uploads/*, /login/oauth2/*, /oauth2/authorization/*")
+  void none_upload_oauth() {
+    assertThat(resolver.resolve("GET", "/uploads/abc.webp")).isEqualTo(EndpointGroup.NONE);
+    assertThat(resolver.resolve("GET", "/login/oauth2/code/kakao")).isEqualTo(EndpointGroup.NONE);
+    assertThat(resolver.resolve("GET", "/oauth2/authorization/google"))
+        .isEqualTo(EndpointGroup.NONE);
+  }
+
+  @Test
+  @DisplayName("NONE - swagger / api-docs / webjars")
+  void none_swagger() {
+    assertThat(resolver.resolve("GET", "/swagger-ui/index.html")).isEqualTo(EndpointGroup.NONE);
+    assertThat(resolver.resolve("GET", "/v3/api-docs")).isEqualTo(EndpointGroup.NONE);
+    assertThat(resolver.resolve("GET", "/swagger-resources/config")).isEqualTo(EndpointGroup.NONE);
+    assertThat(resolver.resolve("GET", "/webjars/swagger.js")).isEqualTo(EndpointGroup.NONE);
+  }
+
+  @Test
+  @DisplayName("ADMIN - /admin/**")
+  void admin_경로() {
+    assertThat(resolver.resolve("GET", "/admin/users")).isEqualTo(EndpointGroup.ADMIN);
+    assertThat(resolver.resolve("POST", "/admin/sentences")).isEqualTo(EndpointGroup.ADMIN);
+  }
+
+  @Test
+  @DisplayName("READ - GET /auth/me")
+  void read_authMe() {
+    assertThat(resolver.resolve("GET", "/auth/me")).isEqualTo(EndpointGroup.READ);
+  }
+
+  @Test
+  @DisplayName("AUTH - 다른 /auth 경로")
+  void auth_login() {
+    assertThat(resolver.resolve("POST", "/auth/login")).isEqualTo(EndpointGroup.AUTH);
+    assertThat(resolver.resolve("POST", "/auth/refresh")).isEqualTo(EndpointGroup.AUTH);
+  }
+
+  @Test
+  @DisplayName("GUESS - POST /daily/guess")
+  void guess() {
+    assertThat(resolver.resolve("POST", "/daily/guess")).isEqualTo(EndpointGroup.GUESS);
+  }
+
+  @Test
+  @DisplayName("SSE - GET /ranking/stream")
+  void sse() {
+    assertThat(resolver.resolve("GET", "/ranking/stream")).isEqualTo(EndpointGroup.SSE);
+  }
+
+  @Test
+  @DisplayName("READ - 일반 GET 요청")
+  void read_일반GET() {
+    assertThat(resolver.resolve("GET", "/daily/today")).isEqualTo(EndpointGroup.READ);
+    assertThat(resolver.resolve("GET", "/ranking/list")).isEqualTo(EndpointGroup.READ);
+  }
+
+  @Test
+  @DisplayName("NONE - 기타 (GUESS 외 POST)")
+  void none_기타POST() {
+    assertThat(resolver.resolve("POST", "/other/endpoint")).isEqualTo(EndpointGroup.NONE);
+    assertThat(resolver.resolve("DELETE", "/daily/something")).isEqualTo(EndpointGroup.NONE);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/ratelimit/RateLimitIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/ratelimit/RateLimitIntegrationTest.java
@@ -1,0 +1,33 @@
+package com.gakkaweo.backend.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.auth.dto.LoginRequest;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+@DisplayName("Rate Limit 통합 테스트")
+@TestPropertySource(properties = {"app.rate-limit.auth-per-minute=3"})
+class RateLimitIntegrationTest extends IntegrationTestBase {
+
+  @Test
+  @DisplayName("auth 엔드포인트 - 3회 이후 429 + Retry-After 헤더")
+  void 레이트리밋_초과_429() {
+    LoginRequest request = new LoginRequest("nonexistent", "wrongpassword");
+
+    for (int i = 0; i < 3; i++) {
+      ResponseEntity<String> response =
+          restTemplate.postForEntity(url("/auth/login"), request, String.class);
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    ResponseEntity<String> limited =
+        restTemplate.postForEntity(url("/auth/login"), request, String.class);
+    assertThat(limited.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+    assertThat(limited.getHeaders().getFirst("Retry-After")).isNotBlank();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/security/SecurityConfigTest.java
@@ -1,0 +1,96 @@
+package com.gakkaweo.backend.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("Security 접근 매트릭스 통합 테스트")
+class SecurityConfigTest extends IntegrationTestBase {
+
+  @Test
+  @DisplayName("public 엔드포인트 - 미인증 접근 허용")
+  void public_미인증_허용() {
+    ResponseEntity<String> health = restTemplate.getForEntity(url("/health"), String.class);
+    assertThat(health.getStatusCode()).isIn(HttpStatus.OK, HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("/auth/me - 미인증 401")
+  void me_미인증_401() {
+    ResponseEntity<String> response = restTemplate.getForEntity(url("/auth/me"), String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("/daily/history - 미인증 401")
+  void history_미인증_401() {
+    ResponseEntity<String> response =
+        restTemplate.getForEntity(
+            url("/daily/history?sentenceId=550e8400-e29b-41d4-a716-446655440000"), String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("/admin/** - 미인증 401")
+  void admin_미인증_401() {
+    ResponseEntity<String> response =
+        restTemplate.getForEntity(url("/admin/users?page=0&size=10"), String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("/admin/** - USER 403")
+  void admin_USER_403() {
+    Member user = testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(user);
+
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            url("/admin/users?page=0&size=10"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("/admin/** - ADMIN 200")
+  void admin_ADMIN_200() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            url("/admin/users?page=0&size=10"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("/daily/today - 미인증 200 (public)")
+  void today_public_200() {
+    testAuthHelper.createTodaySentence("안녕하세요");
+    ResponseEntity<String> response = restTemplate.getForEntity(url("/daily/today"), String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("/ranking/today - 미인증 200")
+  void ranking_public_200() {
+    ResponseEntity<String> response =
+        restTemplate.getForEntity(url("/ranking/today"), String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/DatabaseCleaner.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/DatabaseCleaner.java
@@ -1,0 +1,44 @@
+package com.gakkaweo.backend.support;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseCleaner {
+
+  private final JdbcTemplate jdbcTemplate;
+  private final RedisConnectionFactory redisConnectionFactory;
+
+  public DatabaseCleaner(JdbcTemplate jdbcTemplate, RedisConnectionFactory redisConnectionFactory) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.redisConnectionFactory = redisConnectionFactory;
+  }
+
+  public void clean() {
+    truncateTables();
+    flushRedis();
+  }
+
+  private void truncateTables() {
+    List<String> tables =
+        jdbcTemplate.queryForList(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' "
+                + "AND tablename <> 'flyway_schema_history'",
+            String.class);
+    if (tables.isEmpty()) {
+      return;
+    }
+    String joined = tables.stream().map(t -> "\"" + t + "\"").collect(Collectors.joining(", "));
+    jdbcTemplate.execute("TRUNCATE TABLE " + joined + " RESTART IDENTITY CASCADE");
+  }
+
+  private void flushRedis() {
+    try (RedisConnection connection = redisConnectionFactory.getConnection()) {
+      connection.serverCommands().flushAll();
+    }
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/IntegrationTestBase.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/IntegrationTestBase.java
@@ -1,0 +1,55 @@
+package com.gakkaweo.backend.support;
+
+import java.time.Clock;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import({TestContainerConfig.class, TestClockConfig.class})
+public abstract class IntegrationTestBase {
+
+  @LocalServerPort protected int port;
+
+  @Autowired protected DatabaseCleaner databaseCleaner;
+
+  @Autowired protected TestSimilarityClient testSimilarityClient;
+
+  @Autowired(required = false)
+  protected TestAuthHelper testAuthHelper;
+
+  @Autowired(required = false)
+  protected TestEventCollector testEventCollector;
+
+  @Autowired protected Clock clock;
+
+  protected final RestTemplate restTemplate =
+      new RestTemplateBuilder().errorHandler(new NoOpResponseErrorHandler()).build();
+
+  @BeforeEach
+  void cleanBeforeEach() {
+    databaseCleaner.clean();
+    testSimilarityClient.reset();
+    if (clock instanceof TestClock testClock) {
+      testClock.setInstant(
+          java.time.Clock.system(com.gakkaweo.backend.common.time.TimeConstants.KST).instant());
+    }
+    if (testEventCollector != null) {
+      testEventCollector.reset();
+    }
+  }
+
+  protected String baseUrl() {
+    return "http://localhost:" + port;
+  }
+
+  protected String url(String path) {
+    return baseUrl() + path;
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/NoOpResponseErrorHandler.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/NoOpResponseErrorHandler.java
@@ -1,0 +1,17 @@
+package com.gakkaweo.backend.support;
+
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.ResponseErrorHandler;
+
+public class NoOpResponseErrorHandler implements ResponseErrorHandler {
+
+  @Override
+  public boolean hasError(ClientHttpResponse response) {
+    return false;
+  }
+
+  @Override
+  public void handleError(ClientHttpResponse response) {
+    // 테스트에서 상태 코드를 직접 검증하므로 예외를 던지지 않는다.
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/TestAuthHelper.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/TestAuthHelper.java
@@ -1,0 +1,123 @@
+package com.gakkaweo.backend.support;
+
+import com.gakkaweo.backend.auth.dto.TokenPair;
+import com.gakkaweo.backend.auth.service.AuthService;
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.domain.member.entity.LocalAccount;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.entity.MemberRole;
+import com.gakkaweo.backend.domain.member.repository.LocalAccountRepository;
+import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class TestAuthHelper {
+
+  private static final AtomicLong nicknameSeq = new AtomicLong();
+  private static final AtomicLong usernameSeq = new AtomicLong();
+
+  private final MemberRepository memberRepository;
+  private final LocalAccountRepository localAccountRepository;
+  private final DailySentenceRepository dailySentenceRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final AuthService authService;
+  private final TransactionTemplate transactionTemplate;
+  private final Clock clock;
+
+  public Member createMember() {
+    return createMember(MemberRole.USER, false);
+  }
+
+  public Member createAdmin() {
+    return createMember(MemberRole.ADMIN, false);
+  }
+
+  public Member createBannedMember() {
+    return createMember(MemberRole.USER, true);
+  }
+
+  public Member createMember(MemberRole role, boolean banned) {
+    String nickname = "테스터" + nicknameSeq.incrementAndGet();
+    return transactionTemplate.execute(
+        status -> {
+          Member member = new Member(nickname);
+          if (role == MemberRole.ADMIN) {
+            member.setRole(MemberRole.ADMIN);
+          }
+          if (banned) {
+            member.setBanned(true);
+            member.setBannedAt(clock.instant());
+          }
+          return memberRepository.save(member);
+        });
+  }
+
+  public LocalAccount createLocalAccount(Member member, String username, String rawPassword) {
+    return transactionTemplate.execute(
+        status ->
+            localAccountRepository.save(
+                new LocalAccount(member, username, passwordEncoder.encode(rawPassword))));
+  }
+
+  public String nextUsername() {
+    return "user" + usernameSeq.incrementAndGet();
+  }
+
+  public TokenPair issueTokens(Member member) {
+    return authService.issueTokens(member);
+  }
+
+  public HttpHeaders cookieHeaderFor(Member member) {
+    TokenPair tokens = issueTokens(member);
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(
+        HttpHeaders.COOKIE,
+        "access_token="
+            + tokens.accessToken()
+            + "; refresh_token="
+            + tokens.refreshToken()
+            + "; has_session=1");
+    return headers;
+  }
+
+  public HttpHeaders refreshCookieHeaderFor(String refreshToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.COOKIE, "refresh_token=" + refreshToken);
+    return headers;
+  }
+
+  public HttpHeaders accessCookieHeaderFor(Member member) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.COOKIE, "access_token=" + issueTokens(member).accessToken());
+    return headers;
+  }
+
+  public String accessTokenCookieFor(Member member) {
+    return "access_token=" + issueTokens(member).accessToken();
+  }
+
+  public DailySentence createTodaySentence(String sentence) {
+    return transactionTemplate.execute(
+        status -> {
+          DailySentence s = new DailySentence(sentence);
+          s.setUsedAt(LocalDate.now(clock));
+          s.setStatus(DailySentenceStatus.USED);
+          return dailySentenceRepository.save(s);
+        });
+  }
+
+  public DailySentence createActiveSentence(String sentence) {
+    return transactionTemplate.execute(
+        status -> dailySentenceRepository.save(new DailySentence(sentence)));
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/TestClock.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/TestClock.java
@@ -1,0 +1,50 @@
+package com.gakkaweo.backend.support;
+
+import static com.gakkaweo.backend.common.time.TimeConstants.KST;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class TestClock extends Clock {
+
+  private final ZoneId zone;
+  private Instant instant;
+
+  public TestClock(Instant initial) {
+    this(initial, KST);
+  }
+
+  public TestClock(Instant initial, ZoneId zone) {
+    this.instant = initial;
+    this.zone = zone;
+  }
+
+  public static TestClock systemDefault() {
+    return new TestClock(Clock.system(KST).instant());
+  }
+
+  public void setInstant(Instant instant) {
+    this.instant = instant;
+  }
+
+  public void advanceBy(Duration duration) {
+    this.instant = this.instant.plus(duration);
+  }
+
+  @Override
+  public ZoneId getZone() {
+    return zone;
+  }
+
+  @Override
+  public Clock withZone(ZoneId zone) {
+    return new TestClock(this.instant, zone);
+  }
+
+  @Override
+  public Instant instant() {
+    return instant;
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/TestClockConfig.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/TestClockConfig.java
@@ -1,0 +1,16 @@
+package com.gakkaweo.backend.support;
+
+import java.time.Clock;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestClockConfig {
+
+  @Bean
+  @Primary
+  public Clock testClock() {
+    return TestClock.systemDefault();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/TestContainerConfig.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/TestContainerConfig.java
@@ -1,0 +1,29 @@
+package com.gakkaweo.backend.support;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainerConfig {
+
+  @Bean
+  @ServiceConnection
+  public PostgreSQLContainer<?> postgresContainer() {
+    return new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"))
+        .withDatabaseName("gakkaweo_test")
+        .withUsername("test")
+        .withPassword("test")
+        .withUrlParam("stringtype", "unspecified")
+        .withReuse(true);
+  }
+
+  @Bean
+  @ServiceConnection(name = "redis")
+  public RedisContainer redisContainer() {
+    return new RedisContainer(DockerImageName.parse("redis:7-alpine")).withReuse(true);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/TestEventCollector.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/TestEventCollector.java
@@ -1,0 +1,50 @@
+package com.gakkaweo.backend.support;
+
+import com.gakkaweo.backend.admin.event.AnnouncementEvent;
+import com.gakkaweo.backend.ranking.event.DayChangeEvent;
+import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestEventCollector {
+
+  private final List<RankingUpdateEvent> rankingEvents = new CopyOnWriteArrayList<>();
+  private final List<AnnouncementEvent> announcementEvents = new CopyOnWriteArrayList<>();
+  private final List<DayChangeEvent> dayChangeEvents = new CopyOnWriteArrayList<>();
+
+  @EventListener
+  public void onRanking(RankingUpdateEvent event) {
+    rankingEvents.add(event);
+  }
+
+  @EventListener
+  public void onAnnouncement(AnnouncementEvent event) {
+    announcementEvents.add(event);
+  }
+
+  @EventListener
+  public void onDayChange(DayChangeEvent event) {
+    dayChangeEvents.add(event);
+  }
+
+  public List<RankingUpdateEvent> getRankingEvents() {
+    return rankingEvents;
+  }
+
+  public List<AnnouncementEvent> getAnnouncementEvents() {
+    return announcementEvents;
+  }
+
+  public List<DayChangeEvent> getDayChangeEvents() {
+    return dayChangeEvents;
+  }
+
+  public void reset() {
+    rankingEvents.clear();
+    announcementEvents.clear();
+    dayChangeEvents.clear();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/TestSimilarityClient.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/TestSimilarityClient.java
@@ -1,0 +1,67 @@
+package com.gakkaweo.backend.support;
+
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.infra.ai.service.SimilarityClient;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+@org.springframework.context.annotation.Primary
+public class TestSimilarityClient implements SimilarityClient {
+
+  private final Map<String, BigDecimal> programmedScores = new HashMap<>();
+  private BigDecimal defaultScore = new BigDecimal("50.0");
+  private boolean throwUnavailable = false;
+
+  public void program(String guessText, BigDecimal score) {
+    programmedScores.put(normalizeKey(guessText), score);
+  }
+
+  public void setDefaultScore(BigDecimal score) {
+    this.defaultScore = score;
+  }
+
+  public void throwOnNext() {
+    this.throwUnavailable = true;
+  }
+
+  public void reset() {
+    programmedScores.clear();
+    defaultScore = new BigDecimal("50.0");
+    throwUnavailable = false;
+  }
+
+  @Override
+  public BigDecimal testSimilarity(String sentenceText, String guessText) {
+    return resolveScore(guessText);
+  }
+
+  @Override
+  public BigDecimal calculateSimilarity(
+      Long sentenceId, String guessText, String sentenceText, Duration cacheTtl) {
+    return resolveScore(guessText);
+  }
+
+  private BigDecimal resolveScore(String guessText) {
+    if (throwUnavailable) {
+      throwUnavailable = false;
+      throw new BusinessException(ErrorCode.AI_SERVICE_UNAVAILABLE);
+    }
+    String normalized = normalizeKey(guessText);
+    if (normalized.isEmpty()) {
+      throw new BusinessException(ErrorCode.INVALID_GUESS_TEXT);
+    }
+    return programmedScores.getOrDefault(normalized, defaultScore);
+  }
+
+  private String normalizeKey(String text) {
+    if (text == null) {
+      return "";
+    }
+    return text.replaceAll("[^가-힣a-zA-Z0-9\\s]", "").replaceAll("\\s+", " ").trim();
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/upload/CsvUploadIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/upload/CsvUploadIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.gakkaweo.backend.upload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.admin.dto.CsvUploadResponse;
+import com.gakkaweo.backend.auth.dto.TokenPair;
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@DisplayName("CSV 업로드 통합 테스트")
+class CsvUploadIntegrationTest extends IntegrationTestBase {
+
+  @Autowired DailySentenceRepository dailySentenceRepository;
+
+  @Test
+  @DisplayName("정상 업로드 - 201 + 성공/중복 집계")
+  void 정상_업로드() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createActiveSentence("이미 있는 문장");
+
+    String csv = "새 문장 하나\n새 문장 둘\n이미 있는 문장\n";
+
+    ResponseEntity<CsvUploadResponse> response = upload(admin, csv);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getBody().totalRows()).isEqualTo(3);
+    assertThat(response.getBody().successCount()).isEqualTo(2);
+    assertThat(response.getBody().duplicateCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("빈 파일 - totalRows=0, success=0")
+  void 빈_파일() {
+    Member admin = testAuthHelper.createAdmin();
+    ResponseEntity<CsvUploadResponse> response = upload(admin, "");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getBody().totalRows()).isEqualTo(0);
+    assertThat(response.getBody().successCount()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("공백 라인 스킵")
+  void 공백_라인() {
+    Member admin = testAuthHelper.createAdmin();
+    String csv = "\n문장A\n   \n문장B\n";
+
+    ResponseEntity<CsvUploadResponse> response = upload(admin, csv);
+
+    assertThat(response.getBody().totalRows()).isEqualTo(2);
+    assertThat(response.getBody().successCount()).isEqualTo(2);
+  }
+
+  private ResponseEntity<CsvUploadResponse> upload(Member admin, String csvContent) {
+    TokenPair tokens = testAuthHelper.issueTokens(admin);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+    headers.set(
+        HttpHeaders.COOKIE,
+        "access_token=" + tokens.accessToken() + "; refresh_token=" + tokens.refreshToken());
+
+    ByteArrayResource resource =
+        new ByteArrayResource(csvContent.getBytes()) {
+          @Override
+          public String getFilename() {
+            return "upload.csv";
+          }
+        };
+
+    HttpHeaders partHeaders = new HttpHeaders();
+    partHeaders.setContentType(MediaType.TEXT_PLAIN);
+    HttpEntity<ByteArrayResource> filePart = new HttpEntity<>(resource, partHeaders);
+
+    MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+    body.add("file", filePart);
+
+    return restTemplate.exchange(
+        url("/admin/sentences/upload"),
+        HttpMethod.POST,
+        new HttpEntity<>(body, headers),
+        CsvUploadResponse.class);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/upload/FileUploadTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/upload/FileUploadTest.java
@@ -1,0 +1,105 @@
+package com.gakkaweo.backend.upload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.auth.dto.AuthResponse;
+import com.gakkaweo.backend.auth.dto.TokenPair;
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@DisplayName("파일 업로드 통합 테스트")
+class FileUploadTest extends IntegrationTestBase {
+
+  private static final byte[] MINIMAL_WEBP = {
+    'R', 'I', 'F', 'F', 0, 0, 0, 0, 'W', 'E', 'B', 'P', 0x20, 0x20, 0x20, 0x20
+  };
+
+  private static final byte[] MINIMAL_PNG = {
+    (byte) 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n', 0, 0, 0, 0
+  };
+
+  @Test
+  @DisplayName("WebP 업로드 성공")
+  void webp_성공() {
+    Member member = testAuthHelper.createMember();
+    HttpEntity<MultiValueMap<String, Object>> request =
+        multipartRequest(member, MINIMAL_WEBP, "image/webp", "profile.webp");
+
+    ResponseEntity<AuthResponse> response =
+        restTemplate.exchange(
+            url("/auth/profile-image"), HttpMethod.PATCH, request, AuthResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().profileUrl()).contains(member.getPublicId().toString());
+  }
+
+  @Test
+  @DisplayName("PNG 거부 - INVALID_FILE_TYPE(400)")
+  void png_거부() {
+    Member member = testAuthHelper.createMember();
+    HttpEntity<MultiValueMap<String, Object>> request =
+        multipartRequest(member, MINIMAL_PNG, "image/png", "profile.png");
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/auth/profile-image"), HttpMethod.PATCH, request, ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("INVALID_FILE_TYPE");
+  }
+
+  @Test
+  @DisplayName("text/plain → INVALID_FILE_TYPE")
+  void 텍스트_거부() {
+    Member member = testAuthHelper.createMember();
+    HttpEntity<MultiValueMap<String, Object>> request =
+        multipartRequest(member, "not an image".getBytes(), "text/plain", "notes.txt");
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/auth/profile-image"), HttpMethod.PATCH, request, ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("INVALID_FILE_TYPE");
+  }
+
+  private HttpEntity<MultiValueMap<String, Object>> multipartRequest(
+      Member member, byte[] content, String contentType, String filename) {
+    TokenPair tokens = testAuthHelper.issueTokens(member);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+    headers.set(
+        HttpHeaders.COOKIE,
+        "access_token=" + tokens.accessToken() + "; refresh_token=" + tokens.refreshToken());
+
+    ByteArrayResource resource =
+        new ByteArrayResource(content) {
+          @Override
+          public String getFilename() {
+            return filename;
+          }
+        };
+
+    HttpHeaders partHeaders = new HttpHeaders();
+    partHeaders.setContentType(MediaType.valueOf(contentType));
+    HttpEntity<ByteArrayResource> filePart = new HttpEntity<>(resource, partHeaders);
+
+    MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+    body.add("file", filePart);
+
+    return new HttpEntity<>(body, headers);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/util/HintMaskGeneratorTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/util/HintMaskGeneratorTest.java
@@ -1,0 +1,37 @@
+package com.gakkaweo.backend.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.game.util.HintMaskGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("HintMaskGenerator 단위 테스트")
+class HintMaskGeneratorTest {
+
+  private final HintMaskGenerator generator = new HintMaskGenerator();
+
+  @Test
+  @DisplayName("단어별 글자 수 + 밑줄 마스크")
+  void 마스크_생성() {
+    HintMaskGenerator.HintMask mask = generator.generate("오늘 날씨가 좋다");
+
+    assertThat(mask.charCounts()).containsExactly(2, 3, 2);
+    assertThat(mask.mask()).isEqualTo("__ ___ __");
+  }
+
+  @Test
+  @DisplayName("단일 단어")
+  void 단일_단어() {
+    HintMaskGenerator.HintMask mask = generator.generate("안녕");
+    assertThat(mask.charCounts()).containsExactly(2);
+    assertThat(mask.mask()).isEqualTo("__");
+  }
+
+  @Test
+  @DisplayName("연속 공백 - split 정규식으로 빈 토큰 제외")
+  void 연속공백() {
+    HintMaskGenerator.HintMask mask = generator.generate("가  나");
+    assertThat(mask.charCounts()).containsExactly(1, 1);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/util/TextNormalizerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/util/TextNormalizerTest.java
@@ -1,0 +1,53 @@
+package com.gakkaweo.backend.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.infra.ai.service.TextNormalizer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TextNormalizer 단위 테스트")
+class TextNormalizerTest {
+
+  private final TextNormalizer normalizer = new TextNormalizer();
+
+  @Test
+  @DisplayName("특수문자 제거")
+  void 특수문자_제거() {
+    assertThat(normalizer.normalize("안녕! 하세요?")).isEqualTo("안녕 하세요");
+    assertThat(normalizer.normalize("hello, world.")).isEqualTo("hello world");
+  }
+
+  @Test
+  @DisplayName("연속 공백 축약")
+  void 공백_축약() {
+    assertThat(normalizer.normalize("a   b   c")).isEqualTo("a b c");
+  }
+
+  @Test
+  @DisplayName("한글/영문/숫자 보존")
+  void 보존() {
+    assertThat(normalizer.normalize("가나다123abc")).isEqualTo("가나다123abc");
+  }
+
+  @Test
+  @DisplayName("공백/특수문자만 → 빈 문자열")
+  void 전체_특수문자() {
+    assertThat(normalizer.normalize("!!!")).isEmpty();
+    assertThat(normalizer.normalize("   ")).isEmpty();
+  }
+
+  @Test
+  @DisplayName("해시 - 동일 입력 동일 해시")
+  void 해시_일관성() {
+    String a = normalizer.hashForCache("hello");
+    String b = normalizer.hashForCache("hello");
+    assertThat(a).isEqualTo(b).hasSize(64);
+  }
+
+  @Test
+  @DisplayName("해시 - 다른 입력 다른 해시")
+  void 해시_차이() {
+    assertThat(normalizer.hashForCache("a")).isNotEqualTo(normalizer.hashForCache("b"));
+  }
+}

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -1,0 +1,118 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+  servlet:
+    multipart:
+      max-file-size: 1MB
+      max-request-size: 2MB
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: test-kakao-id
+            client-secret: test-kakao-secret
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope: account_email
+            client-name: Kakao
+          google:
+            client-id: test-google-id
+            client-secret: test-google-secret
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope: email
+            client-name: Google
+          naver:
+            client-id: test-naver-id
+            client-secret: test-naver-secret
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope: email
+            client-name: Naver
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+jwt:
+  access-secret: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
+  access-expiration: 30m
+  refresh-expiration: 7d
+
+cookie:
+  secure: false
+  domain: ""
+
+app:
+  oauth2:
+    authorized-redirect-uri: http://localhost:3000
+  ai-service:
+    url: http://localhost:8000
+    timeout: 3s
+  game:
+    similarity-threshold: 95.0
+    hint-trigger-threshold: 60.0
+    hint-max-similarity: 90.0
+    hint-max-count: 5
+  upload:
+    profile-dir: ${java.io.tmpdir}/gakkaweo-test/profiles
+  rate-limit:
+    guess-per-minute: 10000
+    read-per-minute: 10000
+    sse-per-minute: 10000
+    auth-per-minute: 10000
+    admin-per-minute: 10000
+    bucket-expiry-minutes: 60
+    cleanup-interval-ms: 300000
+  seed:
+    enabled: false
+    admin-password: ""
+  openapi:
+    docs-mode: false
+
+springdoc:
+  api-docs:
+    groups:
+      enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+  show-actuator: false
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      aiService:
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+
+logging:
+  level:
+    com.gakkaweo.backend: INFO
+    org.testcontainers: INFO
+    com.github.dockerjava: WARN


### PR DESCRIPTION
## 관련 이슈

Closes #130

## 변경 사항

### 테스트 인프라 도입
- Testcontainers 기반(PostgreSQL 16 + Redis 7) 통합 테스트 환경 구축
- `IntegrationTestBase` + `DatabaseCleaner`(TRUNCATE+FLUSHALL) 기반 테스트 격리 (`@Transactional` 롤백 불가 문제 회피)
- `TestClock`/`TestSimilarityClient`/`TestAuthHelper`/`TestEventCollector` 등 지원 클래스 마련
- JaCoCo 커버리지 측정 플러그인 추가, `InitialDataSeeder` exclude 반영
- WireMock 3.9.2 testImplementation 추가 (OAuth userinfo, AI 서비스 HTTP 스텁)
- CI에서 백엔드 테스트 실행 활성화

### 테스트 범위 확보
- 인증/OAuth2: 쿠키 저장소, 로그인 성공/실패 핸들러, CustomOAuth2UserService, CustomUserDetails
- 게임/랭킹/SSE: GameFlow, 동시성, 랭킹 스코어 인코딩, SSE 이벤트/스트림/최대 연결, 자정 스케줄러
- 어드민: 문장 CRUD·긴급 교체, 사용자 필터·역할 변경·차단, 시스템 공지·감사 로그
- 보안/예외/RateLimit: SecurityConfig, GlobalExceptionHandler, EndpointGroupResolver
- 인프라/유틸/업로드: Flyway, 네이티브 쿼리, WebP 프로필 업로드, CSV 문장 업로드, 텍스트 정규화
- 외부 서비스: AiServiceClient(WireMock), SimilarityService(Mockito)
- 공개 엔드포인트: AnnouncementController
- 랭킹 Redis 포함 경로: \`updateRanking\` 이후의 조회/재구축 루프 전반

### 부수 변경
- 프로덕션 버그 1건 수정: 리프레시 토큰 재사용 감지 시 family revoke가 상위 트랜잭션 롤백으로 무효화되던 문제를 \`TransactionTemplate(REQUIRES_NEW)\`로 분리
- 시간 의존 서비스에 \`Clock\` 빈 주입 (테스트에서 \`TestClock\`으로 제어)
- \`SseConnectionManager.MAX_CONNECTIONS\` 상수 → \`@Value\` 프로퍼티로 전환
- \`GameSession.markCleared\`/\`updateClearedAt\` 시그니처에 \`Instant now\` 인자 추가

### 커버리지 결과

| 지표 | 최종 |
| --- | --- |
| Line | 93.17% (2045/2195) |
| Branch | 83.49% (364/436) |
| Method | 93.75% (390/416) |
| Class | 100% (80/80) |

총 256개 테스트 전부 통과.

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (전체 256 테스트 통과)
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다 (프로덕션 코드 변경은 리팩토링 커밋에 국한)