### PR TITLE
refactor: 백엔드 소규모 코드 정리 (일괄)

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSentenceController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSentenceController.java
@@ -30,7 +30,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -45,7 +44,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/admin/sentences")
 @RequiredArgsConstructor
-@Transactional
 @Tag(name = "Admin: Sentences", description = "어드민 문장 관리")
 @SecurityRequirement(name = "cookieAuth")
 public class AdminSentenceController {
@@ -57,7 +55,6 @@ public class AdminSentenceController {
   @Operation(summary = "문장 목록 조회")
   @AdminErrorResponses
   @GetMapping
-  @Transactional(readOnly = true)
   public ResponseEntity<SentenceListResponse> getSentences(
       @RequestParam(required = false) String status,
       @RequestParam(defaultValue = "0") int page,
@@ -92,7 +89,6 @@ public class AdminSentenceController {
   @Operation(summary = "문장 상세 조회")
   @AdminErrorResponses
   @GetMapping("/{publicId}")
-  @Transactional(readOnly = true)
   public ResponseEntity<SentenceResponse> getSentence(@PathVariable UUID publicId) {
     return ResponseEntity.ok(adminSentenceService.getSentence(publicId));
   }
@@ -152,7 +148,6 @@ public class AdminSentenceController {
   @Operation(summary = "문장별 통계 조회")
   @AdminErrorResponses
   @GetMapping("/{publicId}/stats")
-  @Transactional(readOnly = true)
   public ResponseEntity<SentenceStatsResponse> getSentenceStats(@PathVariable UUID publicId) {
     return ResponseEntity.ok(adminSentenceService.getSentenceStats(publicId));
   }
@@ -160,7 +155,6 @@ public class AdminSentenceController {
   @Operation(summary = "미사용 문장 수 조회")
   @AdminErrorResponses
   @GetMapping("/unused-count")
-  @Transactional(readOnly = true)
   public ResponseEntity<UnusedCountResponse> getUnusedCount() {
     return ResponseEntity.ok(new UnusedCountResponse(adminSentenceService.getUnusedCount()));
   }
@@ -242,7 +236,6 @@ public class AdminSentenceController {
           - `AI_SERVICE_UNAVAILABLE` (503): AI 서비스 불가""")
   @AdminErrorResponses
   @PostMapping("/similarity-test")
-  @Transactional(readOnly = true)
   public ResponseEntity<SimilarityTestResponse> testSimilarity(
       @Valid @RequestBody SimilarityTestRequest request) {
     return ResponseEntity.ok(adminSentenceService.testSimilarity(request));
@@ -251,7 +244,6 @@ public class AdminSentenceController {
   @Operation(summary = "중복 검사")
   @AdminErrorResponses
   @PostMapping("/duplicate-check")
-  @Transactional(readOnly = true)
   public ResponseEntity<DuplicateCheckResponse> checkDuplicate(
       @Valid @RequestBody DuplicateCheckRequest request) {
     return ResponseEntity.ok(adminSentenceService.checkDuplicate(request));

--- a/backend/src/main/java/com/gakkaweo/backend/admin/event/AuditLogNotificationListener.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/event/AuditLogNotificationListener.java
@@ -22,7 +22,7 @@ public class AuditLogNotificationListener {
 
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
   public void onAuditLog(AuditLogEvent event) {
-    if (!notificationProperties.getAuditAlert().isEnabled()) {
+    if (!notificationProperties.getAuditAlert().enabled()) {
       return;
     }
 

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminDashboardService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminDashboardService.java
@@ -53,22 +53,18 @@ public class AdminDashboardService {
             .findByUsedAt(today)
             .orElseThrow(() -> new BusinessException(ErrorCode.SENTENCE_NOT_FOUND));
 
-    long totalParticipants = gameSessionRepository.countBySentence(sentence);
-    long clearedCount = gameSessionRepository.countClearedBySentence(sentence);
-    long inProgressCount = totalParticipants - clearedCount;
-    BigDecimal avgSimilarity = gameSessionRepository.avgSimilarityBySentence(sentence);
-    double avgAttemptCount = gameSessionRepository.avgAttemptCountBySentence(sentence);
+    SentenceStatsSnapshot stats = collectSentenceStats(sentence);
     long unusedCount = dailySentenceRepository.countUnusedActive();
     int sseCount = sseConnectionManager.getConnectionCount();
 
     return new TodayWidgetResponse(
         sentence.getPublicId(),
         sentence.getSentence(),
-        totalParticipants,
-        clearedCount,
-        inProgressCount,
-        avgSimilarity,
-        avgAttemptCount,
+        stats.totalParticipants(),
+        stats.clearedCount(),
+        stats.totalParticipants() - stats.clearedCount(),
+        stats.avgSimilarity(),
+        stats.avgAttemptCount(),
         unusedCount,
         sseCount);
   }
@@ -91,13 +87,15 @@ public class AdminDashboardService {
             .findByUsedAt(date)
             .orElseThrow(() -> new BusinessException(ErrorCode.SENTENCE_NOT_FOUND));
 
-    long totalParticipants = gameSessionRepository.countBySentence(sentence);
-    long clearedCount = gameSessionRepository.countClearedBySentence(sentence);
-    BigDecimal avgSimilarity = gameSessionRepository.avgSimilarityBySentence(sentence);
-    double avgAttemptCount = gameSessionRepository.avgAttemptCountBySentence(sentence);
+    SentenceStatsSnapshot stats = collectSentenceStats(sentence);
 
     return DateStatsResponse.from(
-        date, sentence, totalParticipants, clearedCount, avgSimilarity, avgAttemptCount);
+        date,
+        sentence,
+        stats.totalParticipants(),
+        stats.clearedCount(),
+        stats.avgSimilarity(),
+        stats.avgAttemptCount());
   }
 
   @Transactional(readOnly = true)
@@ -151,4 +149,19 @@ public class AdminDashboardService {
 
     return new GuessLogResponse(logs);
   }
+
+  private SentenceStatsSnapshot collectSentenceStats(DailySentence sentence) {
+    long totalParticipants = gameSessionRepository.countBySentence(sentence);
+    long clearedCount = gameSessionRepository.countClearedBySentence(sentence);
+    BigDecimal avgSimilarity = gameSessionRepository.avgSimilarityBySentence(sentence);
+    double avgAttemptCount = gameSessionRepository.avgAttemptCountBySentence(sentence);
+    return new SentenceStatsSnapshot(
+        totalParticipants, clearedCount, avgSimilarity, avgAttemptCount);
+  }
+
+  private record SentenceStatsSnapshot(
+      long totalParticipants,
+      long clearedCount,
+      BigDecimal avgSimilarity,
+      double avgAttemptCount) {}
 }

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -1,7 +1,5 @@
 package com.gakkaweo.backend.admin.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
-
 import com.gakkaweo.backend.admin.dto.DuplicateCheckRequest;
 import com.gakkaweo.backend.admin.dto.DuplicateCheckResponse;
 import com.gakkaweo.backend.admin.dto.EmergencyReplaceRequest;
@@ -15,6 +13,7 @@ import com.gakkaweo.backend.admin.dto.SimilarityTestRequest;
 import com.gakkaweo.backend.admin.dto.SimilarityTestResponse;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
@@ -252,8 +251,7 @@ public class AdminSentenceService {
               return newSentence.getPublicId();
             });
 
-    String rankingKey = RANKING_KEY_PREFIX + today;
-    redisTemplate.delete(rankingKey);
+    redisTemplate.delete(RedisKeyConstants.rankingKey(today));
 
     eventPublisher.publishEvent(new DayChangeEvent(newPublicId));
 

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -1,8 +1,5 @@
 package com.gakkaweo.backend.admin.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
-
 import com.gakkaweo.backend.admin.dto.AnnouncementCreateRequest;
 import com.gakkaweo.backend.admin.dto.AnnouncementResponse;
 import com.gakkaweo.backend.admin.dto.AnnouncementUpdateRequest;
@@ -206,13 +203,13 @@ public class AdminSystemService {
 
   public void resetRankingCache() {
     LocalDate today = LocalDate.now(clock);
-    String rankingKey = RANKING_KEY_PREFIX + today;
+    String rankingKey = RedisKeyConstants.rankingKey(today);
 
     Set<String> members = redisTemplate.opsForZSet().range(rankingKey, 0, -1);
     if (members != null) {
       for (String memberKey : members) {
-        String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
-        String detailKey = RedisKeyConstants.rankingDetailKey(today, UUID.fromString(publicIdStr));
+        UUID publicId = RedisKeyConstants.extractMemberPublicId(memberKey);
+        String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
         redisTemplate.delete(detailKey);
       }
     }

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -1,6 +1,5 @@
 package com.gakkaweo.backend.admin.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
 
@@ -13,6 +12,7 @@ import com.gakkaweo.backend.admin.dto.SystemStatusResponse;
 import com.gakkaweo.backend.admin.event.AnnouncementEvent;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.admin.entity.Announcement;
 import com.gakkaweo.backend.domain.admin.entity.AnnouncementType;
 import com.gakkaweo.backend.domain.admin.entity.AuditLog;
@@ -212,8 +212,7 @@ public class AdminSystemService {
     if (members != null) {
       for (String memberKey : members) {
         String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
-        String detailKey =
-            RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicIdStr;
+        String detailKey = RedisKeyConstants.rankingDetailKey(today, UUID.fromString(publicIdStr));
         redisTemplate.delete(detailKey);
       }
     }

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -1,8 +1,5 @@
 package com.gakkaweo.backend.admin.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
-
 import com.gakkaweo.backend.admin.dto.AdminUserResponse;
 import com.gakkaweo.backend.admin.dto.ForceNicknameRequest;
 import com.gakkaweo.backend.admin.dto.RoleChangeRequest;
@@ -26,6 +23,7 @@ import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
 import com.gakkaweo.backend.domain.member.validation.NicknameValidator;
 import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
+import com.gakkaweo.backend.ranking.service.RankingService;
 import jakarta.persistence.criteria.Predicate;
 import java.time.Clock;
 import java.time.LocalDate;
@@ -61,6 +59,7 @@ public class AdminUserService {
   private final NicknameValidator nicknameValidator;
   private final StringRedisTemplate redisTemplate;
   private final ApplicationEventPublisher eventPublisher;
+  private final RankingService rankingService;
   private final Clock clock;
 
   private static Specification<Member> memberFilters(String nickname, Boolean banned) {
@@ -185,19 +184,8 @@ public class AdminUserService {
   }
 
   public void cleanupRedisAfterDelete(UUID publicId) {
-    try {
-      LocalDate today = LocalDate.now(clock);
-      String rankingKey = RANKING_KEY_PREFIX + today;
-      String memberKey = RANKING_MEMBER_PREFIX + publicId;
-      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
-
-      Long removed = redisTemplate.opsForZSet().remove(rankingKey, memberKey);
-      if (removed != null && removed > 0) {
-        redisTemplate.delete(detailKey);
-        eventPublisher.publishEvent(new RankingUpdateEvent());
-      }
-    } catch (Exception e) {
-      log.warn("강제 탈퇴 Redis 정리 실패: publicId={}", publicId, e);
+    if (rankingService.cleanupMemberRanking(publicId)) {
+      eventPublisher.publishEvent(new RankingUpdateEvent());
     }
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -1,6 +1,5 @@
 package com.gakkaweo.backend.admin.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
 
@@ -15,6 +14,7 @@ import com.gakkaweo.backend.admin.dto.UserListResponse;
 import com.gakkaweo.backend.auth.service.ProfileImageService;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.admin.repository.SentenceUploadRepository;
 import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
 import com.gakkaweo.backend.domain.game.entity.GameSession;
@@ -189,7 +189,7 @@ public class AdminUserService {
       LocalDate today = LocalDate.now(clock);
       String rankingKey = RANKING_KEY_PREFIX + today;
       String memberKey = RANKING_MEMBER_PREFIX + publicId;
-      String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
+      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
 
       Long removed = redisTemplate.opsForZSet().remove(rankingKey, memberKey);
       if (removed != null && removed > 0) {
@@ -232,7 +232,7 @@ public class AdminUserService {
   public void syncNicknameToRedis(UUID publicId, String nickname) {
     try {
       LocalDate today = LocalDate.now(clock);
-      String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
+      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
 
       if (redisTemplate.hasKey(detailKey)) {
         redisTemplate.opsForHash().put(detailKey, "nickname", nickname);
@@ -259,7 +259,7 @@ public class AdminUserService {
   private void syncProfileUrlToRedis(UUID publicId, String profileUrl) {
     try {
       LocalDate today = LocalDate.now(clock);
-      String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
+      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
 
       if (redisTemplate.hasKey(detailKey)) {
         redisTemplate.opsForHash().put(detailKey, "profileUrl", Objects.toString(profileUrl, ""));

--- a/backend/src/main/java/com/gakkaweo/backend/auth/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/jwt/JwtAuthenticationFilter.java
@@ -1,8 +1,7 @@
 package com.gakkaweo.backend.auth.jwt;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.BLACKLIST_PREFIX;
-
 import com.gakkaweo.backend.auth.security.CustomUserDetails;
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -65,6 +64,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   }
 
   private boolean isBlacklisted(String jti) {
-    return redisTemplate.hasKey(BLACKLIST_PREFIX + jti);
+    return redisTemplate.hasKey(RedisKeyConstants.blacklistKey(jti));
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/CustomOAuth2UserService.java
@@ -2,6 +2,7 @@ package com.gakkaweo.backend.auth.oauth2.service;
 
 import com.gakkaweo.backend.auth.oauth2.CustomOAuth2User;
 import com.gakkaweo.backend.auth.oauth2.dto.OAuthAttributes;
+import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +30,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     Member member = oAuthMemberService.findOrCreateMember(attributes);
 
     if (Boolean.TRUE.equals(member.getBanned())) {
-      throw new OAuth2AuthenticationException(new OAuth2Error("member_banned", "차단된 계정입니다", null));
+      throw new OAuth2AuthenticationException(
+          new OAuth2Error(
+              ErrorCode.MEMBER_BANNED.name().toLowerCase(),
+              ErrorCode.MEMBER_BANNED.getMessage(),
+              null));
     }
 
     return new CustomOAuth2User(member, oAuth2User.getAttributes());

--- a/backend/src/main/java/com/gakkaweo/backend/auth/security/RestAccessDeniedHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/security/RestAccessDeniedHandler.java
@@ -5,7 +5,7 @@ import com.gakkaweo.backend.common.exception.ErrorBody;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.Instant;
+import java.time.Clock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 public class RestAccessDeniedHandler implements AccessDeniedHandler {
 
   private final ObjectMapper objectMapper;
+  private final Clock clock;
 
   @Override
   public void handle(
@@ -27,7 +28,10 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
       throws IOException {
     ErrorBody body =
         new ErrorBody(
-            HttpStatus.FORBIDDEN.value(), "ACCESS_DENIED", "접근 권한이 없습니다", Instant.now().toString());
+            HttpStatus.FORBIDDEN.value(),
+            "ACCESS_DENIED",
+            "접근 권한이 없습니다",
+            clock.instant().toString());
 
     response.setStatus(HttpStatus.FORBIDDEN.value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/backend/src/main/java/com/gakkaweo/backend/auth/security/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/security/RestAuthenticationEntryPoint.java
@@ -6,7 +6,7 @@ import com.gakkaweo.backend.common.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.Instant;
+import java.time.Clock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
   private final ObjectMapper objectMapper;
+  private final Clock clock;
 
   @Override
   public void commence(
@@ -31,7 +32,7 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
             errorCode.getStatus().value(),
             errorCode.name(),
             errorCode.getMessage(),
-            Instant.now().toString());
+            clock.instant().toString());
 
     response.setStatus(errorCode.getStatus().value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
@@ -57,7 +57,11 @@ public class AccountService {
 
   public void cleanupRedis(UUID publicId, String accessToken) {
     if (accessToken != null) {
-      authService.logout(accessToken);
+      try {
+        authService.logout(accessToken);
+      } catch (Exception e) {
+        log.warn("탈퇴 회원 로그아웃 실패, Redis 정리 계속: publicId={}", publicId, e);
+      }
     }
 
     if (rankingService.cleanupMemberRanking(publicId)) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
@@ -1,11 +1,7 @@
 package com.gakkaweo.backend.auth.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
-
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
-import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.admin.repository.SentenceUploadRepository;
 import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
 import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
@@ -14,13 +10,11 @@ import com.gakkaweo.backend.domain.member.repository.LocalAccountRepository;
 import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
 import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
-import java.time.Clock;
-import java.time.LocalDate;
+import com.gakkaweo.backend.ranking.service.RankingService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,9 +30,8 @@ public class AccountService {
   private final SocialAccountRepository socialAccountRepository;
   private final RefreshTokenRepository refreshTokenRepository;
   private final AuthService authService;
-  private final StringRedisTemplate redisTemplate;
+  private final RankingService rankingService;
   private final ApplicationEventPublisher eventPublisher;
-  private final Clock clock;
 
   @Transactional
   public void deleteAccount(UUID publicId) {
@@ -63,26 +56,14 @@ public class AccountService {
   }
 
   public void cleanupRedis(UUID publicId, String accessToken) {
-    try {
-      if (accessToken != null) {
-        authService.logout(accessToken);
-      }
-
-      LocalDate today = LocalDate.now(clock);
-      String rankingKey = RANKING_KEY_PREFIX + today;
-      String memberKey = RANKING_MEMBER_PREFIX + publicId;
-      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
-
-      Long removed = redisTemplate.opsForZSet().remove(rankingKey, memberKey);
-
-      if (removed != null && removed > 0) {
-        redisTemplate.delete(detailKey);
-        eventPublisher.publishEvent(new RankingUpdateEvent());
-      }
-
-      log.info("탈퇴 회원 Redis 정리 완료: publicId={}", publicId);
-    } catch (Exception e) {
-      log.warn("탈퇴 회원 Redis 정리 실패: publicId={}", publicId, e);
+    if (accessToken != null) {
+      authService.logout(accessToken);
     }
+
+    if (rankingService.cleanupMemberRanking(publicId)) {
+      eventPublisher.publishEvent(new RankingUpdateEvent());
+    }
+
+    log.info("탈퇴 회원 Redis 정리 완료: publicId={}", publicId);
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
@@ -1,11 +1,11 @@
 package com.gakkaweo.backend.auth.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
 
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.admin.repository.SentenceUploadRepository;
 import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
 import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
@@ -71,7 +71,7 @@ public class AccountService {
       LocalDate today = LocalDate.now(clock);
       String rankingKey = RANKING_KEY_PREFIX + today;
       String memberKey = RANKING_MEMBER_PREFIX + publicId;
-      String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
+      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
 
       Long removed = redisTemplate.opsForZSet().remove(rankingKey, memberKey);
 

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
@@ -1,14 +1,13 @@
 package com.gakkaweo.backend.auth.service;
 
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.BLACKLIST_PREFIX;
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
 
 import com.gakkaweo.backend.auth.dto.AuthResponse;
 import com.gakkaweo.backend.auth.dto.TokenPair;
 import com.gakkaweo.backend.auth.jwt.JwtProvider;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.auth.entity.RefreshToken;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.domain.member.repository.MemberRepository;
@@ -134,7 +133,7 @@ public class AuthService {
   public void syncProfileUrlToRedis(UUID publicId, String profileUrl) {
     try {
       LocalDate today = LocalDate.now(clock);
-      String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
+      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
 
       if (redisTemplate.hasKey(detailKey)) {
         redisTemplate.opsForHash().put(detailKey, "profileUrl", Objects.toString(profileUrl, ""));
@@ -148,7 +147,7 @@ public class AuthService {
   public void syncNicknameToRedis(UUID publicId, String nickname) {
     try {
       LocalDate today = LocalDate.now(clock);
-      String detailKey = RANKING_DETAIL_PREFIX + today + ":" + RANKING_MEMBER_PREFIX + publicId;
+      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
 
       if (redisTemplate.hasKey(detailKey)) {
         redisTemplate.opsForHash().put(detailKey, "nickname", nickname);

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
@@ -1,7 +1,5 @@
 package com.gakkaweo.backend.auth.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.BLACKLIST_PREFIX;
-
 import com.gakkaweo.backend.auth.dto.AuthResponse;
 import com.gakkaweo.backend.auth.dto.TokenPair;
 import com.gakkaweo.backend.auth.jwt.JwtProvider;
@@ -74,7 +72,7 @@ public class AuthService {
     if (remainingMillis > 0) {
       redisTemplate
           .opsForValue()
-          .set(BLACKLIST_PREFIX + jti, "logout", Duration.ofMillis(remainingMillis));
+          .set(RedisKeyConstants.blacklistKey(jti), "logout", Duration.ofMillis(remainingMillis));
     }
     log.info("로그아웃: jti={}", jti);
   }

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/GlobalExceptionHandler.java
@@ -2,7 +2,7 @@ package com.gakkaweo.backend.common.exception;
 
 import com.gakkaweo.backend.infra.notification.ServerErrorNotifier;
 import jakarta.servlet.http.HttpServletRequest;
-import java.time.Instant;
+import java.time.Clock;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +28,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
   private final ServerErrorNotifier serverErrorNotifier;
+  private final Clock clock;
 
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<?> handleBusinessException(BusinessException e) {
@@ -38,7 +39,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             errorCode.getStatus().value(),
             errorCode.name(),
             errorCode.getMessage(),
-            Instant.now().toString());
+            clock.instant().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
@@ -51,7 +52,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             errorCode.getStatus().value(),
             errorCode.name(),
             errorCode.getMessage(),
-            Instant.now().toString());
+            clock.instant().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
@@ -68,7 +69,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             errorCode.getStatus().value(),
             errorCode.name(),
             errorCode.getMessage(),
-            Instant.now().toString());
+            clock.instant().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
@@ -85,7 +86,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             errorCode.getStatus().value(),
             errorCode.name(),
             errorCode.getMessage(),
-            Instant.now().toString());
+            clock.instant().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
@@ -99,7 +100,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             errorCode.getStatus().value(),
             errorCode.name(),
             errorCode.getMessage(),
-            Instant.now().toString());
+            clock.instant().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
@@ -115,7 +116,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             .collect(Collectors.joining(", "));
     log.warn("유효성 검증 실패: {}", message);
     ErrorBody body =
-        new ErrorBody(status.value(), "VALIDATION_FAILED", message, Instant.now().toString());
+        new ErrorBody(status.value(), "VALIDATION_FAILED", message, clock.instant().toString());
     return ResponseEntity.status(status).body(body);
   }
 
@@ -132,7 +133,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             errorCode.getStatus().value(),
             errorCode.name(),
             ex.getMessage(),
-            Instant.now().toString());
+            clock.instant().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
@@ -149,7 +150,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             errorCode.getStatus().value(),
             errorCode.name(),
             ex.getMessage(),
-            Instant.now().toString());
+            clock.instant().toString());
     return ResponseEntity.status(errorCode.getStatus()).body(body);
   }
 
@@ -166,7 +167,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             status.value(),
             ex.getClass().getSimpleName(),
             ex.getMessage(),
-            Instant.now().toString());
+            clock.instant().toString());
     return ResponseEntity.status(status).headers(headers).body(errorBody);
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/common/redis/RedisKeyConstants.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/redis/RedisKeyConstants.java
@@ -5,15 +5,35 @@ import java.util.UUID;
 
 public final class RedisKeyConstants {
 
-  public static final String BLACKLIST_PREFIX = "blacklist:jti:";
-  public static final String RANKING_KEY_PREFIX = "ranking:";
-  public static final String RANKING_DETAIL_PREFIX = "ranking_detail:";
-  public static final String RANKING_MEMBER_PREFIX = "member:";
-  public static final String SIMILARITY_CACHE_PREFIX = "similarity:";
+  private static final String BLACKLIST_PREFIX = "blacklist:jti:";
+  private static final String RANKING_KEY_PREFIX = "ranking:";
+  private static final String RANKING_DETAIL_PREFIX = "ranking_detail:";
+  private static final String RANKING_MEMBER_PREFIX = "member:";
+  private static final String SIMILARITY_CACHE_PREFIX = "similarity:";
 
   private RedisKeyConstants() {}
 
+  public static String blacklistKey(String jti) {
+    return BLACKLIST_PREFIX + jti;
+  }
+
+  public static String rankingKey(LocalDate date) {
+    return RANKING_KEY_PREFIX + date;
+  }
+
+  public static String memberKey(UUID publicId) {
+    return RANKING_MEMBER_PREFIX + publicId;
+  }
+
+  public static UUID extractMemberPublicId(String memberKey) {
+    return UUID.fromString(memberKey.substring(RANKING_MEMBER_PREFIX.length()));
+  }
+
   public static String rankingDetailKey(LocalDate date, UUID memberPublicId) {
     return RANKING_DETAIL_PREFIX + date + ":" + RANKING_MEMBER_PREFIX + memberPublicId;
+  }
+
+  public static String similarityCacheKey(Long sentenceId, String hash) {
+    return SIMILARITY_CACHE_PREFIX + sentenceId + ":" + hash;
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/common/redis/RedisKeyConstants.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/redis/RedisKeyConstants.java
@@ -1,5 +1,8 @@
 package com.gakkaweo.backend.common.redis;
 
+import java.time.LocalDate;
+import java.util.UUID;
+
 public final class RedisKeyConstants {
 
   public static final String BLACKLIST_PREFIX = "blacklist:jti:";
@@ -9,4 +12,8 @@ public final class RedisKeyConstants {
   public static final String SIMILARITY_CACHE_PREFIX = "similarity:";
 
   private RedisKeyConstants() {}
+
+  public static String rankingDetailKey(LocalDate date, UUID memberPublicId) {
+    return RANKING_DETAIL_PREFIX + date + ":" + RANKING_MEMBER_PREFIX + memberPublicId;
+  }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/config/GameProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/config/GameProperties.java
@@ -2,18 +2,18 @@ package com.gakkaweo.backend.game.config;
 
 import java.math.BigDecimal;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConfigurationProperties(prefix = "app.game")
 @Getter
-@Setter
+@RequiredArgsConstructor
 public class GameProperties {
 
-  private BigDecimal similarityThreshold = new BigDecimal("95.0");
-  private BigDecimal hintTriggerThreshold = new BigDecimal("60.0");
-  private BigDecimal hintMaxSimilarity = new BigDecimal("90.0");
-  private int hintMaxCount = 5;
+  private final BigDecimal similarityThreshold;
+  private final BigDecimal hintTriggerThreshold;
+  private final BigDecimal hintMaxSimilarity;
+  private final int hintMaxCount;
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/config/GameProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/config/GameProperties.java
@@ -4,9 +4,7 @@ import java.math.BigDecimal;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
-@Component
 @ConfigurationProperties(prefix = "app.game")
 @Getter
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -49,6 +49,10 @@ public class DailySentenceScheduler {
   private final DiscordWebhookClient discordWebhookClient;
   private final Clock clock;
 
+  private static String statusLabel(boolean succeeded) {
+    return succeeded ? "성공" : "실패";
+  }
+
   @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
   public void executeMidnightJob() {
     executeMidnightJob(true);
@@ -237,10 +241,6 @@ public class DailySentenceScheduler {
             new DiscordEmbed.Field("미사용 문장 잔여", String.valueOf(report.unusedCount()), true));
 
     return new DiscordEmbed(title, description, color, fields);
-  }
-
-  private static String statusLabel(boolean succeeded) {
-    return succeeded ? "성공" : "실패";
   }
 
   private void selectTodaySentence(LocalDate today) {

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/client/AiServiceClient.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/client/AiServiceClient.java
@@ -1,5 +1,6 @@
 package com.gakkaweo.backend.infra.ai.client;
 
+import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.infra.ai.client.dto.SimilarityRequest;
 import com.gakkaweo.backend.infra.ai.client.dto.SimilarityResponse;
 import com.gakkaweo.backend.infra.ai.exception.AiServiceException;
@@ -25,7 +26,7 @@ public class AiServiceClient {
           .retrieve()
           .body(SimilarityResponse.class);
     } catch (RestClientException e) {
-      throw new AiServiceException("AI 서비스 요청 실패", e);
+      throw new AiServiceException(ErrorCode.AI_SERVICE_UNAVAILABLE.getMessage(), e);
     }
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/client/dto/SimilarityRequest.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/client/dto/SimilarityRequest.java
@@ -1,3 +1,7 @@
 package com.gakkaweo.backend.infra.ai.client.dto;
 
-public record SimilarityRequest(String sentence, String guess) {}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SimilarityRequest(
+    @Schema(description = "기준 문장", example = "오늘도 좋은 하루 보내세요") String sentence,
+    @Schema(description = "비교할 추측 입력", example = "좋은 하루 되세요") String guess) {}

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/SimilarityService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/SimilarityService.java
@@ -1,9 +1,8 @@
 package com.gakkaweo.backend.infra.ai.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.SIMILARITY_CACHE_PREFIX;
-
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.infra.ai.client.AiServiceClient;
 import com.gakkaweo.backend.infra.ai.client.dto.SimilarityResponse;
 import com.gakkaweo.backend.infra.ai.exception.AiServiceException;
@@ -85,7 +84,7 @@ public class SimilarityService implements SimilarityClient {
 
   private String buildCacheKey(Long sentenceId, String normalizedText) {
     String hash = textNormalizer.hashForCache(normalizedText);
-    return SIMILARITY_CACHE_PREFIX + sentenceId + ":" + hash;
+    return RedisKeyConstants.similarityCacheKey(sentenceId, hash);
   }
 
   private BigDecimal getFromCache(String cacheKey) {

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/ServerErrorNotifier.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/ServerErrorNotifier.java
@@ -29,12 +29,12 @@ public class ServerErrorNotifier {
   public void notify(Exception ex, HttpServletRequest request) {
     try {
       NotificationProperties.ErrorAlert config = notificationProperties.getErrorAlert();
-      if (!config.isEnabled()) {
+      if (!config.enabled()) {
         return;
       }
 
       String dedupKey = ex.getClass().getName() + ":" + request.getRequestURI();
-      if (!deduplicationCache.shouldSend(dedupKey, config.getCooldown())) {
+      if (!deduplicationCache.shouldSend(dedupKey, config.cooldown())) {
         return;
       }
 

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/config/NotificationProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/config/NotificationProperties.java
@@ -13,16 +13,7 @@ public class NotificationProperties {
   private final AuditAlert auditAlert;
   private final ErrorAlert errorAlert;
 
-  @Getter
-  @RequiredArgsConstructor
-  public static class AuditAlert {
-    private final boolean enabled;
-  }
+  public record AuditAlert(boolean enabled) {}
 
-  @Getter
-  @RequiredArgsConstructor
-  public static class ErrorAlert {
-    private final boolean enabled;
-    private final Duration cooldown;
-  }
+  public record ErrorAlert(boolean enabled, Duration cooldown) {}
 }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/dedup/NotificationDeduplicationCache.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/dedup/NotificationDeduplicationCache.java
@@ -38,7 +38,7 @@ public class NotificationDeduplicationCache {
 
   @Scheduled(fixedDelayString = "${app.notification.dedup.cleanup-interval-ms:300000}")
   public void cleanup() {
-    Duration retention = notificationProperties.getErrorAlert().getCooldown().multipliedBy(2);
+    Duration retention = notificationProperties.getErrorAlert().cooldown().multipliedBy(2);
     Instant expiry = clock.instant().minus(retention);
     int before = lastSentAt.size();
     lastSentAt.entrySet().removeIf(entry -> entry.getValue().isBefore(expiry));

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -1,12 +1,12 @@
 package com.gakkaweo.backend.ranking.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_DETAIL_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
 import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
 import static com.gakkaweo.backend.common.time.TimeConstants.KST;
 
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.entity.GameSession;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
@@ -56,7 +56,7 @@ public class RankingService {
       LocalDate today = LocalDate.now(clock);
       String rankingKey = buildRankingKey(today);
       String memberKey = RANKING_MEMBER_PREFIX + member.getPublicId();
-      String detailKey = buildDetailKey(today, member.getPublicId());
+      String detailKey = RedisKeyConstants.rankingDetailKey(today, member.getPublicId());
 
       ZonedDateTime startOfDay = today.atStartOfDay(KST);
       long elapsedSeconds = Duration.between(startOfDay, ZonedDateTime.now(clock)).getSeconds();
@@ -155,7 +155,7 @@ public class RankingService {
       long rank = 1;
       for (String memberKey : allMembers) {
         String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
-        String detailKey = buildDetailKey(date, UUID.fromString(publicIdStr));
+        String detailKey = RedisKeyConstants.rankingDetailKey(date, UUID.fromString(publicIdStr));
 
         Map<Object, Object> detail = redisTemplate.opsForHash().entries(detailKey);
         if (detail.isEmpty()) {
@@ -201,7 +201,7 @@ public class RankingService {
     long rank = 1;
     for (String memberKey : topMembers) {
       String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
-      String detailKey = buildDetailKey(date, UUID.fromString(publicIdStr));
+      String detailKey = RedisKeyConstants.rankingDetailKey(date, UUID.fromString(publicIdStr));
 
       Map<Object, Object> detail = redisTemplate.opsForHash().entries(detailKey);
       if (detail.isEmpty()) {
@@ -233,7 +233,7 @@ public class RankingService {
       return null;
     }
 
-    String detailKey = buildDetailKey(date, memberPublicId);
+    String detailKey = RedisKeyConstants.rankingDetailKey(date, memberPublicId);
     Map<Object, Object> detail = redisTemplate.opsForHash().entries(detailKey);
     if (detail.isEmpty()) {
       return null;
@@ -307,7 +307,7 @@ public class RankingService {
       String memberKey = RANKING_MEMBER_PREFIX + member.getPublicId();
       redisTemplate.opsForZSet().add(rankingKey, memberKey, score);
 
-      String detailKey = buildDetailKey(date, member.getPublicId());
+      String detailKey = RedisKeyConstants.rankingDetailKey(date, member.getPublicId());
       Map<String, String> detail =
           Map.of(
               "publicId", member.getPublicId().toString(),
@@ -332,7 +332,7 @@ public class RankingService {
     if (members != null) {
       for (String memberKey : members) {
         String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
-        String detailKey = buildDetailKey(date, UUID.fromString(publicIdStr));
+        String detailKey = RedisKeyConstants.rankingDetailKey(date, UUID.fromString(publicIdStr));
         redisTemplate.expire(detailKey, EXPIRE_TTL);
         detailCount++;
       }
@@ -365,9 +365,5 @@ public class RankingService {
 
   private String buildRankingKey(LocalDate date) {
     return RANKING_KEY_PREFIX + date;
-  }
-
-  private String buildDetailKey(LocalDate date, UUID memberPublicId) {
-    return RANKING_DETAIL_PREFIX + date + ":" + RANKING_MEMBER_PREFIX + memberPublicId;
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -151,31 +151,7 @@ public class RankingService {
         return new RankingResponse(List.of(), totalPlayers);
       }
 
-      List<RankingEntry> entries = new ArrayList<>();
-      long rank = 1;
-      for (String memberKey : allMembers) {
-        String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
-        String detailKey = RedisKeyConstants.rankingDetailKey(date, UUID.fromString(publicIdStr));
-
-        Map<Object, Object> detail = redisTemplate.opsForHash().entries(detailKey);
-        if (detail.isEmpty()) {
-          continue;
-        }
-
-        String profileUrl = (String) detail.get("profileUrl");
-
-        entries.add(
-            new RankingEntry(
-                rank,
-                UUID.fromString((String) detail.get("publicId")),
-                (String) detail.get("nickname"),
-                profileUrl == null || profileUrl.isEmpty() ? null : profileUrl,
-                new BigDecimal((String) detail.get("similarity")),
-                Integer.parseInt((String) detail.get("attemptCount"))));
-        rank++;
-      }
-
-      return new RankingResponse(entries, totalPlayers);
+      return new RankingResponse(buildRankingEntries(allMembers, date), totalPlayers);
     } catch (Exception e) {
       log.warn("전체 랭킹 조회 실패: date={}", date, e);
       return new RankingResponse(List.of(), 0);
@@ -197,9 +173,13 @@ public class RankingService {
       return new RankingResponse(List.of(), totalPlayers);
     }
 
+    return new RankingResponse(buildRankingEntries(topMembers, date), totalPlayers);
+  }
+
+  private List<RankingEntry> buildRankingEntries(Set<String> memberKeys, LocalDate date) {
     List<RankingEntry> entries = new ArrayList<>();
     long rank = 1;
-    for (String memberKey : topMembers) {
+    for (String memberKey : memberKeys) {
       String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
       String detailKey = RedisKeyConstants.rankingDetailKey(date, UUID.fromString(publicIdStr));
 
@@ -220,8 +200,7 @@ public class RankingService {
               Integer.parseInt((String) detail.get("attemptCount"))));
       rank++;
     }
-
-    return new RankingResponse(entries, totalPlayers);
+    return entries;
   }
 
   private MyRank lookupMyRank(LocalDate date, UUID memberPublicId) {
@@ -322,6 +301,25 @@ public class RankingService {
 
     log.info("랭킹 캐시 재구축: date={}, sessions={}", date, count);
     return count;
+  }
+
+  public boolean cleanupMemberRanking(UUID publicId) {
+    try {
+      LocalDate today = LocalDate.now(clock);
+      String rankingKey = buildRankingKey(today);
+      String memberKey = RANKING_MEMBER_PREFIX + publicId;
+      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
+
+      Long removed = redisTemplate.opsForZSet().remove(rankingKey, memberKey);
+      if (removed != null && removed > 0) {
+        redisTemplate.delete(detailKey);
+        return true;
+      }
+      return false;
+    } catch (Exception e) {
+      log.warn("회원 랭킹 정리 실패: publicId={}", publicId, e);
+      return false;
+    }
   }
 
   public void expirePreviousDayRankingKeys(LocalDate date) {

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -1,7 +1,5 @@
 package com.gakkaweo.backend.ranking.service;
 
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_KEY_PREFIX;
-import static com.gakkaweo.backend.common.redis.RedisKeyConstants.RANKING_MEMBER_PREFIX;
 import static com.gakkaweo.backend.common.time.TimeConstants.KST;
 
 import com.gakkaweo.backend.common.exception.BusinessException;
@@ -54,8 +52,8 @@ public class RankingService {
   public Integer updateRanking(GameSession session, Member member) {
     try {
       LocalDate today = LocalDate.now(clock);
-      String rankingKey = buildRankingKey(today);
-      String memberKey = RANKING_MEMBER_PREFIX + member.getPublicId();
+      String rankingKey = RedisKeyConstants.rankingKey(today);
+      String memberKey = RedisKeyConstants.memberKey(member.getPublicId());
       String detailKey = RedisKeyConstants.rankingDetailKey(today, member.getPublicId());
 
       ZonedDateTime startOfDay = today.atStartOfDay(KST);
@@ -138,7 +136,7 @@ public class RankingService {
 
   public RankingResponse getFullRankingsForDate(LocalDate date) {
     try {
-      String rankingKey = buildRankingKey(date);
+      String rankingKey = RedisKeyConstants.rankingKey(date);
 
       Set<String> allMembers = redisTemplate.opsForZSet().reverseRange(rankingKey, 0, -1);
 
@@ -159,7 +157,7 @@ public class RankingService {
   }
 
   private RankingResponse getRankingsForDate(LocalDate date) {
-    String rankingKey = buildRankingKey(date);
+    String rankingKey = RedisKeyConstants.rankingKey(date);
 
     Set<String> topMembers =
         redisTemplate.opsForZSet().reverseRange(rankingKey, 0, TOP_RANKING_SIZE - 1);
@@ -180,8 +178,8 @@ public class RankingService {
     List<RankingEntry> entries = new ArrayList<>();
     long rank = 1;
     for (String memberKey : memberKeys) {
-      String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
-      String detailKey = RedisKeyConstants.rankingDetailKey(date, UUID.fromString(publicIdStr));
+      UUID publicId = RedisKeyConstants.extractMemberPublicId(memberKey);
+      String detailKey = RedisKeyConstants.rankingDetailKey(date, publicId);
 
       Map<Object, Object> detail = redisTemplate.opsForHash().entries(detailKey);
       if (detail.isEmpty()) {
@@ -204,8 +202,8 @@ public class RankingService {
   }
 
   private MyRank lookupMyRank(LocalDate date, UUID memberPublicId) {
-    String rankingKey = buildRankingKey(date);
-    String memberKey = RANKING_MEMBER_PREFIX + memberPublicId;
+    String rankingKey = RedisKeyConstants.rankingKey(date);
+    String memberKey = RedisKeyConstants.memberKey(memberPublicId);
 
     Long rank = redisTemplate.opsForZSet().reverseRank(rankingKey, memberKey);
     if (rank == null) {
@@ -226,7 +224,7 @@ public class RankingService {
 
   public RankingSnapshot getAllRankingsForDate(LocalDate date) {
     try {
-      String rankingKey = buildRankingKey(date);
+      String rankingKey = RedisKeyConstants.rankingKey(date);
       Long totalPlayers = redisTemplate.opsForZSet().zCard(rankingKey);
       if (totalPlayers == null || totalPlayers == 0) {
         return new RankingSnapshot(List.of(), 0);
@@ -240,7 +238,7 @@ public class RankingService {
       List<RankingSnapshot.MemberRank> memberRanks = new ArrayList<>();
       int rank = 1;
       for (String memberKey : allMembers) {
-        UUID publicId = UUID.fromString(memberKey.substring(RANKING_MEMBER_PREFIX.length()));
+        UUID publicId = RedisKeyConstants.extractMemberPublicId(memberKey);
         memberRanks.add(new RankingSnapshot.MemberRank(publicId, rank++));
       }
 
@@ -259,7 +257,7 @@ public class RankingService {
 
     List<GameSession> sessions = gameSessionRepository.findAllBySentenceWithMember(sentence);
 
-    String rankingKey = buildRankingKey(date);
+    String rankingKey = RedisKeyConstants.rankingKey(date);
     ZonedDateTime startOfDay = date.atStartOfDay(KST);
     int count = 0;
 
@@ -283,7 +281,7 @@ public class RankingService {
               elapsedSeconds,
               clearedAtSeconds);
 
-      String memberKey = RANKING_MEMBER_PREFIX + member.getPublicId();
+      String memberKey = RedisKeyConstants.memberKey(member.getPublicId());
       redisTemplate.opsForZSet().add(rankingKey, memberKey, score);
 
       String detailKey = RedisKeyConstants.rankingDetailKey(date, member.getPublicId());
@@ -306,8 +304,8 @@ public class RankingService {
   public boolean cleanupMemberRanking(UUID publicId) {
     try {
       LocalDate today = LocalDate.now(clock);
-      String rankingKey = buildRankingKey(today);
-      String memberKey = RANKING_MEMBER_PREFIX + publicId;
+      String rankingKey = RedisKeyConstants.rankingKey(today);
+      String memberKey = RedisKeyConstants.memberKey(publicId);
       String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
 
       Long removed = redisTemplate.opsForZSet().remove(rankingKey, memberKey);
@@ -323,14 +321,14 @@ public class RankingService {
   }
 
   public void expirePreviousDayRankingKeys(LocalDate date) {
-    String rankingKey = buildRankingKey(date);
+    String rankingKey = RedisKeyConstants.rankingKey(date);
 
     Set<String> members = redisTemplate.opsForZSet().range(rankingKey, 0, -1);
     int detailCount = 0;
     if (members != null) {
       for (String memberKey : members) {
-        String publicIdStr = memberKey.substring(RANKING_MEMBER_PREFIX.length());
-        String detailKey = RedisKeyConstants.rankingDetailKey(date, UUID.fromString(publicIdStr));
+        UUID publicId = RedisKeyConstants.extractMemberPublicId(memberKey);
+        String detailKey = RedisKeyConstants.rankingDetailKey(date, publicId);
         redisTemplate.expire(detailKey, EXPIRE_TTL);
         detailCount++;
       }
@@ -359,9 +357,5 @@ public class RankingService {
     }
     long seconds = Duration.between(startOfDay, session.getClearedAt().atZone(KST)).getSeconds();
     return Math.max(seconds, 0);
-  }
-
-  private String buildRankingKey(LocalDate date) {
-    return RANKING_KEY_PREFIX + date;
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
@@ -27,13 +27,6 @@ public class SseConnectionManager {
   private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
   private final RankingService rankingService;
   private final int maxConnections;
-
-  public SseConnectionManager(
-      RankingService rankingService, @Value("${app.sse.max-connections:500}") int maxConnections) {
-    this.rankingService = rankingService;
-    this.maxConnections = maxConnections;
-  }
-
   private final ScheduledExecutorService heartbeatExecutor =
       Executors.newSingleThreadScheduledExecutor(
           r -> {
@@ -41,6 +34,12 @@ public class SseConnectionManager {
             t.setDaemon(true);
             return t;
           });
+
+  public SseConnectionManager(
+      RankingService rankingService, @Value("${app.sse.max-connections:500}") int maxConnections) {
+    this.rankingService = rankingService;
+    this.maxConnections = maxConnections;
+  }
 
   @PostConstruct
   void startHeartbeat() {

--- a/backend/src/test/java/com/gakkaweo/backend/announcement/AnnouncementPublicEndpointTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/announcement/AnnouncementPublicEndpointTest.java
@@ -23,11 +23,10 @@ import org.springframework.transaction.support.TransactionTemplate;
 @DisplayName("공지 공개 엔드포인트 통합 테스트")
 class AnnouncementPublicEndpointTest extends IntegrationTestBase {
 
-  @Autowired AnnouncementRepository announcementRepository;
-  @Autowired TransactionTemplate transactionTemplate;
-
   private static final ParameterizedTypeReference<List<ActiveAnnouncementResponse>> RESPONSE_TYPE =
       new ParameterizedTypeReference<>() {};
+  @Autowired AnnouncementRepository announcementRepository;
+  @Autowired TransactionTemplate transactionTemplate;
 
   @Test
   @DisplayName("미인증 호출 - 200 + 활성 공지 반환")

--- a/backend/src/test/java/com/gakkaweo/backend/auth/OAuth2LoginHandlerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/OAuth2LoginHandlerTest.java
@@ -46,6 +46,16 @@ class OAuth2LoginHandlerTest {
   private OAuth2Properties oAuth2Properties;
   private CookieAuthorizationRequestRepository authorizationRequestRepository;
 
+  private static List<HttpCookie> allSetCookies(MockHttpServletResponse response) {
+    return response.getHeaders(HttpHeaders.SET_COOKIE).stream()
+        .flatMap(header -> HttpCookie.parse(header).stream())
+        .toList();
+  }
+
+  private static HttpCookie findCookie(List<HttpCookie> cookies, String name) {
+    return cookies.stream().filter(c -> name.equals(c.getName())).findFirst().orElse(null);
+  }
+
   @BeforeEach
   void setUp() {
     authService = Mockito.mock(AuthService.class);
@@ -59,6 +69,12 @@ class OAuth2LoginHandlerTest {
     oAuth2Properties = new OAuth2Properties(REDIRECT_URI);
     authorizationRequestRepository =
         new CookieAuthorizationRequestRepository(cookieProperties, new ObjectMapper());
+  }
+
+  private static class NullMessageAuthenticationException extends AuthenticationException {
+    NullMessageAuthenticationException() {
+      super(null);
+    }
   }
 
   @Nested
@@ -140,22 +156,6 @@ class OAuth2LoginHandlerTest {
       HttpCookie authReq = findCookie(allSetCookies(response), "oauth2_auth_request");
       assertThat(authReq).isNotNull();
       assertThat(authReq.getMaxAge()).isZero();
-    }
-  }
-
-  private static List<HttpCookie> allSetCookies(MockHttpServletResponse response) {
-    return response.getHeaders(HttpHeaders.SET_COOKIE).stream()
-        .flatMap(header -> HttpCookie.parse(header).stream())
-        .toList();
-  }
-
-  private static HttpCookie findCookie(List<HttpCookie> cookies, String name) {
-    return cookies.stream().filter(c -> name.equals(c.getName())).findFirst().orElse(null);
-  }
-
-  private static class NullMessageAuthenticationException extends AuthenticationException {
-    NullMessageAuthenticationException() {
-      super(null);
     }
   }
 }

--- a/backend/src/test/java/com/gakkaweo/backend/common/GlobalExceptionHandlerUnitTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/common/GlobalExceptionHandlerUnitTest.java
@@ -9,6 +9,9 @@ import static org.mockito.Mockito.verify;
 import com.gakkaweo.backend.common.exception.ErrorBody;
 import com.gakkaweo.backend.common.exception.GlobalExceptionHandler;
 import com.gakkaweo.backend.infra.notification.ServerErrorNotifier;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -25,7 +28,9 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 class GlobalExceptionHandlerUnitTest {
 
   private final ServerErrorNotifier serverErrorNotifier = mock(ServerErrorNotifier.class);
-  private final GlobalExceptionHandler handler = new GlobalExceptionHandler(serverErrorNotifier);
+  private final Clock clock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneId.of("UTC"));
+  private final GlobalExceptionHandler handler =
+      new GlobalExceptionHandler(serverErrorNotifier, clock);
 
   private static ResponseEntity<Object> invokeHandleMaxUploadSizeExceeded(
       GlobalExceptionHandler handler,

--- a/backend/src/test/java/com/gakkaweo/backend/common/GlobalExceptionHandlerUnitTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/common/GlobalExceptionHandlerUnitTest.java
@@ -27,6 +27,66 @@ class GlobalExceptionHandlerUnitTest {
   private final ServerErrorNotifier serverErrorNotifier = mock(ServerErrorNotifier.class);
   private final GlobalExceptionHandler handler = new GlobalExceptionHandler(serverErrorNotifier);
 
+  private static ResponseEntity<Object> invokeHandleMaxUploadSizeExceeded(
+      GlobalExceptionHandler handler,
+      MaxUploadSizeExceededException ex,
+      HttpStatus status,
+      ServletWebRequest req)
+      throws Exception {
+    var method =
+        GlobalExceptionHandler.class.getDeclaredMethod(
+            "handleMaxUploadSizeExceededException",
+            MaxUploadSizeExceededException.class,
+            HttpHeaders.class,
+            org.springframework.http.HttpStatusCode.class,
+            org.springframework.web.context.request.WebRequest.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    ResponseEntity<Object> response =
+        (ResponseEntity<Object>) method.invoke(handler, ex, new HttpHeaders(), status, req);
+    return response;
+  }
+
+  private static ResponseEntity<Object> invokeHandleMissingParameter(
+      GlobalExceptionHandler handler,
+      MissingServletRequestParameterException ex,
+      HttpStatus status,
+      ServletWebRequest req)
+      throws Exception {
+    var method =
+        GlobalExceptionHandler.class.getDeclaredMethod(
+            "handleMissingServletRequestParameter",
+            MissingServletRequestParameterException.class,
+            HttpHeaders.class,
+            org.springframework.http.HttpStatusCode.class,
+            org.springframework.web.context.request.WebRequest.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    ResponseEntity<Object> response =
+        (ResponseEntity<Object>) method.invoke(handler, ex, new HttpHeaders(), status, req);
+    return response;
+  }
+
+  private static ResponseEntity<Object> invokeHandleMethodNotSupported(
+      GlobalExceptionHandler handler,
+      HttpRequestMethodNotSupportedException ex,
+      HttpStatus status,
+      ServletWebRequest req)
+      throws Exception {
+    var method =
+        GlobalExceptionHandler.class.getDeclaredMethod(
+            "handleHttpRequestMethodNotSupported",
+            HttpRequestMethodNotSupportedException.class,
+            HttpHeaders.class,
+            org.springframework.http.HttpStatusCode.class,
+            org.springframework.web.context.request.WebRequest.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    ResponseEntity<Object> response =
+        (ResponseEntity<Object>) method.invoke(handler, ex, new HttpHeaders(), status, req);
+    return response;
+  }
+
   @Test
   @DisplayName("ObjectOptimisticLockingFailureException - CONCURRENT_MODIFICATION 응답")
   void 낙관락_충돌() {
@@ -95,65 +155,5 @@ class GlobalExceptionHandlerUnitTest {
     assertThat(response).isNotNull();
     ErrorBody body = (ErrorBody) response.getBody();
     assertThat(body.code()).isEqualTo("METHOD_NOT_ALLOWED");
-  }
-
-  private static ResponseEntity<Object> invokeHandleMaxUploadSizeExceeded(
-      GlobalExceptionHandler handler,
-      MaxUploadSizeExceededException ex,
-      HttpStatus status,
-      ServletWebRequest req)
-      throws Exception {
-    var method =
-        GlobalExceptionHandler.class.getDeclaredMethod(
-            "handleMaxUploadSizeExceededException",
-            MaxUploadSizeExceededException.class,
-            HttpHeaders.class,
-            org.springframework.http.HttpStatusCode.class,
-            org.springframework.web.context.request.WebRequest.class);
-    method.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ResponseEntity<Object> response =
-        (ResponseEntity<Object>) method.invoke(handler, ex, new HttpHeaders(), status, req);
-    return response;
-  }
-
-  private static ResponseEntity<Object> invokeHandleMissingParameter(
-      GlobalExceptionHandler handler,
-      MissingServletRequestParameterException ex,
-      HttpStatus status,
-      ServletWebRequest req)
-      throws Exception {
-    var method =
-        GlobalExceptionHandler.class.getDeclaredMethod(
-            "handleMissingServletRequestParameter",
-            MissingServletRequestParameterException.class,
-            HttpHeaders.class,
-            org.springframework.http.HttpStatusCode.class,
-            org.springframework.web.context.request.WebRequest.class);
-    method.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ResponseEntity<Object> response =
-        (ResponseEntity<Object>) method.invoke(handler, ex, new HttpHeaders(), status, req);
-    return response;
-  }
-
-  private static ResponseEntity<Object> invokeHandleMethodNotSupported(
-      GlobalExceptionHandler handler,
-      HttpRequestMethodNotSupportedException ex,
-      HttpStatus status,
-      ServletWebRequest req)
-      throws Exception {
-    var method =
-        GlobalExceptionHandler.class.getDeclaredMethod(
-            "handleHttpRequestMethodNotSupported",
-            HttpRequestMethodNotSupportedException.class,
-            HttpHeaders.class,
-            org.springframework.http.HttpStatusCode.class,
-            org.springframework.web.context.request.WebRequest.class);
-    method.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ResponseEntity<Object> response =
-        (ResponseEntity<Object>) method.invoke(handler, ex, new HttpHeaders(), status, req);
-    return response;
   }
 }

--- a/backend/src/test/java/com/gakkaweo/backend/game/DailySentenceSchedulerDiscordIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/game/DailySentenceSchedulerDiscordIntegrationTest.java
@@ -31,6 +31,8 @@ class DailySentenceSchedulerDiscordIntegrationTest extends IntegrationTestBase {
     WIRE_MOCK.start();
   }
 
+  @Autowired DailySentenceScheduler scheduler;
+
   @AfterAll
   static void stopWireMock() {
     WIRE_MOCK.stop();
@@ -40,8 +42,6 @@ class DailySentenceSchedulerDiscordIntegrationTest extends IntegrationTestBase {
   static void overrideWebhookUrl(DynamicPropertyRegistry registry) {
     registry.add("app.notification.discord.webhook-url", () -> WIRE_MOCK.baseUrl() + "/webhook");
   }
-
-  @Autowired DailySentenceScheduler scheduler;
 
   @BeforeEach
   void stubDiscord() {

--- a/backend/src/test/java/com/gakkaweo/backend/game/GameFlowIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/game/GameFlowIntegrationTest.java
@@ -33,6 +33,20 @@ class GameFlowIntegrationTest extends IntegrationTestBase {
 
   @Autowired GameSessionRepository gameSessionRepository;
 
+  private HttpHeaders authedJson(Member member) {
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(member);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+
+  private void submit(UUID sentenceId, String guessText, HttpHeaders headers) {
+    restTemplate.exchange(
+        url("/daily/guess"),
+        HttpMethod.POST,
+        new HttpEntity<>(new GuessRequest(sentenceId, guessText), headers),
+        GuessResponse.class);
+  }
+
   @Nested
   @DisplayName("오늘 문제 조회")
   class Today {
@@ -316,19 +330,5 @@ class GameFlowIntegrationTest extends IntegrationTestBase {
       assertThat(response.getBody().sentenceId()).isEqualTo(sentence.getPublicId());
       assertThat(response.getBody().gameStatus()).isNull();
     }
-  }
-
-  private HttpHeaders authedJson(Member member) {
-    HttpHeaders headers = testAuthHelper.cookieHeaderFor(member);
-    headers.setContentType(MediaType.APPLICATION_JSON);
-    return headers;
-  }
-
-  private void submit(UUID sentenceId, String guessText, HttpHeaders headers) {
-    restTemplate.exchange(
-        url("/daily/guess"),
-        HttpMethod.POST,
-        new HttpEntity<>(new GuessRequest(sentenceId, guessText), headers),
-        GuessResponse.class);
   }
 }

--- a/backend/src/test/java/com/gakkaweo/backend/infra/ai/AiServiceClientTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/infra/ai/AiServiceClientTest.java
@@ -65,7 +65,7 @@ class AiServiceClientTest {
 
     assertThatThrownBy(() -> client.calculateSimilarity("원문", "추측"))
         .isInstanceOf(AiServiceException.class)
-        .hasMessageContaining("AI 서비스 요청 실패");
+        .hasMessageContaining("AI 서비스를 일시적으로 이용할 수 없습니다");
   }
 
   @Test

--- a/backend/src/test/java/com/gakkaweo/backend/infra/notification/NotificationDeduplicationCacheTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/infra/notification/NotificationDeduplicationCacheTest.java
@@ -14,33 +14,6 @@ import org.junit.jupiter.api.Test;
 @DisplayName("NotificationDeduplicationCache 단위 테스트")
 class NotificationDeduplicationCacheTest {
 
-  private static class MutableClock extends Clock {
-    private Instant now;
-
-    MutableClock(Instant now) {
-      this.now = now;
-    }
-
-    void advance(Duration duration) {
-      this.now = this.now.plus(duration);
-    }
-
-    @Override
-    public ZoneId getZone() {
-      return ZoneId.of("UTC");
-    }
-
-    @Override
-    public Clock withZone(ZoneId zone) {
-      return this;
-    }
-
-    @Override
-    public Instant instant() {
-      return now;
-    }
-  }
-
   private NotificationProperties propsWithCooldown(Duration cooldown) {
     return new NotificationProperties(
         new NotificationProperties.AuditAlert(true),
@@ -109,5 +82,32 @@ class NotificationDeduplicationCacheTest {
 
     assertThat(cache.shouldSend("stale", Duration.ofMinutes(5))).isTrue();
     assertThat(cache.shouldSend("fresh", Duration.ofMinutes(5))).isFalse();
+  }
+
+  private static class MutableClock extends Clock {
+    private Instant now;
+
+    MutableClock(Instant now) {
+      this.now = now;
+    }
+
+    void advance(Duration duration) {
+      this.now = this.now.plus(duration);
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneId.of("UTC");
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return now;
+    }
   }
 }

--- a/backend/src/test/java/com/gakkaweo/backend/ranking/RankingServiceIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/ranking/RankingServiceIntegrationTest.java
@@ -38,6 +38,15 @@ class RankingServiceIntegrationTest extends IntegrationTestBase {
   @Autowired TransactionTemplate transactionTemplate;
   @Autowired Clock rankingClock;
 
+  @SuppressWarnings("unused")
+  private static List<String> nicknames(RankingResponse response) {
+    List<String> result = new ArrayList<>();
+    for (RankingResponse.RankingEntry e : response.rankings()) {
+      result.add(e.nickname());
+    }
+    return result;
+  }
+
   @Test
   @DisplayName("GET /ranking/today 미인증 - getRankings 루프 + profileUrl null/empty/값 3분기")
   void 랭킹_조회_미인증() {
@@ -277,14 +286,5 @@ class RankingServiceIntegrationTest extends IntegrationTestBase {
         gameSessionRepository.findByMemberAndSentence(member, sentence).orElseThrow();
     rankingService.updateRanking(session, member);
     return member;
-  }
-
-  @SuppressWarnings("unused")
-  private static List<String> nicknames(RankingResponse response) {
-    List<String> result = new ArrayList<>();
-    for (RankingResponse.RankingEntry e : response.rankings()) {
-      result.add(e.nickname());
-    }
-    return result;
   }
 }

--- a/backend/src/test/java/com/gakkaweo/backend/support/BulkDataFixture.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/BulkDataFixture.java
@@ -14,13 +14,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class BulkDataFixture {
 
-  public record PopulatedIds(
-      List<Long> memberIds,
-      List<Long> sentenceIds,
-      List<Long> sessionIds,
-      long adminId,
-      String topAuditAction) {}
-
   private static final int BATCH = 1000;
   private static final List<String> AUDIT_ACTIONS =
       List.of(
@@ -29,7 +22,6 @@ public class BulkDataFixture {
           "SENTENCE_UPLOAD",
           "SENTENCE_DELETE",
           "ANNOUNCEMENT_CREATE");
-
   private final JdbcTemplate jdbc;
   private final Clock clock;
 
@@ -275,4 +267,11 @@ public class BulkDataFixture {
       batch.clear();
     }
   }
+
+  public record PopulatedIds(
+      List<Long> memberIds,
+      List<Long> sentenceIds,
+      List<Long> sessionIds,
+      long adminId,
+      String topAuditAction) {}
 }

--- a/backend/src/test/java/com/gakkaweo/backend/support/IntegrationTestBase.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/IntegrationTestBase.java
@@ -17,10 +17,10 @@ import org.springframework.web.client.RestTemplate;
 @Import({TestContainerConfig.class, TestClockConfig.class})
 public abstract class IntegrationTestBase {
 
+  protected final RestTemplate restTemplate =
+      new RestTemplateBuilder().errorHandler(new NoOpResponseErrorHandler()).build();
   @LocalServerPort protected int port;
-
   @Autowired protected DatabaseCleaner databaseCleaner;
-
   @Autowired protected TestSimilarityClient testSimilarityClient;
 
   @Autowired(required = false)
@@ -30,9 +30,6 @@ public abstract class IntegrationTestBase {
   protected TestEventCollector testEventCollector;
 
   @Autowired protected Clock clock;
-
-  protected final RestTemplate restTemplate =
-      new RestTemplateBuilder().errorHandler(new NoOpResponseErrorHandler()).build();
 
   @BeforeEach
   void cleanBeforeEach() {


### PR DESCRIPTION
## 관련 이슈

Closes #146

## 변경 사항

### 규칙 정합성 정리
- `NotificationProperties` 내부 `AuditAlert`/`ErrorAlert` static class → record 전환, 호출부 accessor로 정렬
- `Instant.now()` 11곳을 `Clock` 빈으로 교체 (`GlobalExceptionHandler`, `RestAccessDeniedHandler`, `RestAuthenticationEntryPoint`) — backend.md 시간 의존 서비스 규칙 준수
- `AdminSentenceController` 클래스 레벨 `@Transactional` 제거 → `testSimilarity`/`checkDuplicate`의 AI 호출을 TX 밖으로 분리
- `GameProperties` `@Setter` 제거 + 생성자 바인딩으로 불변화
- OAuth2 "차단된 계정입니다" 하드코딩 → `ErrorCode.MEMBER_BANNED`
- `AiServiceClient` 실패 메시지 → `ErrorCode.AI_SERVICE_UNAVAILABLE` 재사용

### 중복 로직 공통화
- `RankingService.cleanupMemberRanking()` 신설 — `AdminUserService`/`AccountService`의 Redis 정리 플로우 재사용
- `RankingService.buildRankingEntries()` 파싱 헬퍼 추출 — `getFullRankingsForDate`/`getRankingsForDate` 중복 제거
- `AdminDashboardService.collectSentenceStats()` 통합 — `getTodayWidget`/`getDateStats` 동일 4쿼리 공용화

### Redis 키 조립 전면 응집 (범위 확장)

검수 중 "Redis 키 조립은 한 곳에서"라는 원칙 합의 → `RedisKeyConstants`에 헬퍼 5종 집약하고 prefix 상수를 `private`로 내려 우회 차단.
- `blacklistKey`, `rankingKey`, `memberKey`, `extractMemberPublicId`, `similarityCacheKey` (+기존 `rankingDetailKey`)
- `AuthService`/`JwtAuthenticationFilter`/`AdminSystemService`/`AdminSentenceService`/`RankingService`/`SimilarityService`의 수작업 조립·파싱 전부 헬퍼 호출로 치환 (15 사이트 → 1 사이트)

### 기타
- `SimilarityRequest`에 `@Schema` 설명 추가
- 필드/메서드 순서 정돈 10 파일 (DailySentenceScheduler, SseConnectionManager, 테스트 7종 등)

### 회귀 수정

Part 1 과정에서 도입된 회귀를 별도 커밋으로 수정 (검증 시 발견):
- `GameProperties`에서 `@Component` 제거 — 생성자 바인딩 전환 시 `@Component` 동반이 Spring 일반 빈 경로로 해석되어 `BigDecimal` 주입 실패(193 테스트 컨텍스트 로드 실패). `@ConfigurationPropertiesScan`이 이미 적용되어 있어 `@Component`만 제거
- `AiServiceClientTest` 기대 메시지 동기화 — `ErrorCode.AI_SERVICE_UNAVAILABLE.getMessage()` 교체 시 assertion 업데이트 누락
- `AccountService.cleanupRedis` logout 예외 보호 복원 — 리팩터 과정에서 try-catch가 사라져 logout 실패 시 이후 Redis 정리·이벤트 발행이 중단되던 회귀. `authService.logout` 호출만 감싸 이후 `cleanupMemberRanking`은 계속 실행되도록 보장

## 알려진 한계 (후속 이슈로 분리)

`AdminSentenceController` 클래스 레벨 `@Transactional` 제거로 인해 서비스 커밋과 감사 로그 저장이 서로 다른 TX에서 실행되는 상태가 됨. 감사 로그 저장 실패 시 비즈니스 기록이 이미 커밋되어 롤백되지 않으므로 감사 기록 누락 가능성 존재.

올바른 해법은 컨트롤러에 `@Transactional`을 되넣는 것이 아니라(이번 리팩터의 "TX 내 I/O 분리" 취지와 모순) **감사 로그 호출을 서비스 레이어로 이동**하는 것이며, 이는 `AdminSentenceService`의 쓰기 메서드 시그니처 변경을 포함하는 다른 성격의 리팩터라 이번 PR 범위(소규모 정리)를 벗어남. 별도 follow-up 이슈에서 처리 예정.

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (`./gradlew test` 292/292 통과, `spotlessCheck` 통과)
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다 (기능 변경 0 유지, 순수 리팩터)