### PR TITLE
feat: 설정 모달 볼륨 아이콘 mute 토글

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -243,6 +243,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 
 - **테마**: 라이트/다크/시스템 3버튼 토글. 활성 = `bg-black text-white`
 - **사운드 볼륨**: `input[type=range]` 슬라이더 (`accent-yellow-400`). localStorage `sound_volume` (기본 0.7, 범위 0~1). 상수: `shared/config/sound.ts`. 0이면 🔇, 그 외 🔊
+- **볼륨 아이콘 mute 토글**: 🔊/🔇 아이콘은 `border-2 shadow-brutal-sm-hover w-7 h-7` 버튼. 클릭 시 mute 토글, 이전 볼륨은 localStorage `sound_last_volume`에 보존(0 초과 값만 저장). 접근성: `aria-label` 동적 전환 + `aria-pressed`
 - **사운드 테스트**: 런치패드 버튼 (`border-2 shadow-brutal-sm`). 색상별 구분 (클리어=green-400, 실패=red-400). 기존 재생 중 사운드 정지 후 새로 재생. 음소거 시 disabled
 
 ### 프로필 이미지 (마이페이지)

--- a/frontend/src/app/layout/SettingsModal.tsx
+++ b/frontend/src/app/layout/SettingsModal.tsx
@@ -3,9 +3,11 @@ import { useThemeStore } from "@/shared/stores/useThemeStore";
 import {
   SOUND_VOLUME_KEY,
   type SoundType,
+  getLastVolume,
   getSoundVolume,
   playSound,
   setCurrentSoundVolume,
+  setLastVolume,
   stopCurrentSound,
 } from "@/shared/config/sound";
 
@@ -39,10 +41,19 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     } catch {
       // 스토리지 접근 불가 시 무시
     }
-    if (v <= 0) {
-      stopCurrentSound();
-    } else {
+    if (v > 0) {
+      setLastVolume(v);
       setCurrentSoundVolume(v);
+    } else {
+      stopCurrentSound();
+    }
+  }
+
+  function handleMuteToggle() {
+    if (volume > 0) {
+      handleVolumeChange(0);
+    } else {
+      handleVolumeChange(getLastVolume());
     }
   }
 
@@ -151,9 +162,15 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               사운드
             </h3>
             <div className="flex items-center gap-3">
-              <span className="text-lg shrink-0" aria-hidden="true">
+              <button
+                type="button"
+                onClick={handleMuteToggle}
+                aria-label={volume === 0 ? "음소거 해제" : "음소거"}
+                aria-pressed={volume === 0}
+                className="border-2 border-black dark:border-white bg-white dark:bg-gray-900 w-7 h-7 shrink-0 flex items-center justify-center text-sm transition-all duration-100 shadow-brutal-sm-hover hover:shadow-none hover:translate-x-[1px] hover:translate-y-[1px] active:shadow-none active:translate-x-[1px] active:translate-y-[1px]"
+              >
                 {volume === 0 ? "🔇" : "🔊"}
-              </span>
+              </button>
               <input
                 type="range"
                 aria-label="사운드 볼륨"

--- a/frontend/src/shared/config/sound.ts
+++ b/frontend/src/shared/config/sound.ts
@@ -1,4 +1,5 @@
 export const SOUND_VOLUME_KEY = "sound_volume";
+export const SOUND_LAST_VOLUME_KEY = "sound_last_volume";
 export const DEFAULT_VOLUME = 0.7;
 
 export type SoundType = "clear" | "fail";
@@ -16,6 +17,30 @@ export function getSoundVolume(): number {
     return v !== null ? parseFloat(v) : DEFAULT_VOLUME;
   } catch {
     return DEFAULT_VOLUME;
+  }
+}
+
+export function getLastVolume(): number {
+  try {
+    const v = localStorage.getItem(SOUND_LAST_VOLUME_KEY);
+    if (v === null) {
+      return DEFAULT_VOLUME;
+    }
+    const parsed = parseFloat(v);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_VOLUME;
+  } catch {
+    return DEFAULT_VOLUME;
+  }
+}
+
+export function setLastVolume(v: number): void {
+  if (!(v > 0)) {
+    return;
+  }
+  try {
+    localStorage.setItem(SOUND_LAST_VOLUME_KEY, String(v));
+  } catch {
+    // 스토리지 접근 불가 시 무시
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

Closes #140

## 변경 사항

- 🔊/🔇 아이콘 `<span>` → `<button>` 전환, 클릭 시 즉시 mute / 이전 볼륨 복원
- `shared/config/sound.ts`에 `SOUND_LAST_VOLUME_KEY` + `getLastVolume()` / `setLastVolume()` 추가 (0 초과 값만 저장 가드, NaN/0 이하 시 `DEFAULT_VOLUME` 폴백)
- `handleVolumeChange`에서 `v > 0`일 때 `setLastVolume(v)` 동시 호출 - 슬라이더 조작도 last 갱신 경로에 포함
- 버튼 스타일은 RankingPanel 재생/정지 버튼 패턴 재사용 (`w-7 h-7 border-2 shadow-brutal-sm-hover` + hover/active translate)
- 접근성: `aria-label` 동적 전환("음소거"/"음소거 해제") + `aria-pressed={volume === 0}`
- `docs/design-system.md` 설정 모달 사운드 항목에 mute 토글 한 줄 동기화

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (`pnpm lint` / `format:check` / `build` 통과)
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는다 (사운드 재생 경로는 기존 `getSoundVolume()` 그대로 사용 → 자동 mute 적용)