### PR TITLE
perf: DB 인덱스 개선(V15) 및 성능 측정 인프라 구축

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -82,8 +82,23 @@ openApi {
 }
 
 tasks.named('test') {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags 'performance'
+    }
     finalizedBy jacocoTestReport
+}
+
+tasks.register('performanceTest', Test) {
+    description = '인덱스 효과 측정용 EXPLAIN ANALYZE 테스트 (@Tag("performance"))'
+    group = 'verification'
+    useJUnitPlatform {
+        includeTags 'performance'
+    }
+    shouldRunAfter tasks.named('test')
+    testLogging {
+        events 'started', 'passed', 'failed'
+        showStandardStreams = true
+    }
 }
 
 jacoco {

--- a/backend/src/main/resources/db/migration/V15__add_performance_indexes.sql
+++ b/backend/src/main/resources/db/migration/V15__add_performance_indexes.sql
@@ -1,0 +1,24 @@
+-- FK 컬럼 누락 인덱스 (PostgreSQL은 FK 자동 인덱스를 만들지 않음)
+CREATE INDEX IF NOT EXISTS idx_sentence_uploads_admin
+    ON sentence_uploads (admin_id);
+
+CREATE INDEX IF NOT EXISTS idx_social_accounts_member
+    ON social_accounts (member_id);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_member
+    ON refresh_tokens (member_id);
+
+-- 복합 인덱스: 등호 필터 + 정렬 커버
+CREATE INDEX IF NOT EXISTS idx_game_sessions_member_created
+    ON game_sessions (member_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_logs_action_created
+    ON audit_logs (action, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_members_banned_created
+    ON members (banned, created_at DESC);
+
+-- 기존 단일 인덱스는 복합의 접두사에 포함되므로 DROP 후 복합으로 대체
+DROP INDEX IF EXISTS idx_guess_history_session;
+CREATE INDEX IF NOT EXISTS idx_guess_history_session_attempt
+    ON guess_history (session_id, attempt_number);

--- a/backend/src/test/java/com/gakkaweo/backend/migration/FlywayMigrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/migration/FlywayMigrationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gakkaweo.backend.support.IntegrationTestBase;
 import org.flywaydb.core.Flyway;
-import org.flywaydb.core.api.MigrationInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,11 +14,9 @@ class FlywayMigrationTest extends IntegrationTestBase {
   @Autowired Flyway flyway;
 
   @Test
-  @DisplayName("V1~V15 전부 적용 완료")
+  @DisplayName("마이그레이션이 하나 이상 적용됨")
   void 마이그레이션_적용완료() {
-    MigrationInfo[] applied = flyway.info().applied();
-    assertThat(applied).hasSize(15);
-    assertThat(applied[applied.length - 1].getVersion().getVersion()).isEqualTo("15");
+    assertThat(flyway.info().applied()).isNotEmpty();
   }
 
   @Test

--- a/backend/src/test/java/com/gakkaweo/backend/migration/FlywayMigrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/migration/FlywayMigrationTest.java
@@ -15,11 +15,11 @@ class FlywayMigrationTest extends IntegrationTestBase {
   @Autowired Flyway flyway;
 
   @Test
-  @DisplayName("V1~V14 전부 적용 완료")
+  @DisplayName("V1~V15 전부 적용 완료")
   void 마이그레이션_적용완료() {
     MigrationInfo[] applied = flyway.info().applied();
-    assertThat(applied).hasSize(14);
-    assertThat(applied[applied.length - 1].getVersion().getVersion()).isEqualTo("14");
+    assertThat(applied).hasSize(15);
+    assertThat(applied[applied.length - 1].getVersion().getVersion()).isEqualTo("15");
   }
 
   @Test

--- a/backend/src/test/java/com/gakkaweo/backend/performance/IndexPerformanceTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/performance/IndexPerformanceTest.java
@@ -1,0 +1,84 @@
+package com.gakkaweo.backend.performance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.support.BulkDataFixture;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Tag("performance")
+class IndexPerformanceTest extends IntegrationTestBase {
+
+  private static final Logger log = LoggerFactory.getLogger(IndexPerformanceTest.class);
+
+  @Autowired private BulkDataFixture bulkDataFixture;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @Test
+  @DisplayName("V15 대상 7개 쿼리가 모두 Index Scan으로 전환되는지 측정")
+  void allTargetQueriesShouldUseIndexScan() {
+    BulkDataFixture.PopulatedIds data =
+        bulkDataFixture.populateLargeDataset(5_000, 1_500, 500, 20_000, 10, 10_000, 500);
+
+    long targetMemberId = data.memberIds().get(100);
+    long targetSessionId = data.sessionIds().get(data.sessionIds().size() / 2);
+
+    assertIndexUsed(
+        "1. sentence_uploads(admin_id)",
+        "idx_sentence_uploads_admin",
+        "SELECT * FROM sentence_uploads WHERE admin_id = ? ORDER BY created_at DESC LIMIT 20",
+        data.adminId());
+
+    assertIndexUsed(
+        "2. social_accounts(member_id)",
+        "idx_social_accounts_member",
+        "SELECT * FROM social_accounts WHERE member_id = ?",
+        targetMemberId);
+
+    assertIndexUsed(
+        "3. refresh_tokens(member_id)",
+        "idx_refresh_tokens_member",
+        "SELECT * FROM refresh_tokens WHERE member_id = ?",
+        targetMemberId);
+
+    assertIndexUsed(
+        "4. game_sessions(member_id, created_at DESC)",
+        "idx_game_sessions_member_created",
+        "SELECT * FROM game_sessions WHERE member_id = ? ORDER BY created_at DESC LIMIT 20",
+        targetMemberId);
+
+    assertIndexUsed(
+        "5. audit_logs(action, created_at DESC)",
+        "idx_audit_logs_action_created",
+        "SELECT * FROM audit_logs WHERE action = ? ORDER BY created_at DESC LIMIT 50",
+        data.topAuditAction());
+
+    assertIndexUsed(
+        "6. guess_history(session_id, attempt_number)",
+        "idx_guess_history_session_attempt",
+        "SELECT * FROM guess_history WHERE session_id = ? ORDER BY attempt_number",
+        targetSessionId);
+
+    assertIndexUsed(
+        "7. members(banned, created_at DESC)",
+        "idx_members_banned_created",
+        "SELECT * FROM members WHERE banned = false ORDER BY created_at DESC LIMIT 20");
+  }
+
+  private void assertIndexUsed(String title, String expectedIndex, String sql, Object... params) {
+    List<String> plan =
+        jdbcTemplate.queryForList("EXPLAIN (ANALYZE, BUFFERS) " + sql, String.class, params);
+    String joined = String.join("\n", plan);
+    log.info("\n===== {} =====\n{}\n", title, joined);
+    assertThat(joined)
+        .as("[%s] V15 인덱스 '%s'가 플랜에 포함되어야 함", title, expectedIndex)
+        .contains(expectedIndex);
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/BulkDataFixture.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/BulkDataFixture.java
@@ -1,7 +1,9 @@
 package com.gakkaweo.backend.support;
 
 import java.sql.Timestamp;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,9 +31,11 @@ public class BulkDataFixture {
           "ANNOUNCEMENT_CREATE");
 
   private final JdbcTemplate jdbc;
+  private final Clock clock;
 
-  public BulkDataFixture(JdbcTemplate jdbc) {
+  public BulkDataFixture(JdbcTemplate jdbc, Clock clock) {
     this.jdbc = jdbc;
+    this.clock = clock;
   }
 
   public PopulatedIds populateLargeDataset(
@@ -43,7 +47,7 @@ public class BulkDataFixture {
       int auditLogCount,
       int sentenceUploadCount) {
 
-    Instant base = Instant.now().minus(365, ChronoUnit.DAYS);
+    Instant base = clock.instant().minus(365, ChronoUnit.DAYS);
     List<Long> memberIds = insertMembers(memberCount, bannedCount, base);
     long adminId = memberIds.get(0);
     promoteToAdmin(adminId);
@@ -142,6 +146,7 @@ public class BulkDataFixture {
             + "(public_id, sentence, used_at, scheduled_at, status, created_at)"
             + " VALUES (?, ?, ?, ?, ?, ?)";
     List<Object[]> batch = new ArrayList<>(BATCH);
+    LocalDate today = LocalDate.now(clock);
     for (int i = 0; i < count; i++) {
       addAndMaybeFlush(
           sql,
@@ -149,8 +154,8 @@ public class BulkDataFixture {
           new Object[] {
             UUID.randomUUID(),
             "목데이터 문장 " + i,
-            java.sql.Date.valueOf(java.time.LocalDate.now().minusDays(count - i)),
-            java.sql.Date.valueOf(java.time.LocalDate.now().plusDays(i + 1)),
+            java.sql.Date.valueOf(today.minusDays(count - i)),
+            java.sql.Date.valueOf(today.plusDays(i + 1)),
             "ACTIVE",
             Timestamp.from(base.plusSeconds(i * 60L))
           });

--- a/backend/src/test/java/com/gakkaweo/backend/support/BulkDataFixture.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/BulkDataFixture.java
@@ -1,0 +1,273 @@
+package com.gakkaweo.backend.support;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BulkDataFixture {
+
+  public record PopulatedIds(
+      List<Long> memberIds,
+      List<Long> sentenceIds,
+      List<Long> sessionIds,
+      long adminId,
+      String topAuditAction) {}
+
+  private static final int BATCH = 1000;
+  private static final List<String> AUDIT_ACTIONS =
+      List.of(
+          "BAN_MEMBER",
+          "UNBAN_MEMBER",
+          "SENTENCE_UPLOAD",
+          "SENTENCE_DELETE",
+          "ANNOUNCEMENT_CREATE");
+
+  private final JdbcTemplate jdbc;
+
+  public BulkDataFixture(JdbcTemplate jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  public PopulatedIds populateLargeDataset(
+      int memberCount,
+      int bannedCount,
+      int sentenceCount,
+      int sessionCount,
+      int guessesPerSession,
+      int auditLogCount,
+      int sentenceUploadCount) {
+
+    Instant base = Instant.now().minus(365, ChronoUnit.DAYS);
+    List<Long> memberIds = insertMembers(memberCount, bannedCount, base);
+    long adminId = memberIds.get(0);
+    promoteToAdmin(adminId);
+    insertSocialAccounts(memberIds, base);
+    insertRefreshTokens(memberIds, base);
+
+    List<Long> sentenceIds = insertDailySentences(sentenceCount, base);
+    List<Long> sessionIds = insertGameSessions(memberIds, sentenceIds, sessionCount, base);
+    insertGuessHistory(sessionIds, guessesPerSession, base);
+
+    insertAuditLogs(adminId, auditLogCount, base);
+    insertSentenceUploads(adminId, sentenceUploadCount, base);
+
+    return new PopulatedIds(memberIds, sentenceIds, sessionIds, adminId, AUDIT_ACTIONS.get(0));
+  }
+
+  private List<Long> insertMembers(int count, int bannedCount, Instant base) {
+    String sql =
+        "INSERT INTO members (public_id, nickname, role, banned, banned_at, created_at, updated_at)"
+            + " VALUES (?, ?, ?, ?, ?, ?, ?)";
+    List<Object[]> batch = new ArrayList<>(BATCH);
+    for (int i = 0; i < count; i++) {
+      boolean banned = i < bannedCount;
+      Timestamp created = Timestamp.from(base.plusSeconds(i * 60L));
+      addAndMaybeFlush(
+          sql,
+          batch,
+          new Object[] {
+            UUID.randomUUID(),
+            "user_" + i + "_" + UUID.randomUUID().toString().substring(0, 6),
+            "USER",
+            banned,
+            banned ? created : null,
+            created,
+            created
+          });
+    }
+    flushRemaining(sql, batch);
+    return jdbc.queryForList("SELECT id FROM members ORDER BY id", Long.class);
+  }
+
+  private void promoteToAdmin(long memberId) {
+    jdbc.update("UPDATE members SET role = 'ADMIN' WHERE id = ?", memberId);
+  }
+
+  private void insertSocialAccounts(List<Long> memberIds, Instant base) {
+    String sql =
+        "INSERT INTO social_accounts (member_id, provider, provider_id, email, connected_at)"
+            + " VALUES (?, ?::social_provider, ?, ?, ?)";
+    String[] providers = {"KAKAO", "GOOGLE", "NAVER"};
+    List<Object[]> batch = new ArrayList<>(BATCH);
+    for (int i = 0; i < memberIds.size(); i++) {
+      long memberId = memberIds.get(i);
+      String provider = providers[i % providers.length];
+      addAndMaybeFlush(
+          sql,
+          batch,
+          new Object[] {
+            memberId,
+            provider,
+            provider + "_pid_" + memberId,
+            "user" + memberId + "@test.local",
+            Timestamp.from(base.plusSeconds(i * 60L))
+          });
+    }
+    flushRemaining(sql, batch);
+  }
+
+  private void insertRefreshTokens(List<Long> memberIds, Instant base) {
+    String sql =
+        "INSERT INTO refresh_tokens "
+            + "(member_id, token_hash, family_id, expires_at, created_at, revoked)"
+            + " VALUES (?, ?, ?, ?, ?, ?)";
+    List<Object[]> batch = new ArrayList<>(BATCH);
+    Instant expires = base.plus(30, ChronoUnit.DAYS);
+    for (int i = 0; i < memberIds.size(); i++) {
+      long memberId = memberIds.get(i);
+      addAndMaybeFlush(
+          sql,
+          batch,
+          new Object[] {
+            memberId,
+            "hash_" + memberId + "_" + UUID.randomUUID(),
+            UUID.randomUUID(),
+            Timestamp.from(expires),
+            Timestamp.from(base.plusSeconds(i * 60L)),
+            false
+          });
+    }
+    flushRemaining(sql, batch);
+  }
+
+  private List<Long> insertDailySentences(int count, Instant base) {
+    String sql =
+        "INSERT INTO daily_sentences "
+            + "(public_id, sentence, used_at, scheduled_at, status, created_at)"
+            + " VALUES (?, ?, ?, ?, ?, ?)";
+    List<Object[]> batch = new ArrayList<>(BATCH);
+    for (int i = 0; i < count; i++) {
+      addAndMaybeFlush(
+          sql,
+          batch,
+          new Object[] {
+            UUID.randomUUID(),
+            "목데이터 문장 " + i,
+            java.sql.Date.valueOf(java.time.LocalDate.now().minusDays(count - i)),
+            java.sql.Date.valueOf(java.time.LocalDate.now().plusDays(i + 1)),
+            "ACTIVE",
+            Timestamp.from(base.plusSeconds(i * 60L))
+          });
+    }
+    flushRemaining(sql, batch);
+    return jdbc.queryForList("SELECT id FROM daily_sentences ORDER BY id", Long.class);
+  }
+
+  private List<Long> insertGameSessions(
+      List<Long> memberIds, List<Long> sentenceIds, int count, Instant base) {
+    String sql =
+        "INSERT INTO game_sessions "
+            + "(public_id, member_id, sentence_id, status, best_similarity, attempt_count,"
+            + " created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+    List<Object[]> batch = new ArrayList<>(BATCH);
+    int memberSize = memberIds.size();
+    int sentenceSize = sentenceIds.size();
+    int generated = 0;
+    for (int slot = 0; slot < memberSize * sentenceSize && generated < count; slot++) {
+      int memberIdx = slot % memberSize;
+      int sentenceIdx = slot / memberSize;
+      Timestamp created = Timestamp.from(base.plusSeconds(generated * 30L));
+      addAndMaybeFlush(
+          sql,
+          batch,
+          new Object[] {
+            UUID.randomUUID(),
+            memberIds.get(memberIdx),
+            sentenceIds.get(sentenceIdx),
+            "IN_PROGRESS",
+            0.0,
+            0,
+            created,
+            created
+          });
+      generated++;
+    }
+    flushRemaining(sql, batch);
+    return jdbc.queryForList("SELECT id FROM game_sessions ORDER BY id", Long.class);
+  }
+
+  private void insertGuessHistory(List<Long> sessionIds, int avgPerSession, Instant base) {
+    String sql =
+        "INSERT INTO guess_history "
+            + "(session_id, guess_text, similarity, attempt_number, created_at)"
+            + " VALUES (?, ?, ?, ?, ?)";
+    List<Object[]> batch = new ArrayList<>(BATCH);
+    long clock = 0;
+    for (long sessionId : sessionIds) {
+      for (int attempt = 1; attempt <= avgPerSession; attempt++) {
+        addAndMaybeFlush(
+            sql,
+            batch,
+            new Object[] {
+              sessionId,
+              "guess_" + sessionId + "_" + attempt,
+              (attempt * 5.0) % 100,
+              attempt,
+              Timestamp.from(base.plusSeconds(clock++))
+            });
+      }
+    }
+    flushRemaining(sql, batch);
+  }
+
+  private void insertAuditLogs(long adminId, int count, Instant base) {
+    String sql =
+        "INSERT INTO audit_logs "
+            + "(admin_id, action, target_type, target_id, detail, ip_address, created_at)"
+            + " VALUES (?, ?, ?, ?, ?, ?, ?)";
+    List<Object[]> batch = new ArrayList<>(BATCH);
+    for (int i = 0; i < count; i++) {
+      String action = AUDIT_ACTIONS.get(i % AUDIT_ACTIONS.size());
+      addAndMaybeFlush(
+          sql,
+          batch,
+          new Object[] {
+            adminId,
+            action,
+            "MEMBER",
+            String.valueOf(i),
+            "detail_" + i,
+            "127.0.0.1",
+            Timestamp.from(base.plusSeconds(i * 10L))
+          });
+    }
+    flushRemaining(sql, batch);
+  }
+
+  private void insertSentenceUploads(long adminId, int count, Instant base) {
+    String sql =
+        "INSERT INTO sentence_uploads (admin_id, file_name, record_count, created_at)"
+            + " VALUES (?, ?, ?, ?)";
+    List<Object[]> batch = new ArrayList<>(BATCH);
+    for (int i = 0; i < count; i++) {
+      addAndMaybeFlush(
+          sql,
+          batch,
+          new Object[] {
+            adminId, "upload_" + i + ".csv", 100, Timestamp.from(base.plusSeconds(i * 3600L))
+          });
+    }
+    flushRemaining(sql, batch);
+  }
+
+  private void addAndMaybeFlush(String sql, List<Object[]> batch, Object[] row) {
+    batch.add(row);
+    if (batch.size() >= BATCH) {
+      jdbc.batchUpdate(sql, batch);
+      batch.clear();
+    }
+  }
+
+  private void flushRemaining(String sql, List<Object[]> batch) {
+    if (!batch.isEmpty()) {
+      jdbc.batchUpdate(sql, batch);
+      batch.clear();
+    }
+  }
+}

--- a/docs/performance/db-indexes-v1.md
+++ b/docs/performance/db-indexes-v1.md
@@ -1,0 +1,102 @@
+# DB 인덱스 개선 — V15
+
+## 왜 했나
+
+실제 성능 문제는 아직까지는 없었다. 2026-04-25 기준 프로덕션의 현재 가장 큰 테이블(`guess_history`)이 12,573행이고 모든 쿼리가 1ms 미만이다.
+
+다만 스키마를 훑어보니 두 가지 이슈가 있었고, 데이터가 늘기 전에 선제로 메웠다.
+
+1. **외래키 컬럼 3개에 인덱스가 없다.** PostgreSQL은 외래키를 선언해도 자동으로 인덱스를 만들지 않는다. 회원 탈퇴처럼 부모 행을 지우는 순간 자식 테이블을 끝까지 훑는다.
+2. **"필터 + 정렬" 쿼리가 기존 단일 인덱스로는 절반만 해결된다.** 어드민 사용자 목록이나 감사 로그처럼 WHERE와 ORDER BY가 함께 걸리는 쿼리는 인덱스로 행을 걸러도 정렬은 별도로 돌아간다.
+
+이번 변경의 이유는 수치적인 개선이라기보다 "데이터가 10배, 100배가 돼도 어느정도 속도를 유지하는 준비"라고 보면 되겠다.
+
+## 추가한 인덱스 7개
+
+| 테이블 / 컬럼                               | 어디에 쓰이는가                                              |
+| ------------------------------------------- | ------------------------------------------------------------ |
+| `sentence_uploads(admin_id)`                | 어드민 탈퇴 시 업로드 이력 익명화, 회원 DELETE의 외래키 확인 |
+| `social_accounts(member_id)`                | 소셜 계정 조회, 탈퇴 시 일괄 삭제                            |
+| `refresh_tokens(member_id)`                 | 로그아웃 시 멤버 토큰 일괄 무효화                            |
+| `game_sessions(member_id, created_at DESC)` | 마이페이지 게임 이력, 어드민 사용자 상세                     |
+| `audit_logs(action, created_at DESC)`       | 어드민 감사 로그 action 필터 + 최신순                        |
+| `guess_history(session_id, attempt_number)` | 세션별 추측 히스토리 재생                                    |
+| `members(banned, created_at DESC)`          | 어드민 사용자 목록 차단/미차단 필터                          |
+
+`guess_history`는 기존 단일 인덱스 `(session_id)`가 새 복합 인덱스의 앞부분에 이미 포함되므로 DROP 후 교체했다. 둘 다 두면 쓰기 때마다 같은 정보를 두 번 저장할 뿐이다.
+
+제외한 항목: `daily_sentences.scheduled_at`, `daily_sentences.used_at`, `members.nickname`은 `UNIQUE` 제약이 걸려 있어 이미 자동 인덱스가 있다.
+
+## 용어
+
+아래 실측 표를 읽을 때 알고 있으면 좋은 단어들. PostgreSQL 공식 문서의 [Using EXPLAIN](https://www.postgresql.org/docs/current/using-explain.html)에 자세히 나와 있다.
+
+> **Seq Scan (Sequential Scan)** — 인덱스를 쓰지 않고 테이블의 모든 행을 순서대로 훑는다.
+>
+> - 좋을 때: 작은 테이블, 또는 대부분의 행을 반환하는 쿼리. 연속 읽기라 I/O 효율이 좋고 인덱스 오버헤드가 없다.
+> - 나쁠 때: 큰 테이블에서 소수 행만 고를 때. 시간이 테이블 크기에 비례(O(n))해 대부분의 작업이 낭비된다.
+>
+> **Index Scan** — 인덱스를 따라가며 매칭되는 행을 바로 읽는다.
+>
+> - 좋을 때: 소수 행 조회, 그리고 인덱스 순서가 정렬 방향과 일치해 ORDER BY를 인덱스만으로 해결할 수 있을 때 (추가 Sort 노드가 사라진다).
+> - 나쁠 때: 반환 행이 많은 경우. 매 행마다 인덱스 → 힙을 랜덤 I/O로 왔다 갔다 해서 Bitmap 방식보다 느릴 수 있다.
+>
+> **Bitmap Index Scan + Bitmap Heap Scan** — 인덱스에서 매칭되는 행 위치를 비트맵으로 먼저 모은 뒤, 디스크 효율이 좋은 순서로 한 번에 테이블을 읽는다.
+>
+> - 좋을 때: 반환 행이 수십~수천 건 단위일 때. 여러 인덱스를 AND/OR로 결합할 수도 있다.
+> - 나쁠 때: 인덱스 순서가 보존되지 않아 ORDER BY에 Sort가 따라붙는다. 비트맵이 `work_mem`을 넘으면 lossy 모드로 떨어져 재검사 비용이 든다.
+>   work_mem이 무엇이냐면, PostgreSQL이 정렬이나 해시 조인 같은 작업을 메모리에서 처리할 때 사용하는 임시 공간이다.
+>   인덱스 스캔이 반환하는 행 위치를 비트맵으로 저장하는데, 이 비트맵이 너무 커서 work_mem을 초과하면 "lossy" 모드로 전환된다.
+>   이 경우 PostgreSQL은 비트맵에 정확한 행 위치 대신 대략적인 페이지 위치만 저장한다.
+>   그래서 나중에 테이블을 읽을 때 해당 페이지의 모든 행을 다시 검사해야 해서 성능이 크게 떨어진다.
+>
+> **top-N heapsort** — `ORDER BY ... LIMIT N`에서 쓰는 정렬 방식. 전체를 정렬하지 않고 크기 N짜리 힙만 유지하면서 한 번 훑어 상위 N개만 뽑는다.
+>
+> - 좋을 때: LIMIT이 작을 때. 메모리/시간 모두 일반 정렬보다 적게 든다.
+> - 나쁠 때: LIMIT이 없거나 N이 전체 크기에 근접할 때. 또, 입력 범위 자체는 여전히 다 훑어야 해서 "정렬 대상이 많다"는 비용은 그대로다.
+
+## 실측
+
+로컬 Testcontainers(PostgreSQL 16-alpine)에 목데이터를 넣고 V15 적용 전후를 비교했다.
+
+규모: members 5,000명(차단된 사용자 1,500명) / game_sessions 20,000 / guess_history 200,000 / audit_logs 10,000 / social_accounts / refresh_tokens 각 5,000 / sentence_uploads / daily_sentences 각 500.
+
+| 쿼리                                        | 전                                                                                                 | 후                                            | 비고                                      |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------------------------------------- |
+| `sentence_uploads(admin_id)`                | 0.166 ms — Seq Scan + top-N heapsort                                                               | 0.111 ms — Index Scan + top-N heapsort        | 정렬은 남지만 스캔 비용 제거              |
+| `social_accounts(member_id)`                | 0.246 ms — Seq Scan (1건 찾자고 5,000행 전부 훑음)                                                 | 0.037 ms — Bitmap Index Scan                  |                                           |
+| `refresh_tokens(member_id)`                 | 0.219 ms — Seq Scan (1건 찾자고 5,000행 전부 훑음)                                                 | 0.033 ms — Bitmap Index Scan                  |                                           |
+| `game_sessions(member_id, created_at DESC)` | 0.116 ms — Bitmap Index Scan + Sort                                                                | 0.034 ms — Index Scan                         | 정렬이 인덱스에 녹아 Sort 노드 사라짐     |
+| `audit_logs(action, created_at DESC)`       | 0.780 ms — Seq Scan + top-N heapsort                                                               | 0.531 ms — Bitmap Index Scan + top-N heapsort | Bitmap은 순서 보존 X → 정렬 일부 남음     |
+| `guess_history(session_id, attempt_number)` | 0.037 ms — Bitmap Index Scan + Sort                                                                | 0.103 ms — Bitmap Index Scan + Sort           | 단일 → 복합 교체. 쓰기/디스크 이득이 본질 |
+| `members(banned, created_at DESC)`          | 0.832 ms — Seq Scan + top-N heapsort (상위 20명 뽑자고 5,000명 전부 훑음, 1,500명은 차단이라 탈락) | 0.032 ms — Index Scan                         | 어드민 사용자 목록                        |
+
+핵심은 개별 수치보다 **스캔 방식이 바뀌었다는 것**이다. Seq Scan은 테이블이 커질수록 선형으로 느려지고, Index/Bitmap Index Scan은 로그 수준으로 느려진다. 그래서 지금은 미미한 차이지만 데이터가 100만 행 단위가 되면 차이가 많이 날 것이라고 생각한다.
+
+프로덕션은 이 목데이터보다 한참 작다. 따라서 배포 직후 눈에 띄는 속도 변화는 기대하지 않는다.
+
+## 회귀 방지
+
+`IndexPerformanceTest`(`@Tag("performance")`)가 EXPLAIN 플랜에 7개 인덱스 이름이 등장하는지 검사한다. 혹시나 V15를 수정하거나 쿼리 컬럼이 바뀌어 인덱스가 더 이상 선택되지 않으면 테스트가 깨진다. 측정 수치 자체는 환경에 따라 흔들리므로 assertion에 포함하지 않았다.
+
+CI는 기본 `test`만 돌리고 이 테스트는 빠진다 (목데이터 삽입에 시간이 걸림). 로컬에서 `./gradlew performanceTest`로 실행한다.
+
+## 배포 / 롤백
+
+Flyway가 V15를 자동으로 실행한다. `CREATE INDEX CONCURRENTLY`는 Flyway의 기본 트랜잭션 방식과 충돌해 이번엔 일반 `CREATE INDEX`를 썼다. 현재 테이블 규모에선 락 시간이 수 밀리초라 문제없다. 만약 테이블이 대용량이 되면 무중단 배포 방식을 따로 준비해야 한다.
+
+롤백은 V16에서 이번에 만든 7개 인덱스를 DROP하고 기존 `idx_guess_history_session`을 되살리면 끝난다. 인덱스는 쿼리 결과에 영향을 주지 않으므로 DDL 한 번으로 완전히 원상복구 가능.
+
+## 다음 과제
+
+- `pg_stat_statements` 활성화 — 운영에서 실제로 어떤 쿼리가 느린지 수집
+  > **pg_stat_statements란 무엇인가**
+  > PostgreSQL의 확장 모듈로, 실행된 SQL 쿼리에 대한 통계 정보를 수집하는 도구입니다.
+  > 각 쿼리의 실행 횟수, 총 실행 시간, 평균 실행 시간, 최대/최소 실행 시간 등을 기록하여 데이터베이스 성능 분석에 도움을 줍니다.
+  > 이를 통해 어떤 쿼리가 자주 실행되고 시간이 오래 걸리는지 파악할 수 있어, 인덱스 최적화나 쿼리 리팩토링 등의 성능 개선 작업에 활용됩니다.
+- 대용량 테이블에서 락 없이 인덱스 만들기 (Flyway out-of-order + CONCURRENTLY)
+- 미사용 인덱스 모니터링 (`pg_stat_user_indexes`)
+  > **pg_stat_user_indexes란 무엇인가**
+  > PostgreSQL의 시스템 뷰 중 하나로, 사용자 테이블에 존재하는 인덱스의 사용 통계를 제공합니다.
+  > 각 인덱스에 대해 스캔 횟수, 튜플 읽기 수, 튜플 반환 수 등의 정보를 기록하여, 인덱스가 실제로 쿼리에서 얼마나 활용되고 있는지 파악할 수 있게 해줍니다.
+  > 이를 통해 사용되지 않는 인덱스를 식별하여 제거하거나, 필요한 인덱스가 제대로 활용되고 있는지 모니터링할 수 있습니다.


### PR DESCRIPTION
## 관련 이슈

Closes #144

## 변경 사항

- V15 마이그레이션으로 성능 인덱스 7종 추가 — FK 누락 3건(`sentence_uploads.admin_id`, `social_accounts.member_id`, `refresh_tokens.member_id`)과 "필터 + 정렬" 복합 4건(`game_sessions`, `audit_logs`, `members`, `guess_history`)
- `guess_history` 단일 인덱스 `(session_id)`는 복합 `(session_id, attempt_number)`의 접두사라 DROP 후 복합으로 교체
- `performanceTest` Gradle 태스크 신설 — `@Tag("performance")`로 CI 기본 `test`에서 분리, JaCoCo 제외
- `BulkDataFixture` + `IndexPerformanceTest` — 대량 목데이터 생성 + EXPLAIN 플랜에 V15 인덱스 이름이 등장하는지 검증
- `FlywayMigrationTest` 마이그레이션 카운트 V14 → V15 갱신

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (`./gradlew test` 292개 통과, `./gradlew performanceTest` 7개 인덱스 assertion 통과)
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다 (인덱스는 쿼리 결과에 영향 없음, 기존 테스트 회귀 없음)

## 참고자료

- 실측 요약: 로컬 5K member 규모에서 `members(banned, created_at DESC)` 쿼리가 0.832ms → 0.032ms. 프로덕션은 현재 규모가 작아 체감 차이는 미미하며, 이번 변경은 데이터 증가에 대비한 선제적 성능 확보 성격
- `CREATE INDEX CONCURRENTLY`는 Flyway 트랜잭션과 충돌해 일반 `CREATE INDEX` 사용. 현재 테이블 규모에서 락 시간 수 밀리초 수준
- 문서 내 상세 실측표 및 용어 해설: `docs/performance/db-indexes-v1.md`