### PR TITLE
fix: 클라이언트 IP 추적 정확화

### DIFF
--- a/nginx/api.conf
+++ b/nginx/api.conf
@@ -9,6 +9,11 @@ server {
     listen 443 ssl;
     server_name api.r4b2.xyz;
 
+    # Cloudflare 실제 클라이언트 IP 복원 (CF 엣지 IP → CF-Connecting-IP 헤더 값)
+    include /etc/nginx/conf.d/cloudflare-ips.conf;
+    real_ip_header CF-Connecting-IP;
+    real_ip_recursive off;
+
     ssl_certificate /etc/nginx/ssl/origin.pem;
     ssl_certificate_key /etc/nginx/ssl/origin-key.pem;
 

--- a/nginx/cloudflare-ips.conf
+++ b/nginx/cloudflare-ips.conf
@@ -1,0 +1,29 @@
+# Cloudflare 신뢰 프록시 IP 대역
+# https://www.cloudflare.com/ips-v4, https://www.cloudflare.com/ips-v6
+# 2026-04-24
+
+# IPv4
+set_real_ip_from 173.245.48.0/20;
+set_real_ip_from 103.21.244.0/22;
+set_real_ip_from 103.22.200.0/22;
+set_real_ip_from 103.31.4.0/22;
+set_real_ip_from 141.101.64.0/18;
+set_real_ip_from 108.162.192.0/18;
+set_real_ip_from 190.93.240.0/20;
+set_real_ip_from 188.114.96.0/20;
+set_real_ip_from 197.234.240.0/22;
+set_real_ip_from 198.41.128.0/17;
+set_real_ip_from 162.158.0.0/15;
+set_real_ip_from 104.16.0.0/13;
+set_real_ip_from 104.24.0.0/14;
+set_real_ip_from 172.64.0.0/13;
+set_real_ip_from 131.0.72.0/22;
+
+# IPv6
+set_real_ip_from 2400:cb00::/32;
+set_real_ip_from 2606:4700::/32;
+set_real_ip_from 2803:f800::/32;
+set_real_ip_from 2405:b500::/32;
+set_real_ip_from 2405:8100::/32;
+set_real_ip_from 2a06:98c0::/29;
+set_real_ip_from 2c0f:f248::/32;


### PR DESCRIPTION
## 관련 이슈

Closes #142

## 변경 사항

- `nginx/cloudflare-ips.conf` 신규 작성. Cloudflare 공식 IPv4 15개, IPv6 7개 CIDR을 `set_real_ip_from`으로 나열 (2026-04-24 fetch)
- `nginx/api.conf`의 443 server 블록에 `include /etc/nginx/conf.d/cloudflare-ips.conf;` + `real_ip_header CF-Connecting-IP;` + `real_ip_recursive off;` 3줄 추가
- 이로써 `$remote_addr`가 CF 엣지 IP → 실제 클라이언트 IP로 치환. BE의 `request.getRemoteAddr()` 22곳(어드민 감사 21곳 + Rate Limit 2곳 중 공통)이 자동 반영
- BE `FORWARD_HEADERS_STRATEGY=native`는 `.env.prod`에 이미 설정되어 있어 코드/환경 변경 없음

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다