### PR TITLE
refactor: 어드민 감사 로그 action/targetType enum화

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/AuditLogResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/AuditLogResponse.java
@@ -1,6 +1,8 @@
 package com.gakkaweo.backend.admin.dto;
 
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.entity.AuditLog;
+import com.gakkaweo.backend.domain.admin.entity.AuditTargetType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 
@@ -8,8 +10,8 @@ import java.time.Instant;
 public record AuditLogResponse(
     @Schema(description = "로그 ID", example = "1") Long id,
     @Schema(description = "관리자 닉네임", example = "관리자") String adminNickname,
-    @Schema(description = "수행 액션", example = "FORCE_NICKNAME") String action,
-    @Schema(description = "대상 유형", example = "MEMBER") String targetType,
+    @Schema(description = "수행 액션", example = "USER_FORCE_NICKNAME") AuditAction action,
+    @Schema(description = "대상 유형", example = "MEMBER") AuditTargetType targetType,
     @Schema(
             description = "대상 ID",
             nullable = true,

--- a/backend/src/main/java/com/gakkaweo/backend/admin/event/AuditLogEvent.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/event/AuditLogEvent.java
@@ -1,10 +1,12 @@
 package com.gakkaweo.backend.admin.event;
 
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
+import com.gakkaweo.backend.domain.admin.entity.AuditTargetType;
 import java.time.Instant;
 
 public record AuditLogEvent(
-    String action,
-    String targetType,
+    AuditAction action,
+    AuditTargetType targetType,
     String targetId,
     String adminNickname,
     String detail,

--- a/backend/src/main/java/com/gakkaweo/backend/admin/event/AuditLogNotificationListener.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/event/AuditLogNotificationListener.java
@@ -31,7 +31,7 @@ public class AuditLogNotificationListener {
 
   private DiscordEmbed buildEmbed(AuditLogEvent event) {
     List<DiscordEmbed.Field> fields = new ArrayList<>();
-    fields.add(new DiscordEmbed.Field("Action", event.action(), true));
+    fields.add(new DiscordEmbed.Field("Action", event.action().name(), true));
     fields.add(new DiscordEmbed.Field("Admin", safe(event.adminNickname()), true));
     fields.add(new DiscordEmbed.Field("Target", formatTarget(event), true));
     fields.add(new DiscordEmbed.Field("IP", safe(event.ipAddress()), true));
@@ -42,7 +42,7 @@ public class AuditLogNotificationListener {
   }
 
   private String formatTarget(AuditLogEvent event) {
-    String targetType = safe(event.targetType());
+    String targetType = event.targetType().name();
     String targetId = event.targetId();
     if (targetId == null || targetId.isBlank()) {
       return targetType;

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminAuditService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminAuditService.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.admin.service;
 import com.gakkaweo.backend.admin.event.AuditLogEvent;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.entity.AuditLog;
 import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
@@ -27,37 +28,34 @@ public class AdminAuditService {
 
   @Transactional
   public void log(
-      Member admin,
-      String action,
-      String targetType,
-      String targetId,
-      String detail,
-      String ipAddress) {
-    AuditLog auditLog = new AuditLog(admin, action, targetType, targetId, detail, ipAddress);
+      Member admin, AuditAction action, String targetId, String detail, String ipAddress) {
+    AuditLog auditLog =
+        new AuditLog(admin, action, action.targetType(), targetId, detail, ipAddress);
     auditLogRepository.save(auditLog);
     log.info(
         "감사 로그: admin={}, action={}, targetType={}, targetId={}",
         admin.getNickname(),
         action,
-        targetType,
+        action.targetType(),
         targetId);
     eventPublisher.publishEvent(
         new AuditLogEvent(
-            action, targetType, targetId, admin.getNickname(), detail, ipAddress, clock.instant()));
+            action,
+            action.targetType(),
+            targetId,
+            admin.getNickname(),
+            detail,
+            ipAddress,
+            clock.instant()));
   }
 
   @Transactional
   public void log(
-      UUID adminPublicId,
-      String action,
-      String targetType,
-      String targetId,
-      String detail,
-      String ipAddress) {
+      UUID adminPublicId, AuditAction action, String targetId, String detail, String ipAddress) {
     Member admin =
         memberRepository
             .findByPublicId(adminPublicId)
             .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-    log(admin, action, targetType, targetId, detail, ipAddress);
+    log(admin, action, targetId, detail, ipAddress);
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -14,6 +14,7 @@ import com.gakkaweo.backend.admin.dto.SimilarityTestResponse;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.common.redis.RedisKeyConstants;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
@@ -95,8 +96,7 @@ public class AdminSentenceService {
     log.info("문장 등록: publicId={}", entity.getPublicId());
     adminAuditService.log(
         adminPublicId,
-        "SENTENCE_CREATE",
-        "SENTENCE",
+        AuditAction.SENTENCE_CREATE,
         entity.getPublicId().toString(),
         sentence,
         ipAddress);
@@ -126,7 +126,7 @@ public class AdminSentenceService {
 
     entity.setSentence(newSentence);
     adminAuditService.log(
-        adminPublicId, "SENTENCE_UPDATE", "SENTENCE", publicId.toString(), newSentence, ipAddress);
+        adminPublicId, AuditAction.SENTENCE_UPDATE, publicId.toString(), newSentence, ipAddress);
     return SentenceResponse.from(entity);
   }
 
@@ -141,7 +141,7 @@ public class AdminSentenceService {
     dailySentenceRepository.delete(entity);
     log.info("문장 삭제: publicId={}", publicId);
     adminAuditService.log(
-        adminPublicId, "SENTENCE_DELETE", "SENTENCE", publicId.toString(), null, ipAddress);
+        adminPublicId, AuditAction.SENTENCE_DELETE, publicId.toString(), null, ipAddress);
   }
 
   @Transactional(readOnly = true)
@@ -184,8 +184,7 @@ public class AdminSentenceService {
     entity.setScheduledAt(request.date());
     adminAuditService.log(
         adminPublicId,
-        "SENTENCE_SCHEDULE",
-        "SENTENCE",
+        AuditAction.SENTENCE_SCHEDULE,
         publicId.toString(),
         "date=" + request.date(),
         ipAddress);
@@ -197,7 +196,7 @@ public class AdminSentenceService {
     DailySentence entity = findByPublicIdOrThrow(publicId);
     entity.setScheduledAt(null);
     adminAuditService.log(
-        adminPublicId, "SENTENCE_UNSCHEDULE", "SENTENCE", publicId.toString(), null, ipAddress);
+        adminPublicId, AuditAction.SENTENCE_UNSCHEDULE, publicId.toString(), null, ipAddress);
     return SentenceResponse.from(entity);
   }
 
@@ -275,8 +274,7 @@ public class AdminSentenceService {
 
               adminAuditService.log(
                   adminPublicId,
-                  "EMERGENCY_REPLACE",
-                  "SENTENCE",
+                  AuditAction.EMERGENCY_REPLACE,
                   newSentence.getPublicId().toString(),
                   "newSentence="
                       + request.newSentencePublicId()

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -12,6 +12,7 @@ import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.admin.entity.Announcement;
 import com.gakkaweo.backend.domain.admin.entity.AnnouncementType;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.entity.AuditLog;
 import com.gakkaweo.backend.domain.admin.repository.AnnouncementRepository;
 import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
@@ -66,13 +67,23 @@ public class AdminSystemService {
 
   private static Specification<AuditLog> auditLogFilters(
       String action, Instant dateFrom, Instant dateTo) {
+    final AuditAction actionEnum;
+    if (action != null && !action.isBlank()) {
+      try {
+        actionEnum = AuditAction.valueOf(action);
+      } catch (IllegalArgumentException e) {
+        throw new BusinessException(ErrorCode.VALIDATION_FAILED);
+      }
+    } else {
+      actionEnum = null;
+    }
     return (root, query, cb) -> {
       if (Long.class != query.getResultType()) {
         root.fetch("admin", JoinType.LEFT);
       }
       List<Predicate> predicates = new ArrayList<>();
-      if (action != null && !action.isBlank()) {
-        predicates.add(cb.equal(root.get("action"), action));
+      if (actionEnum != null) {
+        predicates.add(cb.equal(root.get("action"), actionEnum));
       }
       if (dateFrom != null) {
         predicates.add(cb.greaterThanOrEqualTo(root.get("createdAt"), dateFrom));
@@ -111,8 +122,7 @@ public class AdminSystemService {
               announcementRepository.save(announcement);
               adminAuditService.log(
                   admin,
-                  "ANNOUNCEMENT_CREATE",
-                  "ANNOUNCEMENT",
+                  AuditAction.ANNOUNCEMENT_CREATE,
                   announcement.getId().toString(),
                   request.title(),
                   ipAddress);
@@ -159,12 +169,7 @@ public class AdminSystemService {
               validateAnnouncementDates(announcement.getStartsAt(), announcement.getEndsAt());
               announcementRepository.save(announcement);
               adminAuditService.log(
-                  adminPublicId,
-                  "ANNOUNCEMENT_UPDATE",
-                  "ANNOUNCEMENT",
-                  id.toString(),
-                  null,
-                  ipAddress);
+                  adminPublicId, AuditAction.ANNOUNCEMENT_UPDATE, id.toString(), null, ipAddress);
               return AnnouncementResponse.from(announcement);
             });
 
@@ -190,12 +195,7 @@ public class AdminSystemService {
                   new AnnouncementEvent(id, announcement.getTitle(), null, announcement.getType());
               announcementRepository.delete(announcement);
               adminAuditService.log(
-                  adminPublicId,
-                  "ANNOUNCEMENT_DELETE",
-                  "ANNOUNCEMENT",
-                  id.toString(),
-                  null,
-                  ipAddress);
+                  adminPublicId, AuditAction.ANNOUNCEMENT_DELETE, id.toString(), null, ipAddress);
               return ev;
             });
     eventPublisher.publishEvent(event);
@@ -247,13 +247,13 @@ public class AdminSystemService {
     int rebuilt = rankingService.rebuildRankingCache(today);
     eventPublisher.publishEvent(new RankingUpdateEvent());
     log.info("랭킹 캐시 리셋 및 재구축: date={}, rebuilt={}", today, rebuilt);
-    adminAuditService.log(adminPublicId, "RANKING_CACHE_RESET", "SYSTEM", null, null, ipAddress);
+    adminAuditService.log(adminPublicId, AuditAction.RANKING_CACHE_RESET, null, null, ipAddress);
   }
 
   public void resetRateLimit(UUID adminPublicId, String ipAddress) {
     bucketStore.clearAllBuckets();
     log.info("Rate limit 버킷 전체 초기화");
-    adminAuditService.log(adminPublicId, "RATE_LIMIT_RESET", "SYSTEM", null, null, ipAddress);
+    adminAuditService.log(adminPublicId, AuditAction.RATE_LIMIT_RESET, null, null, ipAddress);
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -12,6 +12,7 @@ import com.gakkaweo.backend.auth.service.ProfileImageService;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.common.redis.RedisKeyConstants;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.repository.SentenceUploadRepository;
 import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
 import com.gakkaweo.backend.domain.game.entity.GameSession;
@@ -139,8 +140,7 @@ public class AdminUserService {
     member.setRole(newRole);
     adminAuditService.log(
         adminPublicId,
-        "ROLE_CHANGE",
-        "MEMBER",
+        AuditAction.ROLE_CHANGE,
         targetPublicId.toString(),
         "newRole=" + request.role(),
         ipAddress);
@@ -163,7 +163,7 @@ public class AdminUserService {
 
     log.info("사용자 차단: publicId={}", targetPublicId);
     adminAuditService.log(
-        adminPublicId, "USER_BAN", "MEMBER", targetPublicId.toString(), null, ipAddress);
+        adminPublicId, AuditAction.USER_BAN, targetPublicId.toString(), null, ipAddress);
   }
 
   @Transactional
@@ -176,7 +176,7 @@ public class AdminUserService {
 
     log.info("사용자 차단 해제: publicId={}", targetPublicId);
     adminAuditService.log(
-        adminPublicId, "USER_UNBAN", "MEMBER", targetPublicId.toString(), null, ipAddress);
+        adminPublicId, AuditAction.USER_UNBAN, targetPublicId.toString(), null, ipAddress);
   }
 
   @Transactional
@@ -194,7 +194,7 @@ public class AdminUserService {
 
     log.info("관리자 강제 탈퇴: publicId={}", targetPublicId);
     adminAuditService.log(
-        adminPublicId, "USER_FORCE_DELETE", "MEMBER", targetPublicId.toString(), null, ipAddress);
+        adminPublicId, AuditAction.USER_FORCE_DELETE, targetPublicId.toString(), null, ipAddress);
   }
 
   public void cleanupRedisAfterDelete(UUID publicId) {
@@ -230,8 +230,7 @@ public class AdminUserService {
 
     adminAuditService.log(
         adminPublicId,
-        "USER_FORCE_NICKNAME",
-        "MEMBER",
+        AuditAction.USER_FORCE_NICKNAME,
         targetPublicId.toString(),
         "newNickname=" + member.getNickname(),
         ipAddress);
@@ -261,8 +260,7 @@ public class AdminUserService {
     member.setProfileUrl(null);
     adminAuditService.log(
         adminPublicId,
-        "USER_FORCE_PROFILE_DELETE",
-        "MEMBER",
+        AuditAction.USER_FORCE_PROFILE_DELETE,
         targetPublicId.toString(),
         null,
         ipAddress);

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/CsvUploadService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/CsvUploadService.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.admin.service;
 import com.gakkaweo.backend.admin.dto.CsvUploadResponse;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.entity.SentenceUpload;
 import com.gakkaweo.backend.domain.admin.repository.SentenceUploadRepository;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
@@ -74,8 +75,7 @@ public class CsvUploadService {
 
           adminAuditService.log(
               admin,
-              "CSV_UPLOAD",
-              "SENTENCE",
+              AuditAction.CSV_UPLOAD,
               null,
               "success=" + successCount + ", duplicate=" + duplicateCount,
               ipAddress);

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditAction.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditAction.java
@@ -1,0 +1,35 @@
+package com.gakkaweo.backend.domain.admin.entity;
+
+public enum AuditAction {
+  SENTENCE_CREATE(AuditTargetType.SENTENCE),
+  SENTENCE_UPDATE(AuditTargetType.SENTENCE),
+  SENTENCE_DELETE(AuditTargetType.SENTENCE),
+  SENTENCE_SCHEDULE(AuditTargetType.SENTENCE),
+  SENTENCE_UNSCHEDULE(AuditTargetType.SENTENCE),
+  EMERGENCY_REPLACE(AuditTargetType.SENTENCE),
+  CSV_UPLOAD(AuditTargetType.SENTENCE),
+
+  ROLE_CHANGE(AuditTargetType.MEMBER),
+  USER_BAN(AuditTargetType.MEMBER),
+  USER_UNBAN(AuditTargetType.MEMBER),
+  USER_FORCE_DELETE(AuditTargetType.MEMBER),
+  USER_FORCE_NICKNAME(AuditTargetType.MEMBER),
+  USER_FORCE_PROFILE_DELETE(AuditTargetType.MEMBER),
+
+  ANNOUNCEMENT_CREATE(AuditTargetType.ANNOUNCEMENT),
+  ANNOUNCEMENT_UPDATE(AuditTargetType.ANNOUNCEMENT),
+  ANNOUNCEMENT_DELETE(AuditTargetType.ANNOUNCEMENT),
+
+  RANKING_CACHE_RESET(AuditTargetType.SYSTEM),
+  RATE_LIMIT_RESET(AuditTargetType.SYSTEM);
+
+  private final AuditTargetType targetType;
+
+  AuditAction(AuditTargetType targetType) {
+    this.targetType = targetType;
+  }
+
+  public AuditTargetType targetType() {
+    return targetType;
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditLog.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditLog.java
@@ -1,11 +1,13 @@
 package com.gakkaweo.backend.domain.admin.entity;
 
+import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import com.gakkaweo.backend.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -31,11 +33,13 @@ public class AuditLog {
   @JoinColumn(name = "admin_id")
   private Member admin;
 
+  @Enumerated(STRING)
   @Column(nullable = false, length = 100)
-  private String action;
+  private AuditAction action;
 
+  @Enumerated(STRING)
   @Column(nullable = false, length = 50)
-  private String targetType;
+  private AuditTargetType targetType;
 
   @Column(length = 255)
   private String targetId;
@@ -50,8 +54,8 @@ public class AuditLog {
 
   public AuditLog(
       Member admin,
-      String action,
-      String targetType,
+      AuditAction action,
+      AuditTargetType targetType,
       String targetId,
       String detail,
       String ipAddress) {

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditTargetType.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditTargetType.java
@@ -1,0 +1,8 @@
+package com.gakkaweo.backend.domain.admin.entity;
+
+public enum AuditTargetType {
+  MEMBER,
+  SENTENCE,
+  ANNOUNCEMENT,
+  SYSTEM
+}

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditAtomicityTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditAtomicityTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.doThrow;
 import com.gakkaweo.backend.admin.dto.RoleChangeRequest;
 import com.gakkaweo.backend.admin.dto.SentenceCreateRequest;
 import com.gakkaweo.backend.admin.service.AdminAuditService;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.entity.AuditLog;
 import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
@@ -44,7 +45,12 @@ class AdminAuditAtomicityTest extends IntegrationTestBase {
 
     doThrow(new RuntimeException("audit failure"))
         .when(adminAuditService)
-        .log(any(UUID.class), eq("SENTENCE_CREATE"), anyString(), anyString(), anyString(), any());
+        .log(
+            any(UUID.class),
+            eq(AuditAction.SENTENCE_CREATE),
+            anyString(),
+            anyString(),
+            anyString());
 
     ResponseEntity<Void> response =
         restTemplate.exchange(
@@ -55,7 +61,7 @@ class AdminAuditAtomicityTest extends IntegrationTestBase {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     assertThat(dailySentenceRepository.existsBySentence("원자성 테스트 문장")).isFalse();
-    assertThat(auditRowsByAction("SENTENCE_CREATE")).isZero();
+    assertThat(auditRowsByAction(AuditAction.SENTENCE_CREATE)).isZero();
   }
 
   @Test
@@ -67,7 +73,7 @@ class AdminAuditAtomicityTest extends IntegrationTestBase {
 
     doThrow(new RuntimeException("audit failure"))
         .when(adminAuditService)
-        .log(any(UUID.class), eq("ROLE_CHANGE"), anyString(), anyString(), anyString(), any());
+        .log(any(UUID.class), eq(AuditAction.ROLE_CHANGE), anyString(), anyString(), anyString());
 
     ResponseEntity<Void> response =
         restTemplate.exchange(
@@ -79,10 +85,10 @@ class AdminAuditAtomicityTest extends IntegrationTestBase {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     Member reloaded = memberRepository.findByPublicId(target.getPublicId()).orElseThrow();
     assertThat(reloaded.getRole()).isEqualTo(MemberRole.USER);
-    assertThat(auditRowsByAction("ROLE_CHANGE")).isZero();
+    assertThat(auditRowsByAction(AuditAction.ROLE_CHANGE)).isZero();
   }
 
-  private long auditRowsByAction(String action) {
+  private long auditRowsByAction(AuditAction action) {
     return auditLogRepository.findAll().stream()
         .map(AuditLog::getAction)
         .filter(action::equals)

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditRecordingTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditRecordingTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gakkaweo.backend.admin.dto.RoleChangeRequest;
 import com.gakkaweo.backend.admin.dto.SentenceCreateRequest;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.entity.AuditLog;
+import com.gakkaweo.backend.domain.admin.entity.AuditTargetType;
 import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.support.IntegrationTestBase;
@@ -35,8 +37,8 @@ class AdminAuditRecordingTest extends IntegrationTestBase {
         new HttpEntity<>(new RoleChangeRequest("ADMIN"), headers),
         Void.class);
 
-    AuditLog logged = assertSingleLog("ROLE_CHANGE");
-    assertThat(logged.getTargetType()).isEqualTo("MEMBER");
+    AuditLog logged = assertSingleLog(AuditAction.ROLE_CHANGE);
+    assertThat(logged.getTargetType()).isEqualTo(AuditTargetType.MEMBER);
     assertThat(logged.getTargetId()).isEqualTo(target.getPublicId().toString());
     assertThat(logged.getDetail()).contains("ADMIN");
   }
@@ -54,7 +56,7 @@ class AdminAuditRecordingTest extends IntegrationTestBase {
         new HttpEntity<>(headers),
         Void.class);
 
-    AuditLog logged = assertSingleLog("USER_BAN");
+    AuditLog logged = assertSingleLog(AuditAction.USER_BAN);
     assertThat(logged.getTargetId()).isEqualTo(target.getPublicId().toString());
   }
 
@@ -70,8 +72,8 @@ class AdminAuditRecordingTest extends IntegrationTestBase {
         new HttpEntity<>(new SentenceCreateRequest("테스트 문장"), headers),
         Void.class);
 
-    AuditLog logged = assertSingleLog("SENTENCE_CREATE");
-    assertThat(logged.getTargetType()).isEqualTo("SENTENCE");
+    AuditLog logged = assertSingleLog(AuditAction.SENTENCE_CREATE);
+    assertThat(logged.getTargetType()).isEqualTo(AuditTargetType.SENTENCE);
     assertThat(logged.getDetail()).isEqualTo("테스트 문장");
   }
 
@@ -88,13 +90,13 @@ class AdminAuditRecordingTest extends IntegrationTestBase {
         new HttpEntity<>(headers),
         Void.class);
 
-    AuditLog logged = assertSingleLog("RANKING_CACHE_RESET");
-    assertThat(logged.getTargetType()).isEqualTo("SYSTEM");
+    AuditLog logged = assertSingleLog(AuditAction.RANKING_CACHE_RESET);
+    assertThat(logged.getTargetType()).isEqualTo(AuditTargetType.SYSTEM);
   }
 
-  private AuditLog assertSingleLog(String action) {
+  private AuditLog assertSingleLog(AuditAction action) {
     List<AuditLog> logs =
-        auditLogRepository.findAll().stream().filter(l -> action.equals(l.getAction())).toList();
+        auditLogRepository.findAll().stream().filter(l -> action == l.getAction()).toList();
     assertThat(logs).hasSize(1);
     return logs.get(0);
   }

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditServiceTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditServiceTest.java
@@ -6,7 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.gakkaweo.backend.admin.service.AdminAuditService;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.entity.AuditLog;
+import com.gakkaweo.backend.domain.admin.entity.AuditTargetType;
 import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.support.IntegrationTestBase;
@@ -26,11 +28,11 @@ class AdminAuditServiceTest extends IntegrationTestBase {
   void log_member_직접호출() {
     Member admin = testAuthHelper.createAdmin();
 
-    adminAuditService.log(admin, "TEST_ACTION", "TARGET", "t-1", "detail", "127.0.0.1");
+    adminAuditService.log(admin, AuditAction.SENTENCE_CREATE, "t-1", "detail", "127.0.0.1");
 
     AuditLog saved = auditLogRepository.findAll().get(0);
-    assertThat(saved.getAction()).isEqualTo("TEST_ACTION");
-    assertThat(saved.getTargetType()).isEqualTo("TARGET");
+    assertThat(saved.getAction()).isEqualTo(AuditAction.SENTENCE_CREATE);
+    assertThat(saved.getTargetType()).isEqualTo(AuditTargetType.SENTENCE);
     assertThat(saved.getTargetId()).isEqualTo("t-1");
     assertThat(saved.getIpAddress()).isEqualTo("127.0.0.1");
   }
@@ -41,7 +43,7 @@ class AdminAuditServiceTest extends IntegrationTestBase {
     UUID unknown = UUID.randomUUID();
 
     assertThatThrownBy(
-            () -> adminAuditService.log(unknown, "ACTION", "TARGET", "t-1", null, "127.0.0.1"))
+            () -> adminAuditService.log(unknown, AuditAction.ROLE_CHANGE, "t-1", null, "127.0.0.1"))
         .isInstanceOf(BusinessException.class)
         .extracting("errorCode")
         .isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
@@ -52,10 +54,11 @@ class AdminAuditServiceTest extends IntegrationTestBase {
   void log_publicId_유효() {
     Member admin = testAuthHelper.createAdmin();
 
-    adminAuditService.log(admin.getPublicId(), "VALID_ACTION", "TARGET", "t-1", null, "127.0.0.1");
+    adminAuditService.log(
+        admin.getPublicId(), AuditAction.RANKING_CACHE_RESET, "t-1", null, "127.0.0.1");
 
     assertThat(auditLogRepository.findAll())
         .extracting(AuditLog::getAction)
-        .contains("VALID_ACTION");
+        .contains(AuditAction.RANKING_CACHE_RESET);
   }
 }

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSystemIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSystemIntegrationTest.java
@@ -8,6 +8,7 @@ import com.gakkaweo.backend.admin.dto.AuditLogListResponse;
 import com.gakkaweo.backend.admin.dto.SystemStatusResponse;
 import com.gakkaweo.backend.admin.event.AnnouncementEvent;
 import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.entity.AuditLog;
 import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
@@ -358,20 +359,20 @@ class AdminSystemIntegrationTest extends IntegrationTestBase {
   @DisplayName("감사 로그 조회 - action 필터 일치 항목만 반환")
   void 감사로그_action_필터() {
     Member admin = testAuthHelper.createAdmin();
-    seedAuditLog(admin, "ACTION_A", clock.instant());
-    seedAuditLog(admin, "ACTION_B", clock.instant());
+    seedAuditLog(admin, AuditAction.SENTENCE_CREATE, clock.instant());
+    seedAuditLog(admin, AuditAction.ROLE_CHANGE, clock.instant());
     HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
 
     ResponseEntity<AuditLogListResponse> response =
         restTemplate.exchange(
-            url("/admin/system/audit-logs?action=ACTION_A"),
+            url("/admin/system/audit-logs?action=SENTENCE_CREATE"),
             HttpMethod.GET,
             new HttpEntity<>(headers),
             AuditLogListResponse.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody().content())
-        .allSatisfy(entry -> assertThat(entry.action()).isEqualTo("ACTION_A"));
+        .allSatisfy(entry -> assertThat(entry.action()).isEqualTo(AuditAction.SENTENCE_CREATE));
     assertThat(response.getBody().totalElements()).isEqualTo(1L);
   }
 
@@ -379,20 +380,37 @@ class AdminSystemIntegrationTest extends IntegrationTestBase {
   @DisplayName("감사 로그 조회 - dateFrom/dateTo 필터")
   void 감사로그_날짜_필터() {
     Member admin = testAuthHelper.createAdmin();
-    seedAuditLog(admin, "ANY", clock.instant());
+    seedAuditLog(admin, AuditAction.USER_BAN, clock.instant());
     HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
     Instant from = Instant.now().minus(Duration.ofMinutes(5));
     Instant to = Instant.now().plus(Duration.ofMinutes(5));
 
     ResponseEntity<AuditLogListResponse> response =
         restTemplate.exchange(
-            url("/admin/system/audit-logs?dateFrom=" + from + "&dateTo=" + to + "&action=ANY"),
+            url("/admin/system/audit-logs?dateFrom=" + from + "&dateTo=" + to + "&action=USER_BAN"),
             HttpMethod.GET,
             new HttpEntity<>(headers),
             AuditLogListResponse.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody().totalElements()).isGreaterThanOrEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("감사 로그 조회 - 알 수 없는 action 값은 400 VALIDATION_FAILED")
+  void 감사로그_action_잘못된값() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/system/audit-logs?action=BOGUS"),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
   }
 
   private AnnouncementResponse createAnnouncement(String title, String type) {
@@ -445,10 +463,11 @@ class AdminSystemIntegrationTest extends IntegrationTestBase {
         .getBody();
   }
 
-  private void seedAuditLog(Member admin, String action, Instant ignored) {
+  private void seedAuditLog(Member admin, AuditAction action, Instant ignored) {
     transactionTemplate.executeWithoutResult(
         status ->
-            auditLogRepository.save(new AuditLog(admin, action, "TEST", null, null, "127.0.0.1")));
+            auditLogRepository.save(
+                new AuditLog(admin, action, action.targetType(), null, null, "127.0.0.1")));
   }
 
   private HttpHeaders authedJson(Member admin) {

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AuditLogNotificationListenerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AuditLogNotificationListenerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import com.gakkaweo.backend.admin.event.AuditLogEvent;
 import com.gakkaweo.backend.admin.event.AuditLogNotificationListener;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.infra.notification.NotificationLevel;
 import com.gakkaweo.backend.infra.notification.client.DiscordWebhookClient;
 import com.gakkaweo.backend.infra.notification.config.NotificationProperties;
@@ -28,9 +29,9 @@ class AuditLogNotificationListenerTest {
         new NotificationProperties.ErrorAlert(true, Duration.ofMinutes(5)));
   }
 
-  private AuditLogEvent event(String action, String detail) {
+  private AuditLogEvent event(AuditAction action, String detail) {
     return new AuditLogEvent(
-        action, "MEMBER", "user-1", "admin-nick", detail, "127.0.0.1", Instant.now());
+        action, action.targetType(), "user-1", "admin-nick", detail, "127.0.0.1", Instant.now());
   }
 
   @Test
@@ -41,7 +42,13 @@ class AuditLogNotificationListenerTest {
     Instant createdAt = Instant.parse("2026-04-22T03:04:05Z");
     AuditLogEvent ev =
         new AuditLogEvent(
-            "USER_BAN", "MEMBER", "user-1", "admin-nick", "계정 정지 사유", "127.0.0.1", createdAt);
+            AuditAction.USER_BAN,
+            AuditAction.USER_BAN.targetType(),
+            "user-1",
+            "admin-nick",
+            "계정 정지 사유",
+            "127.0.0.1",
+            createdAt);
 
     listener.onAuditLog(ev);
 
@@ -62,7 +69,7 @@ class AuditLogNotificationListenerTest {
     DiscordWebhookClient client = mock(DiscordWebhookClient.class);
     AuditLogNotificationListener listener = new AuditLogNotificationListener(client, props(true));
 
-    listener.onAuditLog(event("SENTENCE_CREATE", "문장 등록"));
+    listener.onAuditLog(event(AuditAction.SENTENCE_CREATE, "문장 등록"));
 
     verify(client).send(eq(NotificationLevel.HIGH), any(DiscordEmbed.class));
   }
@@ -73,7 +80,7 @@ class AuditLogNotificationListenerTest {
     DiscordWebhookClient client = mock(DiscordWebhookClient.class);
     AuditLogNotificationListener listener = new AuditLogNotificationListener(client, props(false));
 
-    listener.onAuditLog(event("USER_BAN", "detail"));
+    listener.onAuditLog(event(AuditAction.USER_BAN, "detail"));
 
     verify(client, never()).send(any(), any());
   }
@@ -86,7 +93,7 @@ class AuditLogNotificationListenerTest {
 
     String longDetail = "x".repeat(500);
 
-    listener.onAuditLog(event("USER_BAN", longDetail));
+    listener.onAuditLog(event(AuditAction.USER_BAN, longDetail));
 
     ArgumentCaptor<DiscordEmbed> embedCaptor = ArgumentCaptor.forClass(DiscordEmbed.class);
     verify(client).send(eq(NotificationLevel.HIGH), embedCaptor.capture());
@@ -107,7 +114,13 @@ class AuditLogNotificationListenerTest {
     AuditLogNotificationListener listener = new AuditLogNotificationListener(client, props(true));
     AuditLogEvent ev =
         new AuditLogEvent(
-            "SYSTEM_RESET", "SYSTEM", null, "admin-nick", null, "127.0.0.1", Instant.now());
+            AuditAction.RANKING_CACHE_RESET,
+            AuditAction.RANKING_CACHE_RESET.targetType(),
+            null,
+            "admin-nick",
+            null,
+            "127.0.0.1",
+            Instant.now());
 
     listener.onAuditLog(ev);
 
@@ -129,7 +142,7 @@ class AuditLogNotificationListenerTest {
     DiscordWebhookClient client = mock(DiscordWebhookClient.class);
     AuditLogNotificationListener listener = new AuditLogNotificationListener(client, props(true));
 
-    listener.onAuditLog(event("USER_BAN", null));
+    listener.onAuditLog(event(AuditAction.USER_BAN, null));
 
     ArgumentCaptor<DiscordEmbed> embedCaptor = ArgumentCaptor.forClass(DiscordEmbed.class);
     verify(client).send(eq(NotificationLevel.HIGH), embedCaptor.capture());


### PR DESCRIPTION
## 관련 이슈

Closes #150

## 변경 사항

- `AuditAction`(18개) / `AuditTargetType`(4개) enum 도입. `AuditAction`은 `targetType()` 헬퍼로 1:1 매핑 응집
- `AuditLog` 엔티티 `@Enumerated(STRING)` 적용. 컬럼 length=100/50 유지하여 Flyway 마이그레이션 불필요
- `AdminAuditService.log` 시그니처에서 `targetType` 인자 제거(`action.targetType()`로 자동 도출). `(Member, …)` / `(UUID, …)` 두 오버로드 유지
- 어드민 18개 호출 사이트 enum 참조 전환 (`AdminSentenceService`, `CsvUploadService`, `AdminUserService`, `AdminSystemService`)
- `AuditLogEvent` record 필드 enum 전환. `AuditLogNotificationListener`는 Discord 임베드용으로 `enum.name()` 명시 변환 → 와이어 포맷 동일
- `AuditLogResponse` DTO 필드 enum 노출. Jackson 기본 STRING 직렬화로 `"action": "ROLE_CHANGE"` JSON 형태 그대로 유지 → FE 무 변경
- `auditLogFilters` 빌더에서 외부 `?action=…` 파라미터를 `AuditAction.valueOf` 변환하고 `IllegalArgumentException`을 `BusinessException(VALIDATION_FAILED)`로 매핑 → 잘못된 값은 빈 결과가 아닌 400 응답
- 테스트 5종(기록/원자성/단위/통합/알림 리스너) enum 참조로 전환. mockito `eq(AuditAction.X)`로 컴파일 타임 안전성 강화. `?action=BOGUS → 400 VALIDATION_FAILED` 회귀 가드 추가

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (테스트 295/0/0 통과, spotlessCheck PASS)
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다 (JSON 와이어 포맷 불변 → FE 무 변경, DB 컬럼 length 유지 → 마이그레이션 없음)