### PR TITLE
refactor: 어드민 감사 로그 호출을 서비스 레이어로 이동

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSentenceController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSentenceController.java
@@ -13,7 +13,6 @@ import com.gakkaweo.backend.admin.dto.SentenceUpdateRequest;
 import com.gakkaweo.backend.admin.dto.SimilarityTestRequest;
 import com.gakkaweo.backend.admin.dto.SimilarityTestResponse;
 import com.gakkaweo.backend.admin.dto.UnusedCountResponse;
-import com.gakkaweo.backend.admin.service.AdminAuditService;
 import com.gakkaweo.backend.admin.service.AdminSentenceService;
 import com.gakkaweo.backend.admin.service.CsvUploadService;
 import com.gakkaweo.backend.auth.security.CustomUserDetails;
@@ -50,7 +49,6 @@ public class AdminSentenceController {
 
   private final AdminSentenceService adminSentenceService;
   private final CsvUploadService csvUploadService;
-  private final AdminAuditService adminAuditService;
 
   @Operation(summary = "문장 목록 조회")
   @AdminErrorResponses
@@ -75,14 +73,9 @@ public class AdminSentenceController {
       @Valid @RequestBody SentenceCreateRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    SentenceResponse response = adminSentenceService.createSentence(request);
-    adminAuditService.log(
-        userDetails.publicId(),
-        "SENTENCE_CREATE",
-        "SENTENCE",
-        response.publicId().toString(),
-        request.sentence(),
-        httpRequest.getRemoteAddr());
+    SentenceResponse response =
+        adminSentenceService.createSentence(
+            request, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
@@ -108,14 +101,9 @@ public class AdminSentenceController {
       @Valid @RequestBody SentenceUpdateRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    SentenceResponse response = adminSentenceService.updateSentence(publicId, request);
-    adminAuditService.log(
-        userDetails.publicId(),
-        "SENTENCE_UPDATE",
-        "SENTENCE",
-        publicId.toString(),
-        request.sentence(),
-        httpRequest.getRemoteAddr());
+    SentenceResponse response =
+        adminSentenceService.updateSentence(
+            publicId, request, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok(response);
   }
 
@@ -134,14 +122,8 @@ public class AdminSentenceController {
       @PathVariable UUID publicId,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    adminSentenceService.deleteSentence(publicId);
-    adminAuditService.log(
-        userDetails.publicId(),
-        "SENTENCE_DELETE",
-        "SENTENCE",
-        publicId.toString(),
-        null,
-        httpRequest.getRemoteAddr());
+    adminSentenceService.deleteSentence(
+        publicId, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok().build();
   }
 
@@ -172,14 +154,8 @@ public class AdminSentenceController {
       @Parameter(description = "CSV 파일 (UTF-8, 줄 단위 문장)") @RequestParam("file") MultipartFile file,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    CsvUploadResponse response = csvUploadService.uploadCsv(file, userDetails.publicId());
-    adminAuditService.log(
-        userDetails.publicId(),
-        "CSV_UPLOAD",
-        "SENTENCE",
-        null,
-        "success=" + response.successCount() + ", duplicate=" + response.duplicateCount(),
-        httpRequest.getRemoteAddr());
+    CsvUploadResponse response =
+        csvUploadService.uploadCsv(file, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
@@ -198,14 +174,9 @@ public class AdminSentenceController {
       @Valid @RequestBody ScheduleRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    SentenceResponse response = adminSentenceService.schedule(publicId, request);
-    adminAuditService.log(
-        userDetails.publicId(),
-        "SENTENCE_SCHEDULE",
-        "SENTENCE",
-        publicId.toString(),
-        "date=" + request.date(),
-        httpRequest.getRemoteAddr());
+    SentenceResponse response =
+        adminSentenceService.schedule(
+            publicId, request, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok(response);
   }
 
@@ -216,14 +187,9 @@ public class AdminSentenceController {
       @PathVariable UUID publicId,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    SentenceResponse response = adminSentenceService.unschedule(publicId);
-    adminAuditService.log(
-        userDetails.publicId(),
-        "SENTENCE_UNSCHEDULE",
-        "SENTENCE",
-        publicId.toString(),
-        null,
-        httpRequest.getRemoteAddr());
+    SentenceResponse response =
+        adminSentenceService.unschedule(
+            publicId, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok(response);
   }
 
@@ -264,17 +230,9 @@ public class AdminSentenceController {
       @Valid @RequestBody EmergencyReplaceRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    SentenceResponse response = adminSentenceService.emergencyReplace(request);
-    adminAuditService.log(
-        userDetails.publicId(),
-        "EMERGENCY_REPLACE",
-        "SENTENCE",
-        response.publicId().toString(),
-        "newSentence="
-            + request.newSentencePublicId()
-            + ", returnToPool="
-            + request.returnOldToPool(),
-        httpRequest.getRemoteAddr());
+    SentenceResponse response =
+        adminSentenceService.emergencyReplace(
+            request, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok(response);
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSystemController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSystemController.java
@@ -5,7 +5,6 @@ import com.gakkaweo.backend.admin.dto.AnnouncementResponse;
 import com.gakkaweo.backend.admin.dto.AnnouncementUpdateRequest;
 import com.gakkaweo.backend.admin.dto.AuditLogListResponse;
 import com.gakkaweo.backend.admin.dto.SystemStatusResponse;
-import com.gakkaweo.backend.admin.service.AdminAuditService;
 import com.gakkaweo.backend.admin.service.AdminSystemService;
 import com.gakkaweo.backend.auth.security.CustomUserDetails;
 import com.gakkaweo.backend.config.openapi.AdminErrorResponses;
@@ -36,13 +35,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/admin/system")
 @RequiredArgsConstructor
-@Transactional
 @Tag(name = "Admin: System", description = "어드민 시스템 관리")
 @SecurityRequirement(name = "cookieAuth")
 public class AdminSystemController {
 
   private final AdminSystemService adminSystemService;
-  private final AdminAuditService adminAuditService;
 
   @Operation(summary = "공지 목록 조회")
   @AdminErrorResponses
@@ -62,14 +59,8 @@ public class AdminSystemController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
     AnnouncementResponse response =
-        adminSystemService.createAnnouncement(request, userDetails.publicId());
-    adminAuditService.log(
-        userDetails.publicId(),
-        "ANNOUNCEMENT_CREATE",
-        "ANNOUNCEMENT",
-        response.id().toString(),
-        request.title(),
-        httpRequest.getRemoteAddr());
+        adminSystemService.createAnnouncement(
+            request, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
@@ -86,14 +77,9 @@ public class AdminSystemController {
       @Valid @RequestBody AnnouncementUpdateRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    AnnouncementResponse response = adminSystemService.updateAnnouncement(id, request);
-    adminAuditService.log(
-        userDetails.publicId(),
-        "ANNOUNCEMENT_UPDATE",
-        "ANNOUNCEMENT",
-        id.toString(),
-        null,
-        httpRequest.getRemoteAddr());
+    AnnouncementResponse response =
+        adminSystemService.updateAnnouncement(
+            id, request, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok(response);
   }
 
@@ -109,14 +95,7 @@ public class AdminSystemController {
       @PathVariable Long id,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    adminSystemService.deleteAnnouncement(id);
-    adminAuditService.log(
-        userDetails.publicId(),
-        "ANNOUNCEMENT_DELETE",
-        "ANNOUNCEMENT",
-        id.toString(),
-        null,
-        httpRequest.getRemoteAddr());
+    adminSystemService.deleteAnnouncement(id, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok().build();
   }
 
@@ -133,14 +112,7 @@ public class AdminSystemController {
   @PostMapping("/ranking-cache/reset")
   public ResponseEntity<Void> resetRankingCache(
       @AuthenticationPrincipal CustomUserDetails userDetails, HttpServletRequest httpRequest) {
-    adminSystemService.resetRankingCache();
-    adminAuditService.log(
-        userDetails.publicId(),
-        "RANKING_CACHE_RESET",
-        "SYSTEM",
-        null,
-        null,
-        httpRequest.getRemoteAddr());
+    adminSystemService.resetRankingCache(userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok().build();
   }
 
@@ -149,14 +121,7 @@ public class AdminSystemController {
   @PostMapping("/rate-limit/reset")
   public ResponseEntity<Void> resetRateLimit(
       @AuthenticationPrincipal CustomUserDetails userDetails, HttpServletRequest httpRequest) {
-    adminSystemService.resetRateLimit();
-    adminAuditService.log(
-        userDetails.publicId(),
-        "RATE_LIMIT_RESET",
-        "SYSTEM",
-        null,
-        null,
-        httpRequest.getRemoteAddr());
+    adminSystemService.resetRateLimit(userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok().build();
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminUserController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminUserController.java
@@ -6,7 +6,6 @@ import com.gakkaweo.backend.admin.dto.RoleChangeRequest;
 import com.gakkaweo.backend.admin.dto.UserDetailResponse;
 import com.gakkaweo.backend.admin.dto.UserGameHistoryResponse;
 import com.gakkaweo.backend.admin.dto.UserListResponse;
-import com.gakkaweo.backend.admin.service.AdminAuditService;
 import com.gakkaweo.backend.admin.service.AdminUserService;
 import com.gakkaweo.backend.auth.security.CustomUserDetails;
 import com.gakkaweo.backend.config.openapi.AdminErrorResponses;
@@ -35,13 +34,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/admin/users")
 @RequiredArgsConstructor
 @Slf4j
-@Transactional
 @Tag(name = "Admin: Users", description = "어드민 사용자 관리")
 @SecurityRequirement(name = "cookieAuth")
 public class AdminUserController {
 
   private final AdminUserService adminUserService;
-  private final AdminAuditService adminAuditService;
 
   @Operation(summary = "사용자 목록 조회")
   @AdminErrorResponses
@@ -87,14 +84,8 @@ public class AdminUserController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
     AdminUserResponse response =
-        adminUserService.changeRole(publicId, userDetails.publicId(), request);
-    adminAuditService.log(
-        userDetails.publicId(),
-        "ROLE_CHANGE",
-        "MEMBER",
-        publicId.toString(),
-        "newRole=" + request.role(),
-        httpRequest.getRemoteAddr());
+        adminUserService.changeRole(
+            publicId, userDetails.publicId(), request, httpRequest.getRemoteAddr());
     return ResponseEntity.ok(response);
   }
 
@@ -111,14 +102,7 @@ public class AdminUserController {
       @PathVariable UUID publicId,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    adminUserService.banUser(publicId, userDetails.publicId());
-    adminAuditService.log(
-        userDetails.publicId(),
-        "USER_BAN",
-        "MEMBER",
-        publicId.toString(),
-        null,
-        httpRequest.getRemoteAddr());
+    adminUserService.banUser(publicId, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok().build();
   }
 
@@ -135,14 +119,7 @@ public class AdminUserController {
       @PathVariable UUID publicId,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    adminUserService.unbanUser(publicId, userDetails.publicId());
-    adminAuditService.log(
-        userDetails.publicId(),
-        "USER_UNBAN",
-        "MEMBER",
-        publicId.toString(),
-        null,
-        httpRequest.getRemoteAddr());
+    adminUserService.unbanUser(publicId, userDetails.publicId(), httpRequest.getRemoteAddr());
     return ResponseEntity.ok().build();
   }
 
@@ -159,14 +136,7 @@ public class AdminUserController {
       @PathVariable UUID publicId,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    adminUserService.forceDeleteUser(publicId, userDetails.publicId());
-    adminAuditService.log(
-        userDetails.publicId(),
-        "USER_FORCE_DELETE",
-        "MEMBER",
-        publicId.toString(),
-        null,
-        httpRequest.getRemoteAddr());
+    adminUserService.forceDeleteUser(publicId, userDetails.publicId(), httpRequest.getRemoteAddr());
     try {
       adminUserService.cleanupRedisAfterDelete(publicId);
       adminUserService.cleanupProfileImage(publicId);
@@ -193,15 +163,9 @@ public class AdminUserController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
     AdminUserResponse response =
-        adminUserService.forceChangeNickname(publicId, userDetails.publicId(), request);
+        adminUserService.forceChangeNickname(
+            publicId, userDetails.publicId(), request, httpRequest.getRemoteAddr());
     adminUserService.syncNicknameToRedis(publicId, response.nickname());
-    adminAuditService.log(
-        userDetails.publicId(),
-        "USER_FORCE_NICKNAME",
-        "MEMBER",
-        publicId.toString(),
-        "newNickname=" + response.nickname(),
-        httpRequest.getRemoteAddr());
     return ResponseEntity.ok(response);
   }
 
@@ -218,14 +182,8 @@ public class AdminUserController {
       @PathVariable UUID publicId,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       HttpServletRequest httpRequest) {
-    adminUserService.forceDeleteProfileImage(publicId, userDetails.publicId());
-    adminAuditService.log(
-        userDetails.publicId(),
-        "USER_FORCE_PROFILE_DELETE",
-        "MEMBER",
-        publicId.toString(),
-        null,
-        httpRequest.getRemoteAddr());
+    adminUserService.forceDeleteProfileImage(
+        publicId, userDetails.publicId(), httpRequest.getRemoteAddr());
     try {
       adminUserService.cleanupProfileImageAndRedis(publicId);
     } catch (Exception e) {

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -98,7 +98,7 @@ public class AdminSentenceService {
         "SENTENCE_CREATE",
         "SENTENCE",
         entity.getPublicId().toString(),
-        request.sentence(),
+        sentence,
         ipAddress);
     return SentenceResponse.from(entity);
   }
@@ -126,12 +126,7 @@ public class AdminSentenceService {
 
     entity.setSentence(newSentence);
     adminAuditService.log(
-        adminPublicId,
-        "SENTENCE_UPDATE",
-        "SENTENCE",
-        publicId.toString(),
-        request.sentence(),
-        ipAddress);
+        adminPublicId, "SENTENCE_UPDATE", "SENTENCE", publicId.toString(), newSentence, ipAddress);
     return SentenceResponse.from(entity);
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -51,6 +51,7 @@ public class AdminSentenceService {
   private final StringRedisTemplate redisTemplate;
   private final ApplicationEventPublisher eventPublisher;
   private final TransactionTemplate transactionTemplate;
+  private final AdminAuditService adminAuditService;
   private final Clock clock;
 
   @Transactional(readOnly = true)
@@ -82,7 +83,8 @@ public class AdminSentenceService {
   }
 
   @Transactional
-  public SentenceResponse createSentence(SentenceCreateRequest request) {
+  public SentenceResponse createSentence(
+      SentenceCreateRequest request, UUID adminPublicId, String ipAddress) {
     String sentence = request.sentence().strip();
     if (dailySentenceRepository.existsBySentence(sentence)) {
       throw new BusinessException(ErrorCode.SENTENCE_DUPLICATE);
@@ -91,6 +93,13 @@ public class AdminSentenceService {
     DailySentence entity = new DailySentence(sentence);
     dailySentenceRepository.save(entity);
     log.info("문장 등록: publicId={}", entity.getPublicId());
+    adminAuditService.log(
+        adminPublicId,
+        "SENTENCE_CREATE",
+        "SENTENCE",
+        entity.getPublicId().toString(),
+        request.sentence(),
+        ipAddress);
     return SentenceResponse.from(entity);
   }
 
@@ -101,7 +110,8 @@ public class AdminSentenceService {
   }
 
   @Transactional
-  public SentenceResponse updateSentence(UUID publicId, SentenceUpdateRequest request) {
+  public SentenceResponse updateSentence(
+      UUID publicId, SentenceUpdateRequest request, UUID adminPublicId, String ipAddress) {
     DailySentence entity = findByPublicIdOrThrow(publicId);
 
     if (entity.getUsedAt() != null) {
@@ -115,11 +125,18 @@ public class AdminSentenceService {
     }
 
     entity.setSentence(newSentence);
+    adminAuditService.log(
+        adminPublicId,
+        "SENTENCE_UPDATE",
+        "SENTENCE",
+        publicId.toString(),
+        request.sentence(),
+        ipAddress);
     return SentenceResponse.from(entity);
   }
 
   @Transactional
-  public void deleteSentence(UUID publicId) {
+  public void deleteSentence(UUID publicId, UUID adminPublicId, String ipAddress) {
     DailySentence entity = findByPublicIdOrThrow(publicId);
 
     if (entity.getUsedAt() != null) {
@@ -128,6 +145,8 @@ public class AdminSentenceService {
 
     dailySentenceRepository.delete(entity);
     log.info("문장 삭제: publicId={}", publicId);
+    adminAuditService.log(
+        adminPublicId, "SENTENCE_DELETE", "SENTENCE", publicId.toString(), null, ipAddress);
   }
 
   @Transactional(readOnly = true)
@@ -150,7 +169,8 @@ public class AdminSentenceService {
   }
 
   @Transactional
-  public SentenceResponse schedule(UUID publicId, ScheduleRequest request) {
+  public SentenceResponse schedule(
+      UUID publicId, ScheduleRequest request, UUID adminPublicId, String ipAddress) {
     if (request.date().isBefore(LocalDate.now(clock))) {
       throw new BusinessException(ErrorCode.VALIDATION_FAILED);
     }
@@ -167,13 +187,22 @@ public class AdminSentenceService {
     }
 
     entity.setScheduledAt(request.date());
+    adminAuditService.log(
+        adminPublicId,
+        "SENTENCE_SCHEDULE",
+        "SENTENCE",
+        publicId.toString(),
+        "date=" + request.date(),
+        ipAddress);
     return SentenceResponse.from(entity);
   }
 
   @Transactional
-  public SentenceResponse unschedule(UUID publicId) {
+  public SentenceResponse unschedule(UUID publicId, UUID adminPublicId, String ipAddress) {
     DailySentence entity = findByPublicIdOrThrow(publicId);
     entity.setScheduledAt(null);
+    adminAuditService.log(
+        adminPublicId, "SENTENCE_UNSCHEDULE", "SENTENCE", publicId.toString(), null, ipAddress);
     return SentenceResponse.from(entity);
   }
 
@@ -203,7 +232,8 @@ public class AdminSentenceService {
     return new DuplicateCheckResponse(!similarEntries.isEmpty(), similarEntries);
   }
 
-  public SentenceResponse emergencyReplace(EmergencyReplaceRequest request) {
+  public SentenceResponse emergencyReplace(
+      EmergencyReplaceRequest request, UUID adminPublicId, String ipAddress) {
     LocalDate today = LocalDate.now(clock);
 
     UUID newPublicId =
@@ -247,6 +277,17 @@ public class AdminSentenceService {
                   currentSentence.getPublicId(),
                   newSentence.getPublicId(),
                   request.returnOldToPool());
+
+              adminAuditService.log(
+                  adminPublicId,
+                  "EMERGENCY_REPLACE",
+                  "SENTENCE",
+                  newSentence.getPublicId().toString(),
+                  "newSentence="
+                      + request.newSentencePublicId()
+                      + ", returnToPool="
+                      + request.returnOldToPool(),
+                  ipAddress);
 
               return newSentence.getPublicId();
             });

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -61,6 +61,7 @@ public class AdminSystemService {
   private final StringRedisTemplate redisTemplate;
   private final ApplicationEventPublisher eventPublisher;
   private final TransactionTemplate transactionTemplate;
+  private final AdminAuditService adminAuditService;
   private final Clock clock;
 
   private static Specification<AuditLog> auditLogFilters(
@@ -91,7 +92,7 @@ public class AdminSystemService {
   }
 
   public AnnouncementResponse createAnnouncement(
-      AnnouncementCreateRequest request, UUID adminPublicId) {
+      AnnouncementCreateRequest request, UUID adminPublicId, String ipAddress) {
     AnnouncementType type = parseAnnouncementType(request.type());
     validateAnnouncementDates(request.startsAt(), request.endsAt());
 
@@ -108,6 +109,13 @@ public class AdminSystemService {
                       request.startsAt(),
                       request.endsAt());
               announcementRepository.save(announcement);
+              adminAuditService.log(
+                  admin,
+                  "ANNOUNCEMENT_CREATE",
+                  "ANNOUNCEMENT",
+                  announcement.getId().toString(),
+                  request.title(),
+                  ipAddress);
               return AnnouncementResponse.from(announcement);
             });
 
@@ -119,7 +127,8 @@ public class AdminSystemService {
     return response;
   }
 
-  public AnnouncementResponse updateAnnouncement(Long id, AnnouncementUpdateRequest request) {
+  public AnnouncementResponse updateAnnouncement(
+      Long id, AnnouncementUpdateRequest request, UUID adminPublicId, String ipAddress) {
     if (request.type() != null) {
       parseAnnouncementType(request.type());
     }
@@ -149,6 +158,13 @@ public class AdminSystemService {
               }
               validateAnnouncementDates(announcement.getStartsAt(), announcement.getEndsAt());
               announcementRepository.save(announcement);
+              adminAuditService.log(
+                  adminPublicId,
+                  "ANNOUNCEMENT_UPDATE",
+                  "ANNOUNCEMENT",
+                  id.toString(),
+                  null,
+                  ipAddress);
               return AnnouncementResponse.from(announcement);
             });
 
@@ -165,11 +181,24 @@ public class AdminSystemService {
     return response;
   }
 
-  public void deleteAnnouncement(Long id) {
-    Announcement announcement = findAnnouncement(id);
-    transactionTemplate.executeWithoutResult(status -> announcementRepository.delete(announcement));
-    eventPublisher.publishEvent(
-        new AnnouncementEvent(id, announcement.getTitle(), null, announcement.getType()));
+  public void deleteAnnouncement(Long id, UUID adminPublicId, String ipAddress) {
+    AnnouncementEvent event =
+        transactionTemplate.execute(
+            status -> {
+              Announcement announcement = findAnnouncement(id);
+              AnnouncementEvent ev =
+                  new AnnouncementEvent(id, announcement.getTitle(), null, announcement.getType());
+              announcementRepository.delete(announcement);
+              adminAuditService.log(
+                  adminPublicId,
+                  "ANNOUNCEMENT_DELETE",
+                  "ANNOUNCEMENT",
+                  id.toString(),
+                  null,
+                  ipAddress);
+              return ev;
+            });
+    eventPublisher.publishEvent(event);
   }
 
   public SystemStatusResponse getSystemStatus() {
@@ -201,7 +230,7 @@ public class AdminSystemService {
         unusedSentences);
   }
 
-  public void resetRankingCache() {
+  public void resetRankingCache(UUID adminPublicId, String ipAddress) {
     LocalDate today = LocalDate.now(clock);
     String rankingKey = RedisKeyConstants.rankingKey(today);
 
@@ -218,11 +247,13 @@ public class AdminSystemService {
     int rebuilt = rankingService.rebuildRankingCache(today);
     eventPublisher.publishEvent(new RankingUpdateEvent());
     log.info("랭킹 캐시 리셋 및 재구축: date={}, rebuilt={}", today, rebuilt);
+    adminAuditService.log(adminPublicId, "RANKING_CACHE_RESET", "SYSTEM", null, null, ipAddress);
   }
 
-  public void resetRateLimit() {
+  public void resetRateLimit(UUID adminPublicId, String ipAddress) {
     bucketStore.clearAllBuckets();
     log.info("Rate limit 버킷 전체 초기화");
+    adminAuditService.log(adminPublicId, "RATE_LIMIT_RESET", "SYSTEM", null, null, ipAddress);
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -60,6 +60,7 @@ public class AdminUserService {
   private final StringRedisTemplate redisTemplate;
   private final ApplicationEventPublisher eventPublisher;
   private final RankingService rankingService;
+  private final AdminAuditService adminAuditService;
   private final Clock clock;
 
   private static Specification<Member> memberFilters(String nickname, Boolean banned) {
@@ -120,7 +121,7 @@ public class AdminUserService {
 
   @Transactional
   public AdminUserResponse changeRole(
-      UUID targetPublicId, UUID adminPublicId, RoleChangeRequest request) {
+      UUID targetPublicId, UUID adminPublicId, RoleChangeRequest request, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findMember(targetPublicId);
@@ -136,11 +137,18 @@ public class AdminUserService {
     }
 
     member.setRole(newRole);
+    adminAuditService.log(
+        adminPublicId,
+        "ROLE_CHANGE",
+        "MEMBER",
+        targetPublicId.toString(),
+        "newRole=" + request.role(),
+        ipAddress);
     return toUserResponse(member);
   }
 
   @Transactional
-  public void banUser(UUID targetPublicId, UUID adminPublicId) {
+  public void banUser(UUID targetPublicId, UUID adminPublicId, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findMember(targetPublicId);
@@ -154,10 +162,12 @@ public class AdminUserService {
     reloaded.setBannedAt(clock.instant());
 
     log.info("사용자 차단: publicId={}", targetPublicId);
+    adminAuditService.log(
+        adminPublicId, "USER_BAN", "MEMBER", targetPublicId.toString(), null, ipAddress);
   }
 
   @Transactional
-  public void unbanUser(UUID targetPublicId, UUID adminPublicId) {
+  public void unbanUser(UUID targetPublicId, UUID adminPublicId, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findMember(targetPublicId);
@@ -165,10 +175,12 @@ public class AdminUserService {
     member.setBannedAt(null);
 
     log.info("사용자 차단 해제: publicId={}", targetPublicId);
+    adminAuditService.log(
+        adminPublicId, "USER_UNBAN", "MEMBER", targetPublicId.toString(), null, ipAddress);
   }
 
   @Transactional
-  public void forceDeleteUser(UUID targetPublicId, UUID adminPublicId) {
+  public void forceDeleteUser(UUID targetPublicId, UUID adminPublicId, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findMember(targetPublicId);
@@ -181,6 +193,8 @@ public class AdminUserService {
     memberRepository.delete(member);
 
     log.info("관리자 강제 탈퇴: publicId={}", targetPublicId);
+    adminAuditService.log(
+        adminPublicId, "USER_FORCE_DELETE", "MEMBER", targetPublicId.toString(), null, ipAddress);
   }
 
   public void cleanupRedisAfterDelete(UUID publicId) {
@@ -195,7 +209,7 @@ public class AdminUserService {
 
   @Transactional
   public AdminUserResponse forceChangeNickname(
-      UUID targetPublicId, UUID adminPublicId, ForceNicknameRequest request) {
+      UUID targetPublicId, UUID adminPublicId, ForceNicknameRequest request, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findMember(targetPublicId);
@@ -213,6 +227,14 @@ public class AdminUserService {
     } catch (DataIntegrityViolationException e) {
       throw new BusinessException(ErrorCode.NICKNAME_DUPLICATED);
     }
+
+    adminAuditService.log(
+        adminPublicId,
+        "USER_FORCE_NICKNAME",
+        "MEMBER",
+        targetPublicId.toString(),
+        "newNickname=" + member.getNickname(),
+        ipAddress);
 
     return toUserResponse(member);
   }
@@ -232,11 +254,18 @@ public class AdminUserService {
   }
 
   @Transactional
-  public void forceDeleteProfileImage(UUID targetPublicId, UUID adminPublicId) {
+  public void forceDeleteProfileImage(UUID targetPublicId, UUID adminPublicId, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findMember(targetPublicId);
     member.setProfileUrl(null);
+    adminAuditService.log(
+        adminPublicId,
+        "USER_FORCE_PROFILE_DELETE",
+        "MEMBER",
+        targetPublicId.toString(),
+        null,
+        ipAddress);
   }
 
   public void cleanupProfileImageAndRedis(UUID publicId) {

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/CsvUploadService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/CsvUploadService.java
@@ -29,9 +29,10 @@ public class CsvUploadService {
   private final DailySentenceRepository dailySentenceRepository;
   private final SentenceUploadRepository sentenceUploadRepository;
   private final MemberRepository memberRepository;
+  private final AdminAuditService adminAuditService;
   private final TransactionTemplate transactionTemplate;
 
-  public CsvUploadResponse uploadCsv(MultipartFile file, UUID adminPublicId) {
+  public CsvUploadResponse uploadCsv(MultipartFile file, UUID adminPublicId, String ipAddress) {
     Member admin =
         memberRepository
             .findByPublicId(adminPublicId)
@@ -70,6 +71,14 @@ public class CsvUploadService {
               lines.size(),
               successCount,
               duplicateCount);
+
+          adminAuditService.log(
+              admin,
+              "CSV_UPLOAD",
+              "SENTENCE",
+              null,
+              "success=" + successCount + ", duplicate=" + duplicateCount,
+              ipAddress);
 
           return new CsvUploadResponse(lines.size(), successCount, duplicateCount);
         });

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditAtomicityTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditAtomicityTest.java
@@ -1,0 +1,89 @@
+package com.gakkaweo.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+
+import com.gakkaweo.backend.admin.dto.RoleChangeRequest;
+import com.gakkaweo.backend.admin.dto.SentenceCreateRequest;
+import com.gakkaweo.backend.admin.service.AdminAuditService;
+import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.entity.MemberRole;
+import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@DisplayName("Admin 감사 로그 원자성 회귀 가드")
+class AdminAuditAtomicityTest extends IntegrationTestBase {
+
+  @MockitoSpyBean AdminAuditService adminAuditService;
+  @Autowired DailySentenceRepository dailySentenceRepository;
+  @Autowired MemberRepository memberRepository;
+  @Autowired AuditLogRepository auditLogRepository;
+
+  @Test
+  @DisplayName("문장 등록 중 audit 실패 시 DailySentence 쓰기가 롤백된다")
+  void 문장등록_audit실패_롤백() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+
+    doThrow(new RuntimeException("audit failure"))
+        .when(adminAuditService)
+        .log(any(UUID.class), eq("SENTENCE_CREATE"), anyString(), anyString(), anyString(), any());
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/sentences"),
+            HttpMethod.POST,
+            new HttpEntity<>(new SentenceCreateRequest("원자성 테스트 문장"), headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(dailySentenceRepository.existsBySentence("원자성 테스트 문장")).isFalse();
+    assertThat(auditLogRepository.count()).isZero();
+  }
+
+  @Test
+  @DisplayName("역할 변경 중 audit 실패 시 Member.role 변경이 롤백된다")
+  void 역할변경_audit실패_롤백() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = authedJson(admin);
+
+    doThrow(new RuntimeException("audit failure"))
+        .when(adminAuditService)
+        .log(any(UUID.class), eq("ROLE_CHANGE"), anyString(), anyString(), anyString(), any());
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/role"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new RoleChangeRequest("ADMIN"), headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    Member reloaded = memberRepository.findByPublicId(target.getPublicId()).orElseThrow();
+    assertThat(reloaded.getRole()).isEqualTo(MemberRole.USER);
+    assertThat(auditLogRepository.count()).isZero();
+  }
+
+  private HttpHeaders authedJson(Member admin) {
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditAtomicityTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditAtomicityTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.doThrow;
 import com.gakkaweo.backend.admin.dto.RoleChangeRequest;
 import com.gakkaweo.backend.admin.dto.SentenceCreateRequest;
 import com.gakkaweo.backend.admin.service.AdminAuditService;
+import com.gakkaweo.backend.domain.admin.entity.AuditLog;
 import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
@@ -54,7 +55,7 @@ class AdminAuditAtomicityTest extends IntegrationTestBase {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     assertThat(dailySentenceRepository.existsBySentence("원자성 테스트 문장")).isFalse();
-    assertThat(auditLogRepository.count()).isZero();
+    assertThat(auditRowsByAction("SENTENCE_CREATE")).isZero();
   }
 
   @Test
@@ -78,7 +79,14 @@ class AdminAuditAtomicityTest extends IntegrationTestBase {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     Member reloaded = memberRepository.findByPublicId(target.getPublicId()).orElseThrow();
     assertThat(reloaded.getRole()).isEqualTo(MemberRole.USER);
-    assertThat(auditLogRepository.count()).isZero();
+    assertThat(auditRowsByAction("ROLE_CHANGE")).isZero();
+  }
+
+  private long auditRowsByAction(String action) {
+    return auditLogRepository.findAll().stream()
+        .map(AuditLog::getAction)
+        .filter(action::equals)
+        .count();
   }
 
   private HttpHeaders authedJson(Member admin) {


### PR DESCRIPTION
## 관련 이슈

Closes #148

## 변경 사항

- `AdminSentenceService` / `CsvUploadService` / `AdminUserService` / `AdminSystemService`의 18개 쓰기 메서드 시그니처에 `adminPublicId` · `ipAddress`를 개별 파라미터로 추가하고 `adminAuditService.log(...)` 호출을 `@Transactional` 안으로 이동
- `AdminSentenceService.emergencyReplace`와 `CsvUploadService.uploadCsv`, `AdminSystemService.createAnnouncement` / `updateAnnouncement` / `deleteAnnouncement`는 `transactionTemplate.execute` 람다 내부에서 audit을 호출. 비즈니스 DB 쓰기와 audit 쓰기가 동일 TX로 커밋됨
- `AdminSystemService.deleteAnnouncement`는 `executeWithoutResult` → `execute`로 재구성해 `find` · `delete` · `audit`을 한 람다 안에 통합하고, 후속 `AnnouncementEvent` 발행에 필요한 `title` / `type`은 람다 안에서 이벤트를 구성해 반환
- `CsvUploadService`는 람다 바깥에서 이미 admin `Member`를 조회하므로 `log(Member, ...)` 오버로드를 호출해 중복 쿼리 회피
- `AdminUserController` / `AdminSystemController`의 클래스 레벨 `@Transactional` 제거. 이로써 `forceDeleteUser` / `forceChangeNickname` / `forceDeleteProfileImage`의 Redis · 파일 후처리가 자동으로 트랜잭션 경계 밖으로 분리됨 (TX 내 외부 I/O 분리 원칙 회복)
- 세 컨트롤러에서 `AdminAuditService` 의존성과 18건의 audit 호출 제거
- `AdminSentenceService.createSentence` / `updateSentence`의 audit detail에 정규화된 `sentence` / `newSentence`를 전달해 DB 저장값과 일치
- `AdminAuditAtomicityTest` 추가 — `@MockitoSpyBean`으로 `AdminAuditService.log`에 예외 주입 시 비즈니스 DB 쓰기 롤백 검증 (audit 검증은 action 필터링 헬퍼로 강건화)

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (`./gradlew :backend:test` 통과 — 294건 / 0실패)
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다 (HTTP 레이어 시그니처 불변, AdminAuditRecordingTest · Admin*IntegrationTest · AuditLogNotification*Test 통과)

## 알려진 한계 / 후속 과제

- **`AuditLog.action` · `targetType` enum화** — 자유 문자열 리터럴을 enum + `@Enumerated(STRING)`로 응집. 호출부 18곳 + 엔티티 + JPQL 영향이라 별도 PR로 분리
- **`AnnouncementEvent` 발행 조건 통일** — `deleteAnnouncement`는 active/time-window와 무관하게 무조건 SSE 이벤트 발행, `create` / `update`는 active한 경우에만 발행. 본 PR 이전부터의 비대칭 동작이며 클라이언트 SSE 처리 정책과 함께 별도 검토
- **클라이언트 IP 해석** — 백엔드 추가 작업 불요. `nginx/api.conf`의 `real_ip_header CF-Connecting-IP` + `cloudflare-ips.conf`의 CF CIDR 등록으로 nginx가 `\$remote_addr`을 진짜 클라이언트 IP로 정정 후 Tomcat에 전달. Spring에서 X-Forwarded-For를 다시 파싱하면 이중 처리 또는 client-controlled XFF 신뢰로 보안 후퇴 위험