### PR TITLE
feat: Redis 키 라이프사이클 정리

### DIFF
--- a/.env.prod.sample
+++ b/.env.prod.sample
@@ -79,7 +79,7 @@ NOTIFICATION_DEDUP_CLEANUP_INTERVAL_MS=300000
 # Redis 키 누수 정리 스케줄러 (6h 간격, 04:30/10:30/16:30/22:30 KST)
 REDIS_CLEANUP_ENABLED=true
 REDIS_CLEANUP_SCAN_BATCH_SIZE=500
-# N일 이상 오래된 ranking/ranking_detail 키 삭제 (자정 스케줄러 영역 보호 위해 2 이상 권장)
+# N일 이상 오래된 ranking/ranking_detail 키 삭제 (자정 스케줄러 영역 보호 위해 최소 2)
 REDIS_CLEANUP_PURGE_OLDER_THAN_DAYS=2
 REDIS_CLEANUP_NOTIFY_ON_ZERO=false
 

--- a/.env.prod.sample
+++ b/.env.prod.sample
@@ -76,6 +76,13 @@ ERROR_ALERT_COOLDOWN=5m
 # 중복 억제 캐시 정리 주기(ms). 기본 5분, 통상 조정 불필요
 NOTIFICATION_DEDUP_CLEANUP_INTERVAL_MS=300000
 
+# Redis 키 누수 정리 스케줄러 (6h 간격, 04:30/10:30/16:30/22:30 KST)
+REDIS_CLEANUP_ENABLED=true
+REDIS_CLEANUP_SCAN_BATCH_SIZE=500
+# N일 이상 오래된 ranking/ranking_detail 키 삭제 (자정 스케줄러 영역 보호 위해 2 이상 권장)
+REDIS_CLEANUP_PURGE_OLDER_THAN_DAYS=2
+REDIS_CLEANUP_NOTIFY_ON_ZERO=false
+
 # OpenAPI (CI 전용, 프로덕션에서는 false 유지)
 APP_OPENAPI_DOCS_MODE=false
 

--- a/.env.sample
+++ b/.env.sample
@@ -76,6 +76,13 @@ ERROR_ALERT_COOLDOWN=5m
 # 중복 억제 캐시 정리 주기(ms). 기본 5분, 통상 조정 불필요
 NOTIFICATION_DEDUP_CLEANUP_INTERVAL_MS=300000
 
+# Redis 키 누수 정리 스케줄러 (6h 간격, 04:30/10:30/16:30/22:30 KST)
+REDIS_CLEANUP_ENABLED=true
+REDIS_CLEANUP_SCAN_BATCH_SIZE=500
+# N일 이상 오래된 ranking/ranking_detail 키 삭제 (자정 스케줄러 영역 보호 위해 2 이상 권장)
+REDIS_CLEANUP_PURGE_OLDER_THAN_DAYS=2
+REDIS_CLEANUP_NOTIFY_ON_ZERO=false
+
 # OpenAPI (CI 전용, 로컬에서는 false 유지)
 APP_OPENAPI_DOCS_MODE=false
 

--- a/.env.sample
+++ b/.env.sample
@@ -79,7 +79,7 @@ NOTIFICATION_DEDUP_CLEANUP_INTERVAL_MS=300000
 # Redis 키 누수 정리 스케줄러 (6h 간격, 04:30/10:30/16:30/22:30 KST)
 REDIS_CLEANUP_ENABLED=true
 REDIS_CLEANUP_SCAN_BATCH_SIZE=500
-# N일 이상 오래된 ranking/ranking_detail 키 삭제 (자정 스케줄러 영역 보호 위해 2 이상 권장)
+# N일 이상 오래된 ranking/ranking_detail 키 삭제 (자정 스케줄러 영역 보호 위해 최소 2)
 REDIS_CLEANUP_PURGE_OLDER_THAN_DAYS=2
 REDIS_CLEANUP_NOTIFY_ON_ZERO=false
 

--- a/backend/src/main/java/com/gakkaweo/backend/common/redis/RedisKeyConstants.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/redis/RedisKeyConstants.java
@@ -1,17 +1,26 @@
 package com.gakkaweo.backend.common.redis;
 
 import java.time.LocalDate;
+import java.util.Set;
 import java.util.UUID;
 
 public final class RedisKeyConstants {
 
-  private static final String BLACKLIST_PREFIX = "blacklist:jti:";
-  private static final String RANKING_KEY_PREFIX = "ranking:";
-  private static final String RANKING_DETAIL_PREFIX = "ranking_detail:";
+  public static final String BLACKLIST_PREFIX = "blacklist:jti:";
+  public static final String RANKING_KEY_PREFIX = "ranking:";
+  public static final String RANKING_DETAIL_PREFIX = "ranking_detail:";
+  public static final String SIMILARITY_CACHE_PREFIX = "similarity:";
+
   private static final String RANKING_MEMBER_PREFIX = "member:";
-  private static final String SIMILARITY_CACHE_PREFIX = "similarity:";
+
+  private static final Set<String> KNOWN_PREFIXES =
+      Set.of(BLACKLIST_PREFIX, RANKING_KEY_PREFIX, RANKING_DETAIL_PREFIX, SIMILARITY_CACHE_PREFIX);
 
   private RedisKeyConstants() {}
+
+  public static Set<String> knownPrefixes() {
+    return KNOWN_PREFIXES;
+  }
 
   public static String blacklistKey(String jti) {
     return BLACKLIST_PREFIX + jti;

--- a/backend/src/main/java/com/gakkaweo/backend/infra/redis/config/RedisCleanupProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/redis/config/RedisCleanupProperties.java
@@ -1,16 +1,24 @@
 package com.gakkaweo.backend.infra.redis.config;
 
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties(prefix = "app.redis.cleanup")
+@Validated
 @Getter
 @RequiredArgsConstructor
 public class RedisCleanupProperties {
 
   private final boolean enabled;
+
+  @Min(1)
   private final int scanBatchSize;
+
+  @Min(2)
   private final int purgeOlderThanDays;
+
   private final boolean notifyOnZero;
 }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/redis/config/RedisCleanupProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/redis/config/RedisCleanupProperties.java
@@ -1,0 +1,16 @@
+package com.gakkaweo.backend.infra.redis.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.redis.cleanup")
+@Getter
+@RequiredArgsConstructor
+public class RedisCleanupProperties {
+
+  private final boolean enabled;
+  private final int scanBatchSize;
+  private final int purgeOlderThanDays;
+  private final boolean notifyOnZero;
+}

--- a/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupReport.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupReport.java
@@ -1,0 +1,21 @@
+package com.gakkaweo.backend.infra.redis.scheduler;
+
+public record RedisCleanupReport(
+    int orphanCount,
+    int purgedRankingCount,
+    int purgedDetailCount,
+    boolean orphanScanFailed,
+    boolean rankingPurgeFailed) {
+
+  public int totalPurgedCount() {
+    return purgedRankingCount + purgedDetailCount;
+  }
+
+  public boolean hasAnyAction() {
+    return orphanCount > 0 || totalPurgedCount() > 0;
+  }
+
+  public boolean hasFailure() {
+    return orphanScanFailed || rankingPurgeFailed;
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupScheduler.java
@@ -10,6 +10,7 @@ import io.github.resilience4j.retry.RetryRegistry;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -102,7 +103,7 @@ public class RedisCleanupScheduler {
   }
 
   private int purgeStaleKeys(String pattern, LocalDate cutoff) {
-    int deleted = 0;
+    List<String> targets = new ArrayList<>();
     try (Cursor<String> cursor = openCursor(pattern)) {
       while (cursor.hasNext()) {
         String key = cursor.next();
@@ -112,15 +113,17 @@ public class RedisCleanupScheduler {
           continue;
         }
         if (!keyDate.isAfter(cutoff)) {
-          Boolean removed = redisTemplate.delete(key);
-          if (removed) {
-            log.info("Redis 누수 키 삭제: {}", key);
-            deleted++;
-          }
+          targets.add(key);
         }
       }
     }
-    return deleted;
+    if (targets.isEmpty()) {
+      return 0;
+    }
+    Long removed = redisTemplate.delete(targets);
+    int count = removed == null ? 0 : removed.intValue();
+    log.info("Redis 누수 키 삭제: pattern={}, count={}", pattern, count);
+    return count;
   }
 
   private Cursor<String> openCursor(String pattern) {

--- a/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupScheduler.java
@@ -1,0 +1,197 @@
+package com.gakkaweo.backend.infra.redis.scheduler;
+
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
+import com.gakkaweo.backend.infra.notification.NotificationLevel;
+import com.gakkaweo.backend.infra.notification.client.DiscordWebhookClient;
+import com.gakkaweo.backend.infra.notification.dto.DiscordEmbed;
+import com.gakkaweo.backend.infra.redis.config.RedisCleanupProperties;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RedisCleanupScheduler {
+
+  private static final int COLOR_INFO = 0x3498DB;
+  private static final int COLOR_PARTIAL = 0xFEE75C;
+
+  private final StringRedisTemplate redisTemplate;
+  private final RetryRegistry retryRegistry;
+  private final DiscordWebhookClient discordWebhookClient;
+  private final RedisCleanupProperties properties;
+  private final Clock clock;
+
+  @Scheduled(cron = "0 30 4,10,16,22 * * *", zone = "Asia/Seoul")
+  public void executeCleanup() {
+    if (!properties.isEnabled()) {
+      log.debug("Redis 정리 스케줄러 비활성화");
+      return;
+    }
+
+    log.info("Redis 정리 스케줄러 시작");
+
+    Retry orphanRetry = retryRegistry.retry("redisCleanupOrphanScan");
+    Retry purgeRetry = retryRegistry.retry("redisCleanupRankingPurge");
+
+    int[] orphanCount = {0};
+    int[] purgedRanking = {0};
+    int[] purgedDetail = {0};
+    boolean orphanFailed = false;
+    boolean purgeFailed = false;
+
+    try {
+      orphanRetry.executeRunnable(() -> orphanCount[0] = scanOrphanKeys());
+    } catch (Exception e) {
+      orphanFailed = true;
+      log.error("Redis orphan 스캔 실패: {}", e.getMessage(), e);
+    }
+
+    LocalDate cutoff = LocalDate.now(clock).minusDays(properties.getPurgeOlderThanDays());
+    try {
+      purgeRetry.executeRunnable(
+          () -> {
+            purgedRanking[0] = purgeStaleKeys(RedisKeyConstants.RANKING_KEY_PREFIX + "*", cutoff);
+            purgedDetail[0] = purgeStaleKeys(RedisKeyConstants.RANKING_DETAIL_PREFIX + "*", cutoff);
+          });
+    } catch (Exception e) {
+      purgeFailed = true;
+      log.error("Redis ranking 누수 정리 실패: {}", e.getMessage(), e);
+    }
+
+    RedisCleanupReport report =
+        new RedisCleanupReport(
+            orphanCount[0], purgedRanking[0], purgedDetail[0], orphanFailed, purgeFailed);
+
+    log.info(
+        "Redis 정리 스케줄러 완료: orphan={}, purgedRanking={}, purgedDetail={}, failures=[{}{}]",
+        report.orphanCount(),
+        report.purgedRankingCount(),
+        report.purgedDetailCount(),
+        report.orphanScanFailed() ? "orphanScan " : "",
+        report.rankingPurgeFailed() ? "rankingPurge" : "");
+
+    notifyDiscord(report);
+  }
+
+  private int scanOrphanKeys() {
+    Set<String> known = RedisKeyConstants.knownPrefixes();
+    int count = 0;
+    try (Cursor<String> cursor = openCursor("*")) {
+      while (cursor.hasNext()) {
+        String key = cursor.next();
+        if (!matchesAnyPrefix(key, known)) {
+          log.warn("Redis orphan 키 발견: {}", key);
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
+  private int purgeStaleKeys(String pattern, LocalDate cutoff) {
+    int deleted = 0;
+    try (Cursor<String> cursor = openCursor(pattern)) {
+      while (cursor.hasNext()) {
+        String key = cursor.next();
+        LocalDate keyDate = extractDate(key);
+        if (keyDate == null) {
+          log.warn("Redis 키 날짜 파싱 실패 (orphan으로 분류 권장): {}", key);
+          continue;
+        }
+        if (!keyDate.isAfter(cutoff)) {
+          Boolean removed = redisTemplate.delete(key);
+          if (removed) {
+            log.info("Redis 누수 키 삭제: {}", key);
+            deleted++;
+          }
+        }
+      }
+    }
+    return deleted;
+  }
+
+  private Cursor<String> openCursor(String pattern) {
+    ScanOptions options =
+        ScanOptions.scanOptions().match(pattern).count(properties.getScanBatchSize()).build();
+    return redisTemplate.scan(options);
+  }
+
+  private boolean matchesAnyPrefix(String key, Set<String> prefixes) {
+    for (String prefix : prefixes) {
+      if (key.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private LocalDate extractDate(String key) {
+    String body;
+    if (key.startsWith(RedisKeyConstants.RANKING_DETAIL_PREFIX)) {
+      body = key.substring(RedisKeyConstants.RANKING_DETAIL_PREFIX.length());
+    } else if (key.startsWith(RedisKeyConstants.RANKING_KEY_PREFIX)) {
+      body = key.substring(RedisKeyConstants.RANKING_KEY_PREFIX.length());
+    } else {
+      return null;
+    }
+    int colonIdx = body.indexOf(':');
+    String datePart = colonIdx == -1 ? body : body.substring(0, colonIdx);
+    try {
+      return LocalDate.parse(datePart);
+    } catch (DateTimeParseException e) {
+      return null;
+    }
+  }
+
+  private void notifyDiscord(RedisCleanupReport report) {
+    if (!report.hasAnyAction() && !report.hasFailure() && !properties.isNotifyOnZero()) {
+      return;
+    }
+    try {
+      NotificationLevel level =
+          report.hasFailure() ? NotificationLevel.HIGH : NotificationLevel.INFO;
+      discordWebhookClient.send(level, buildEmbed(report));
+    } catch (Exception e) {
+      log.warn("Discord 웹훅 전송 중 예외 발생: {}", e.getMessage(), e);
+    }
+  }
+
+  private DiscordEmbed buildEmbed(RedisCleanupReport report) {
+    String title;
+    int color;
+    if (report.hasFailure()) {
+      title = "Redis 정리 스케줄러 일부 실패";
+      color = COLOR_PARTIAL;
+    } else {
+      title = "Redis 정리 스케줄러 실행 완료";
+      color = COLOR_INFO;
+    }
+
+    String description = report.hasAnyAction() ? "정리 대상이 감지되어 처리되었습니다." : "이번 사이클에서 정리할 키가 없습니다.";
+
+    List<DiscordEmbed.Field> fields =
+        List.of(
+            new DiscordEmbed.Field("Orphan 키", String.valueOf(report.orphanCount()), true),
+            new DiscordEmbed.Field("정리 ranking", String.valueOf(report.purgedRankingCount()), true),
+            new DiscordEmbed.Field("정리 detail", String.valueOf(report.purgedDetailCount()), true),
+            new DiscordEmbed.Field("Orphan 스캔", report.orphanScanFailed() ? "실패" : "성공", true),
+            new DiscordEmbed.Field("Ranking 정리", report.rankingPurgeFailed() ? "실패" : "성공", true),
+            new DiscordEmbed.Field(
+                "삭제 임계 일수", String.valueOf(properties.getPurgeOlderThanDays()), true));
+
+    return new DiscordEmbed(title, description, color, fields);
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -41,6 +41,7 @@ public class RankingService {
 
   private static final int TOP_RANKING_SIZE = 10;
   private static final Duration EXPIRE_TTL = Duration.ofHours(1);
+  private static final Duration LIVE_TTL = Duration.ofHours(30);
   private static final BigDecimal PERFECT_SIMILARITY = new BigDecimal("100");
 
   private final StringRedisTemplate redisTemplate;
@@ -77,6 +78,9 @@ public class RankingService {
               "attemptCount", String.valueOf(session.getAttemptCount()),
               "elapsedSeconds", String.valueOf(elapsedSeconds));
       redisTemplate.opsForHash().putAll(detailKey, detail);
+
+      redisTemplate.expire(rankingKey, LIVE_TTL);
+      redisTemplate.expire(detailKey, LIVE_TTL);
 
       Long rank = redisTemplate.opsForZSet().reverseRank(rankingKey, memberKey);
       if (rank != null) {
@@ -294,7 +298,12 @@ public class RankingService {
               "attemptCount", String.valueOf(session.getAttemptCount()),
               "elapsedSeconds", String.valueOf(elapsedSeconds));
       redisTemplate.opsForHash().putAll(detailKey, detail);
+      redisTemplate.expire(detailKey, LIVE_TTL);
       count++;
+    }
+
+    if (count > 0) {
+      redisTemplate.expire(rankingKey, LIVE_TTL);
     }
 
     log.info("랭킹 캐시 재구축: date={}, sessions={}", date, count);

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -119,6 +119,13 @@ app:
   openapi:
     docs-mode: ${APP_OPENAPI_DOCS_MODE:false}
 
+  redis:
+    cleanup:
+      enabled: ${REDIS_CLEANUP_ENABLED:true}
+      scan-batch-size: ${REDIS_CLEANUP_SCAN_BATCH_SIZE:500}
+      purge-older-than-days: ${REDIS_CLEANUP_PURGE_OLDER_THAN_DAYS:2}
+      notify-on-zero: ${REDIS_CLEANUP_NOTIFY_ON_ZERO:false}
+
 springdoc:
   api-docs:
     groups:
@@ -156,6 +163,16 @@ resilience4j:
         enable-exponential-backoff: true
         exponential-backoff-multiplier: 2
       schedulerSelectToday:
+        max-attempts: 3
+        wait-duration: 2s
+        enable-exponential-backoff: true
+        exponential-backoff-multiplier: 2
+      redisCleanupOrphanScan:
+        max-attempts: 3
+        wait-duration: 2s
+        enable-exponential-backoff: true
+        exponential-backoff-multiplier: 2
+      redisCleanupRankingPurge:
         max-attempts: 3
         wait-duration: 2s
         enable-exponential-backoff: true

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSystemIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSystemIntegrationTest.java
@@ -8,19 +8,28 @@ import com.gakkaweo.backend.admin.dto.AuditLogListResponse;
 import com.gakkaweo.backend.admin.dto.SystemStatusResponse;
 import com.gakkaweo.backend.admin.event.AnnouncementEvent;
 import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.entity.AuditLog;
 import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
+import com.gakkaweo.backend.domain.game.entity.GameSession;
+import com.gakkaweo.backend.domain.game.repository.GameSessionRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.ranking.service.RankingService;
 import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -32,9 +41,15 @@ import org.springframework.transaction.support.TransactionTemplate;
 @DisplayName("Admin 시스템 관리 통합 테스트")
 class AdminSystemIntegrationTest extends IntegrationTestBase {
 
+  private static final long LIVE_TTL_SECONDS = 30 * 3600L;
+  private static final long TTL_TOLERANCE_SECONDS = 60L;
+
   @Autowired Clock clock;
   @Autowired AuditLogRepository auditLogRepository;
   @Autowired TransactionTemplate transactionTemplate;
+  @Autowired StringRedisTemplate redisTemplate;
+  @Autowired RankingService rankingService;
+  @Autowired GameSessionRepository gameSessionRepository;
 
   @Test
   @DisplayName("공지 등록 - 201 + 목록 조회")
@@ -110,6 +125,42 @@ class AdminSystemIntegrationTest extends IntegrationTestBase {
             Void.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("랭킹 캐시 리셋 - 재구축된 today 키에 30h TTL 부여")
+  void 랭킹캐시_리셋_TTL_부여() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("오늘 문장");
+    Member player = testAuthHelper.createMember();
+
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          GameSession session = new GameSession(player, sentence);
+          session.updateBestSimilarity(new BigDecimal("80.0"));
+          gameSessionRepository.save(session);
+        });
+
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/system/ranking-cache/reset"),
+            HttpMethod.POST,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    LocalDate today = LocalDate.now(clock);
+    String rankingKey = RedisKeyConstants.rankingKey(today);
+    String detailKey = RedisKeyConstants.rankingDetailKey(today, player.getPublicId());
+
+    Long rankingTtl = redisTemplate.getExpire(rankingKey, TimeUnit.SECONDS);
+    Long detailTtl = redisTemplate.getExpire(detailKey, TimeUnit.SECONDS);
+
+    assertThat(rankingTtl).isBetween(LIVE_TTL_SECONDS - TTL_TOLERANCE_SECONDS, LIVE_TTL_SECONDS);
+    assertThat(detailTtl).isBetween(LIVE_TTL_SECONDS - TTL_TOLERANCE_SECONDS, LIVE_TTL_SECONDS);
   }
 
   @Test

--- a/backend/src/test/java/com/gakkaweo/backend/infra/redis/RedisCleanupSchedulerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/infra/redis/RedisCleanupSchedulerTest.java
@@ -1,0 +1,102 @@
+package com.gakkaweo.backend.infra.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.gakkaweo.backend.infra.notification.NotificationLevel;
+import com.gakkaweo.backend.infra.notification.client.DiscordWebhookClient;
+import com.gakkaweo.backend.infra.notification.dto.DiscordEmbed;
+import com.gakkaweo.backend.infra.redis.scheduler.RedisCleanupScheduler;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@DisplayName("RedisCleanupScheduler 통합 테스트")
+class RedisCleanupSchedulerTest extends IntegrationTestBase {
+
+  @Autowired RedisCleanupScheduler scheduler;
+  @Autowired StringRedisTemplate redisTemplate;
+
+  @MockitoBean DiscordWebhookClient discordWebhookClient;
+
+  @Test
+  @DisplayName("executeCleanup - D-2 이상 키 정리 + orphan 카운트 + Discord INFO 발송")
+  void 정리_시나리오() {
+    LocalDate today = LocalDate.now(clock);
+    LocalDate dMinus3 = today.minusDays(3);
+    LocalDate dMinus2 = today.minusDays(2);
+    LocalDate yesterday = today.minusDays(1);
+
+    redisTemplate.opsForValue().set("ranking:" + dMinus3, "1");
+    redisTemplate.opsForHash().put("ranking_detail:" + dMinus3 + ":member:abc", "k", "v");
+    redisTemplate.opsForValue().set("ranking:" + dMinus2, "1");
+    redisTemplate.opsForHash().put("ranking_detail:" + dMinus2 + ":member:def", "k", "v");
+    redisTemplate.opsForValue().set("ranking:" + yesterday, "1");
+    redisTemplate.opsForValue().set("ranking:" + today, "1");
+    redisTemplate.opsForValue().set("unknown_prefix:something", "1");
+
+    scheduler.executeCleanup();
+
+    assertThat(redisTemplate.hasKey("ranking:" + dMinus3)).isFalse();
+    assertThat(redisTemplate.hasKey("ranking_detail:" + dMinus3 + ":member:abc")).isFalse();
+    assertThat(redisTemplate.hasKey("ranking:" + dMinus2)).isFalse();
+    assertThat(redisTemplate.hasKey("ranking_detail:" + dMinus2 + ":member:def")).isFalse();
+    assertThat(redisTemplate.hasKey("ranking:" + yesterday)).isTrue();
+    assertThat(redisTemplate.hasKey("ranking:" + today)).isTrue();
+    assertThat(redisTemplate.hasKey("unknown_prefix:something")).isTrue();
+
+    ArgumentCaptor<DiscordEmbed> captor = ArgumentCaptor.forClass(DiscordEmbed.class);
+    verify(discordWebhookClient).send(eq(NotificationLevel.INFO), captor.capture());
+    DiscordEmbed embed = captor.getValue();
+    assertThat(embed.title()).contains("실행 완료");
+    assertThat(embed.fields())
+        .anyMatch(f -> f.name().equals("Orphan 키") && f.value().equals("1"))
+        .anyMatch(f -> f.name().equals("정리 ranking") && f.value().equals("2"))
+        .anyMatch(f -> f.name().equals("정리 detail") && f.value().equals("2"));
+  }
+
+  @Test
+  @DisplayName("executeCleanup - 정리 0건 + notifyOnZero=false이면 Discord 미발송")
+  void 정리_0건_미발송() {
+    scheduler.executeCleanup();
+
+    verifyNoInteractions(discordWebhookClient);
+  }
+
+  @Test
+  @DisplayName("executeCleanup - 잘못된 키 형식은 스킵하고 보존 (parse 실패는 orphan/purge 모두 미해당)")
+  void 잘못된_키_형식() {
+    redisTemplate.opsForValue().set("ranking:not-a-date", "1");
+    redisTemplate.opsForValue().set("ranking_detail:also-bad:member:abc", "v");
+
+    scheduler.executeCleanup();
+
+    assertThat(redisTemplate.hasKey("ranking:not-a-date")).isTrue();
+    assertThat(redisTemplate.hasKey("ranking_detail:also-bad:member:abc")).isTrue();
+    verifyNoInteractions(discordWebhookClient);
+  }
+
+  @Test
+  @DisplayName("executeCleanup - 화이트리스트 외 prefix는 orphan으로 분류만, 삭제 X")
+  void orphan_분류만() {
+    redisTemplate.opsForValue().set("strange_prefix:value", "1");
+    redisTemplate.opsForValue().set("malicious:foo", "1");
+
+    scheduler.executeCleanup();
+
+    assertThat(redisTemplate.hasKey("strange_prefix:value")).isTrue();
+    assertThat(redisTemplate.hasKey("malicious:foo")).isTrue();
+
+    ArgumentCaptor<DiscordEmbed> captor = ArgumentCaptor.forClass(DiscordEmbed.class);
+    verify(discordWebhookClient).send(eq(NotificationLevel.INFO), captor.capture());
+    assertThat(captor.getValue().fields())
+        .anyMatch(f -> f.name().equals("Orphan 키") && f.value().equals("2"));
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/ranking/RankingServiceIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/ranking/RankingServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.ranking;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gakkaweo.backend.admin.dto.FullRankingResponse;
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
 import com.gakkaweo.backend.domain.game.entity.GameSession;
@@ -18,9 +19,11 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -31,12 +34,16 @@ import org.springframework.transaction.support.TransactionTemplate;
 @DisplayName("RankingService 통합 테스트 (Redis 데이터 포함 경로)")
 class RankingServiceIntegrationTest extends IntegrationTestBase {
 
+  private static final long LIVE_TTL_SECONDS = 30 * 3600L;
+  private static final long TTL_TOLERANCE_SECONDS = 60L;
+
   @Autowired RankingService rankingService;
   @Autowired MemberRepository memberRepository;
   @Autowired DailySentenceRepository dailySentenceRepository;
   @Autowired GameSessionRepository gameSessionRepository;
   @Autowired TransactionTemplate transactionTemplate;
   @Autowired Clock rankingClock;
+  @Autowired StringRedisTemplate redisTemplate;
 
   @SuppressWarnings("unused")
   private static List<String> nicknames(RankingResponse response) {
@@ -258,6 +265,46 @@ class RankingServiceIntegrationTest extends IntegrationTestBase {
 
     LocalDate today = LocalDate.now(rankingClock);
     rankingService.expirePreviousDayRankingKeys(today);
+  }
+
+  @Test
+  @DisplayName("updateRanking - ranking/detail 키에 30h TTL 부여")
+  void updateRanking_TTL_부여() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("오늘 문장");
+    Member member = seedRanking(sentence, "참여자", null, new BigDecimal("80.0"), false);
+
+    LocalDate today = LocalDate.now(rankingClock);
+    String rankingKey = RedisKeyConstants.rankingKey(today);
+    String detailKey = RedisKeyConstants.rankingDetailKey(today, member.getPublicId());
+
+    Long rankingTtl = redisTemplate.getExpire(rankingKey, TimeUnit.SECONDS);
+    Long detailTtl = redisTemplate.getExpire(detailKey, TimeUnit.SECONDS);
+
+    assertThat(rankingTtl).isBetween(LIVE_TTL_SECONDS - TTL_TOLERANCE_SECONDS, LIVE_TTL_SECONDS);
+    assertThat(detailTtl).isBetween(LIVE_TTL_SECONDS - TTL_TOLERANCE_SECONDS, LIVE_TTL_SECONDS);
+  }
+
+  @Test
+  @DisplayName("rebuildRankingCache - 재구축 후 ranking/detail 키에 30h TTL 부여")
+  void rebuildRankingCache_TTL_부여() {
+    DailySentence sentence = testAuthHelper.createTodaySentence("오늘 문장");
+    Member member = seedRanking(sentence, "재구축자", null, new BigDecimal("90.0"), false);
+
+    LocalDate today = LocalDate.now(rankingClock);
+    String rankingKey = RedisKeyConstants.rankingKey(today);
+    String detailKey = RedisKeyConstants.rankingDetailKey(today, member.getPublicId());
+
+    redisTemplate.persist(rankingKey);
+    redisTemplate.persist(detailKey);
+    assertThat(redisTemplate.getExpire(rankingKey, TimeUnit.SECONDS)).isEqualTo(-1L);
+    assertThat(redisTemplate.getExpire(detailKey, TimeUnit.SECONDS)).isEqualTo(-1L);
+
+    rankingService.rebuildRankingCache(today);
+
+    Long rankingTtl = redisTemplate.getExpire(rankingKey, TimeUnit.SECONDS);
+    Long detailTtl = redisTemplate.getExpire(detailKey, TimeUnit.SECONDS);
+    assertThat(rankingTtl).isBetween(LIVE_TTL_SECONDS - TTL_TOLERANCE_SECONDS, LIVE_TTL_SECONDS);
+    assertThat(detailTtl).isBetween(LIVE_TTL_SECONDS - TTL_TOLERANCE_SECONDS, LIVE_TTL_SECONDS);
   }
 
   private Member seedRanking(


### PR DESCRIPTION
## 관련 이슈

Closes #152

## 변경 사항

- `updateRanking`/`rebuildRankingCache` 마지막에 ranking/detail 키 30h expire 호출 추가. 자정 스케줄러 +1h expire와 멱등 공존
- 어드민 랭킹 캐시 리셋 후 재구축 키도 동일 경로로 자동 보호
- `RedisCleanupScheduler` 신규: 6h 간격(04:30/10:30/16:30/22:30 KST). 자정 작업과 4h 30m 거리 확보
- step1: 화이트리스트 외 prefix는 로그+Discord 경고만 (외부 prefix 데이터 손실 방지)
- step2: `ranking:*`/`ranking_detail:*` SCAN, D-2 이상 즉시 delete
- 단계별 Resilience4j retry 인스턴스(`orphanScan`/`rankingPurge`) + 부분 실패 허용. 정리 0건 사이클은 Discord 알림 미발송 (노이즈 억제)
- `RedisKeyConstants.knownPrefixes()` 화이트리스트 노출 (prefix 상수 public화)
- `RedisCleanupProperties`(`@ConfigurationProperties`)로 `enabled`/`scanBatchSize`/`purgeOlderThanDays`/`notifyOnZero` 외부 설정. 기존 Properties 11개와 동일한 `class + @Getter + @RequiredArgsConstructor` 패턴 통일
- `application.yaml`에 `app.redis.cleanup` 블록 + retry 인스턴스 2종 추가
- `.env.sample`/`.env.prod.sample`에 `REDIS_CLEANUP_*` 4종 노출
- 통합 테스트: `RankingServiceIntegrationTest` TTL 검증 2건, `AdminSystemIntegrationTest` 리셋 후 TTL 1건, `RedisCleanupSchedulerTest` 4건(정리 시나리오 / 0건 미발송 / 잘못된 키 형식 / orphan 분류만)

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다