### PR TITLE
feat: 어드민 목록 동적 정렬 (필드/방향 + FE 헤더)

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSentenceController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSentenceController.java
@@ -50,14 +50,22 @@ public class AdminSentenceController {
   private final AdminSentenceService adminSentenceService;
   private final CsvUploadService csvUploadService;
 
-  @Operation(summary = "문장 목록 조회")
+  @Operation(
+      summary = "문장 목록 조회",
+      description =
+          """
+          정렬 (`sort=field,dir`):
+          - 가능 필드: `createdAt`, `status`, `usedAt`, `scheduledAt`, `sentence`
+          - 기본값: `createdAt,desc`
+          - 잘못된 필드/방향: 400 `VALIDATION_FAILED`""")
   @AdminErrorResponses
   @GetMapping
   public ResponseEntity<SentenceListResponse> getSentences(
       @RequestParam(required = false) String status,
+      @RequestParam(required = false) String sort,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "20") int size) {
-    return ResponseEntity.ok(adminSentenceService.getSentences(status, page, size));
+    return ResponseEntity.ok(adminSentenceService.getSentences(status, sort, page, size));
   }
 
   @Operation(

--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSystemController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSystemController.java
@@ -125,7 +125,14 @@ public class AdminSystemController {
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "감사 로그 조회")
+  @Operation(
+      summary = "감사 로그 조회",
+      description =
+          """
+          정렬 (`sort=field,dir`):
+          - 가능 필드: `createdAt`, `action`
+          - 기본값: `createdAt,desc`
+          - 잘못된 필드/방향: 400 `VALIDATION_FAILED`""")
   @AdminErrorResponses
   @GetMapping("/audit-logs")
   @Transactional(readOnly = true)
@@ -135,8 +142,10 @@ public class AdminSystemController {
           Instant dateFrom,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
           Instant dateTo,
+      @RequestParam(required = false) String sort,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "20") int size) {
-    return ResponseEntity.ok(adminSystemService.getAuditLogs(action, dateFrom, dateTo, page, size));
+    return ResponseEntity.ok(
+        adminSystemService.getAuditLogs(action, dateFrom, dateTo, sort, page, size));
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminUserController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminUserController.java
@@ -40,16 +40,24 @@ public class AdminUserController {
 
   private final AdminUserService adminUserService;
 
-  @Operation(summary = "사용자 목록 조회")
+  @Operation(
+      summary = "사용자 목록 조회",
+      description =
+          """
+          정렬 (`sort=field,dir`):
+          - 가능 필드: `createdAt`, `nickname`, `role`, `banned`
+          - 기본값: `createdAt,desc`
+          - 잘못된 필드/방향: 400 `VALIDATION_FAILED`""")
   @AdminErrorResponses
   @GetMapping
   @Transactional(readOnly = true)
   public ResponseEntity<UserListResponse> getUsers(
       @RequestParam(required = false) String nickname,
       @RequestParam(required = false) Boolean banned,
+      @RequestParam(required = false) String sort,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "20") int size) {
-    return ResponseEntity.ok(adminUserService.getUsers(nickname, banned, page, size));
+    return ResponseEntity.ok(adminUserService.getUsers(nickname, banned, sort, page, size));
   }
 
   @Operation(summary = "사용자 상세 조회")

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -13,6 +13,7 @@ import com.gakkaweo.backend.admin.dto.SimilarityTestRequest;
 import com.gakkaweo.backend.admin.dto.SimilarityTestResponse;
 import com.gakkaweo.backend.admin.sort.SentenceSortField;
 import com.gakkaweo.backend.admin.sort.SortRequestParser;
+import com.gakkaweo.backend.admin.sort.SortSpecBuilder;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.common.redis.RedisKeyConstants;
@@ -70,16 +71,16 @@ public class AdminSentenceService {
       statusEnum = null;
     }
 
-    Sort sortSpec =
+    SortRequestParser.SortSpec sortSpec =
         SortRequestParser.parse(
-                sort, SentenceSortField.class, SentenceSortField.CREATED_AT, Sort.Direction.DESC)
-            .and(Sort.by(Sort.Direction.DESC, "id"));
+            sort, SentenceSortField.class, SentenceSortField.CREATED_AT, Sort.Direction.DESC);
 
-    Specification<DailySentence> spec =
+    Specification<DailySentence> filterSpec =
         (root, query, cb) ->
             statusEnum != null ? cb.equal(root.get("status"), statusEnum) : cb.conjunction();
+    Specification<DailySentence> spec = filterSpec.and(SortSpecBuilder.build(sortSpec, "id"));
     Page<DailySentence> pageResult =
-        dailySentenceRepository.findAll(spec, PageRequest.of(page, size, sortSpec));
+        dailySentenceRepository.findAll(spec, PageRequest.of(page, size));
 
     return new SentenceListResponse(
         pageResult.getContent().stream().map(SentenceResponse::from).toList(),

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -11,6 +11,8 @@ import com.gakkaweo.backend.admin.dto.SentenceStatsResponse;
 import com.gakkaweo.backend.admin.dto.SentenceUpdateRequest;
 import com.gakkaweo.backend.admin.dto.SimilarityTestRequest;
 import com.gakkaweo.backend.admin.dto.SimilarityTestResponse;
+import com.gakkaweo.backend.admin.sort.SentenceSortField;
+import com.gakkaweo.backend.admin.sort.SortRequestParser;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.common.redis.RedisKeyConstants;
@@ -56,7 +58,7 @@ public class AdminSentenceService {
   private final Clock clock;
 
   @Transactional(readOnly = true)
-  public SentenceListResponse getSentences(String status, int page, int size) {
+  public SentenceListResponse getSentences(String status, String sort, int page, int size) {
     final DailySentenceStatus statusEnum;
     if (status != null && !status.isBlank()) {
       try {
@@ -68,12 +70,16 @@ public class AdminSentenceService {
       statusEnum = null;
     }
 
+    Sort sortSpec =
+        SortRequestParser.parse(
+                sort, SentenceSortField.class, SentenceSortField.CREATED_AT, Sort.Direction.DESC)
+            .and(Sort.by(Sort.Direction.DESC, "id"));
+
     Specification<DailySentence> spec =
         (root, query, cb) ->
             statusEnum != null ? cb.equal(root.get("status"), statusEnum) : cb.conjunction();
     Page<DailySentence> pageResult =
-        dailySentenceRepository.findAll(
-            spec, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+        dailySentenceRepository.findAll(spec, PageRequest.of(page, size, sortSpec));
 
     return new SentenceListResponse(
         pageResult.getContent().stream().map(SentenceResponse::from).toList(),

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -9,6 +9,7 @@ import com.gakkaweo.backend.admin.dto.SystemStatusResponse;
 import com.gakkaweo.backend.admin.event.AnnouncementEvent;
 import com.gakkaweo.backend.admin.sort.AuditLogSortField;
 import com.gakkaweo.backend.admin.sort.SortRequestParser;
+import com.gakkaweo.backend.admin.sort.SortSpecBuilder;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.common.redis.RedisKeyConstants;
@@ -261,13 +262,12 @@ public class AdminSystemService {
   @Transactional(readOnly = true)
   public AuditLogListResponse getAuditLogs(
       String action, Instant dateFrom, Instant dateTo, String sort, int page, int size) {
-    Sort sortSpec =
+    SortRequestParser.SortSpec sortSpec =
         SortRequestParser.parse(
-                sort, AuditLogSortField.class, AuditLogSortField.CREATED_AT, Sort.Direction.DESC)
-            .and(Sort.by(Sort.Direction.DESC, "id"));
-    Page<AuditLog> pageResult =
-        auditLogRepository.findAll(
-            auditLogFilters(action, dateFrom, dateTo), PageRequest.of(page, size, sortSpec));
+            sort, AuditLogSortField.class, AuditLogSortField.CREATED_AT, Sort.Direction.DESC);
+    Specification<AuditLog> spec =
+        auditLogFilters(action, dateFrom, dateTo).and(SortSpecBuilder.build(sortSpec, "id"));
+    Page<AuditLog> pageResult = auditLogRepository.findAll(spec, PageRequest.of(page, size));
 
     return new AuditLogListResponse(
         pageResult.getContent().stream().map(AuditLogResponse::from).toList(),

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -7,6 +7,8 @@ import com.gakkaweo.backend.admin.dto.AuditLogListResponse;
 import com.gakkaweo.backend.admin.dto.AuditLogResponse;
 import com.gakkaweo.backend.admin.dto.SystemStatusResponse;
 import com.gakkaweo.backend.admin.event.AnnouncementEvent;
+import com.gakkaweo.backend.admin.sort.AuditLogSortField;
+import com.gakkaweo.backend.admin.sort.SortRequestParser;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.common.redis.RedisKeyConstants;
@@ -258,11 +260,14 @@ public class AdminSystemService {
 
   @Transactional(readOnly = true)
   public AuditLogListResponse getAuditLogs(
-      String action, Instant dateFrom, Instant dateTo, int page, int size) {
+      String action, Instant dateFrom, Instant dateTo, String sort, int page, int size) {
+    Sort sortSpec =
+        SortRequestParser.parse(
+                sort, AuditLogSortField.class, AuditLogSortField.CREATED_AT, Sort.Direction.DESC)
+            .and(Sort.by(Sort.Direction.DESC, "id"));
     Page<AuditLog> pageResult =
         auditLogRepository.findAll(
-            auditLogFilters(action, dateFrom, dateTo),
-            PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+            auditLogFilters(action, dateFrom, dateTo), PageRequest.of(page, size, sortSpec));
 
     return new AuditLogListResponse(
         pageResult.getContent().stream().map(AuditLogResponse::from).toList(),

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -8,6 +8,8 @@ import com.gakkaweo.backend.admin.dto.UserDetailResponse.ActivitySummary;
 import com.gakkaweo.backend.admin.dto.UserGameHistoryResponse;
 import com.gakkaweo.backend.admin.dto.UserGameHistoryResponse.GameHistoryEntry;
 import com.gakkaweo.backend.admin.dto.UserListResponse;
+import com.gakkaweo.backend.admin.sort.SortRequestParser;
+import com.gakkaweo.backend.admin.sort.UserSortField;
 import com.gakkaweo.backend.auth.service.ProfileImageService;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
@@ -79,11 +81,15 @@ public class AdminUserService {
   }
 
   @Transactional(readOnly = true)
-  public UserListResponse getUsers(String nickname, Boolean banned, int page, int size) {
+  public UserListResponse getUsers(
+      String nickname, Boolean banned, String sort, int page, int size) {
+    Sort sortSpec =
+        SortRequestParser.parse(
+                sort, UserSortField.class, UserSortField.CREATED_AT, Sort.Direction.DESC)
+            .and(Sort.by(Sort.Direction.DESC, "id"));
     Page<Member> pageResult =
         memberRepository.findAll(
-            memberFilters(nickname, banned),
-            PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+            memberFilters(nickname, banned), PageRequest.of(page, size, sortSpec));
 
     return new UserListResponse(
         pageResult.getContent().stream().map(this::toUserResponse).toList(),

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -9,6 +9,7 @@ import com.gakkaweo.backend.admin.dto.UserGameHistoryResponse;
 import com.gakkaweo.backend.admin.dto.UserGameHistoryResponse.GameHistoryEntry;
 import com.gakkaweo.backend.admin.dto.UserListResponse;
 import com.gakkaweo.backend.admin.sort.SortRequestParser;
+import com.gakkaweo.backend.admin.sort.SortSpecBuilder;
 import com.gakkaweo.backend.admin.sort.UserSortField;
 import com.gakkaweo.backend.auth.service.ProfileImageService;
 import com.gakkaweo.backend.common.exception.BusinessException;
@@ -83,13 +84,12 @@ public class AdminUserService {
   @Transactional(readOnly = true)
   public UserListResponse getUsers(
       String nickname, Boolean banned, String sort, int page, int size) {
-    Sort sortSpec =
+    SortRequestParser.SortSpec sortSpec =
         SortRequestParser.parse(
-                sort, UserSortField.class, UserSortField.CREATED_AT, Sort.Direction.DESC)
-            .and(Sort.by(Sort.Direction.DESC, "id"));
-    Page<Member> pageResult =
-        memberRepository.findAll(
-            memberFilters(nickname, banned), PageRequest.of(page, size, sortSpec));
+            sort, UserSortField.class, UserSortField.CREATED_AT, Sort.Direction.DESC);
+    Specification<Member> spec =
+        memberFilters(nickname, banned).and(SortSpecBuilder.build(sortSpec, "id"));
+    Page<Member> pageResult = memberRepository.findAll(spec, PageRequest.of(page, size));
 
     return new UserListResponse(
         pageResult.getContent().stream().map(this::toUserResponse).toList(),

--- a/backend/src/main/java/com/gakkaweo/backend/admin/sort/AuditLogSortField.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/sort/AuditLogSortField.java
@@ -1,0 +1,24 @@
+package com.gakkaweo.backend.admin.sort;
+
+public enum AuditLogSortField implements SortField {
+  CREATED_AT("createdAt", "createdAt"),
+  ACTION("action", "action");
+
+  private final String fieldKey;
+  private final String entityField;
+
+  AuditLogSortField(String fieldKey, String entityField) {
+    this.fieldKey = fieldKey;
+    this.entityField = entityField;
+  }
+
+  @Override
+  public String fieldKey() {
+    return fieldKey;
+  }
+
+  @Override
+  public String entityField() {
+    return entityField;
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/sort/SentenceSortField.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/sort/SentenceSortField.java
@@ -1,0 +1,27 @@
+package com.gakkaweo.backend.admin.sort;
+
+public enum SentenceSortField implements SortField {
+  CREATED_AT("createdAt", "createdAt"),
+  STATUS("status", "status"),
+  USED_AT("usedAt", "usedAt"),
+  SCHEDULED_AT("scheduledAt", "scheduledAt"),
+  SENTENCE("sentence", "sentence");
+
+  private final String fieldKey;
+  private final String entityField;
+
+  SentenceSortField(String fieldKey, String entityField) {
+    this.fieldKey = fieldKey;
+    this.entityField = entityField;
+  }
+
+  @Override
+  public String fieldKey() {
+    return fieldKey;
+  }
+
+  @Override
+  public String entityField() {
+    return entityField;
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/sort/SortField.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/sort/SortField.java
@@ -1,0 +1,8 @@
+package com.gakkaweo.backend.admin.sort;
+
+public interface SortField {
+
+  String fieldKey();
+
+  String entityField();
+}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/sort/SortRequestParser.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/sort/SortRequestParser.java
@@ -9,10 +9,12 @@ public final class SortRequestParser {
 
   private SortRequestParser() {}
 
-  public static <E extends Enum<E> & SortField> Sort parse(
+  public record SortSpec(String entityField, Sort.Direction direction) {}
+
+  public static <E extends Enum<E> & SortField> SortSpec parse(
       String raw, Class<E> enumType, E defaultField, Sort.Direction defaultDirection) {
     if (raw == null || raw.isBlank()) {
-      return Sort.by(defaultDirection, defaultField.entityField());
+      return new SortSpec(defaultField.entityField(), defaultDirection);
     }
 
     String[] parts = raw.split(",", -1);
@@ -47,6 +49,6 @@ public final class SortRequestParser {
       throw new BusinessException(ErrorCode.VALIDATION_FAILED);
     }
 
-    return Sort.by(direction, matched.entityField());
+    return new SortSpec(matched.entityField(), direction);
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/admin/sort/SortRequestParser.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/sort/SortRequestParser.java
@@ -1,0 +1,52 @@
+package com.gakkaweo.backend.admin.sort;
+
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import java.util.Locale;
+import org.springframework.data.domain.Sort;
+
+public final class SortRequestParser {
+
+  private SortRequestParser() {}
+
+  public static <E extends Enum<E> & SortField> Sort parse(
+      String raw, Class<E> enumType, E defaultField, Sort.Direction defaultDirection) {
+    if (raw == null || raw.isBlank()) {
+      return Sort.by(defaultDirection, defaultField.entityField());
+    }
+
+    String[] parts = raw.split(",", -1);
+    if (parts.length < 1 || parts.length > 2) {
+      throw new BusinessException(ErrorCode.VALIDATION_FAILED);
+    }
+
+    String fieldKey = parts[0].trim();
+    if (fieldKey.isEmpty()) {
+      throw new BusinessException(ErrorCode.VALIDATION_FAILED);
+    }
+
+    Sort.Direction direction = defaultDirection;
+    if (parts.length == 2) {
+      String dirRaw = parts[1].trim().toLowerCase(Locale.ROOT);
+      direction =
+          switch (dirRaw) {
+            case "asc" -> Sort.Direction.ASC;
+            case "desc" -> Sort.Direction.DESC;
+            default -> throw new BusinessException(ErrorCode.VALIDATION_FAILED);
+          };
+    }
+
+    E matched = null;
+    for (E candidate : enumType.getEnumConstants()) {
+      if (candidate.fieldKey().equalsIgnoreCase(fieldKey)) {
+        matched = candidate;
+        break;
+      }
+    }
+    if (matched == null) {
+      throw new BusinessException(ErrorCode.VALIDATION_FAILED);
+    }
+
+    return Sort.by(direction, matched.entityField());
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/sort/SortSpecBuilder.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/sort/SortSpecBuilder.java
@@ -1,0 +1,27 @@
+package com.gakkaweo.backend.admin.sort;
+
+import jakarta.persistence.criteria.Path;
+import org.hibernate.query.NullPrecedence;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.hibernate.query.criteria.JpaOrder;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+
+public final class SortSpecBuilder {
+
+  private SortSpecBuilder() {}
+
+  public static <T> Specification<T> build(SortRequestParser.SortSpec spec, String tiebreakField) {
+    return (root, query, cb) -> {
+      if (Long.class != query.getResultType()) {
+        HibernateCriteriaBuilder hcb = (HibernateCriteriaBuilder) cb;
+        Path<?> primaryPath = root.get(spec.entityField());
+        JpaOrder primary =
+            (spec.direction() == Sort.Direction.ASC ? hcb.asc(primaryPath) : hcb.desc(primaryPath))
+                .nullPrecedence(NullPrecedence.LAST);
+        query.orderBy(primary, cb.desc(root.get(tiebreakField)));
+      }
+      return cb.conjunction();
+    };
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/sort/UserSortField.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/sort/UserSortField.java
@@ -1,0 +1,26 @@
+package com.gakkaweo.backend.admin.sort;
+
+public enum UserSortField implements SortField {
+  CREATED_AT("createdAt", "createdAt"),
+  NICKNAME("nickname", "nickname"),
+  ROLE("role", "role"),
+  BANNED("banned", "banned");
+
+  private final String fieldKey;
+  private final String entityField;
+
+  UserSortField(String fieldKey, String entityField) {
+    this.fieldKey = fieldKey;
+    this.entityField = entityField;
+  }
+
+  @Override
+  public String fieldKey() {
+    return fieldKey;
+  }
+
+  @Override
+  public String entityField() {
+    return entityField;
+  }
+}

--- a/backend/src/main/resources/db/migration/V16__add_admin_sort_indexes.sql
+++ b/backend/src/main/resources/db/migration/V16__add_admin_sort_indexes.sql
@@ -1,0 +1,8 @@
+-- 어드민 문장 목록 동적 정렬 보조 인덱스
+-- status 필터 + created_at 정렬 결합 패턴 (가장 흔한 운영 정렬)
+CREATE INDEX IF NOT EXISTS idx_daily_sentences_status_created
+    ON daily_sentences (status, created_at DESC);
+
+-- 스케줄 정렬 (NULL 다수 + 미래 일정 소수: B-tree로 충분)
+CREATE INDEX IF NOT EXISTS idx_daily_sentences_scheduled_at
+    ON daily_sentences (scheduled_at);

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSortIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSortIntegrationTest.java
@@ -1,0 +1,235 @@
+package com.gakkaweo.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.admin.dto.AdminUserResponse;
+import com.gakkaweo.backend.admin.dto.AuditLogListResponse;
+import com.gakkaweo.backend.admin.dto.AuditLogResponse;
+import com.gakkaweo.backend.admin.dto.SentenceListResponse;
+import com.gakkaweo.backend.admin.dto.SentenceResponse;
+import com.gakkaweo.backend.admin.dto.UserListResponse;
+import com.gakkaweo.backend.admin.service.AdminAuditService;
+import com.gakkaweo.backend.common.exception.ErrorBody;
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@DisplayName("Admin 목록 동적 정렬 통합 테스트")
+class AdminSortIntegrationTest extends IntegrationTestBase {
+
+  @Autowired AdminAuditService adminAuditService;
+
+  @Nested
+  @DisplayName("/admin/users")
+  class Users {
+
+    @Test
+    @DisplayName("사용자 목록 - 닉네임 오름차순 정렬 - 200")
+    void 사용자_닉네임_오름차순() {
+      Member admin = testAuthHelper.createAdmin();
+      testAuthHelper.createMember();
+      testAuthHelper.createMember();
+      testAuthHelper.createMember();
+
+      ResponseEntity<UserListResponse> response =
+          restTemplate.exchange(
+              url("/admin/users?sort=nickname,asc&page=0&size=20"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              UserListResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      List<String> nicknames =
+          response.getBody().users().stream().map(AdminUserResponse::nickname).toList();
+      assertThat(nicknames).isSortedAccordingTo(Comparator.naturalOrder());
+    }
+
+    @Test
+    @DisplayName("사용자 목록 - 차단 필터 + 정렬 결합 - 200")
+    void 사용자_필터_정렬_결합() {
+      Member admin = testAuthHelper.createAdmin();
+      testAuthHelper.createBannedMember();
+      testAuthHelper.createBannedMember();
+      testAuthHelper.createMember();
+
+      ResponseEntity<UserListResponse> response =
+          restTemplate.exchange(
+              url("/admin/users?banned=true&sort=banned,desc&page=0&size=20"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              UserListResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().users())
+          .isNotEmpty()
+          .allSatisfy(user -> assertThat(user.banned()).isTrue());
+    }
+
+    @Test
+    @DisplayName("사용자 목록 - sort 누락 - 200 + 기본 정렬")
+    void 사용자_sort_누락_기본정렬() {
+      Member admin = testAuthHelper.createAdmin();
+      testAuthHelper.createMember();
+
+      ResponseEntity<UserListResponse> response =
+          restTemplate.exchange(
+              url("/admin/users?page=0&size=20"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              UserListResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().users()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("사용자 목록 - 화이트리스트 외 필드 - 400 VALIDATION_FAILED")
+    void 사용자_화이트리스트외_400() {
+      Member admin = testAuthHelper.createAdmin();
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.exchange(
+              url("/admin/users?sort=password,desc"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+    }
+
+    @Test
+    @DisplayName("사용자 목록 - 잘못된 방향 - 400 VALIDATION_FAILED")
+    void 사용자_잘못된_방향_400() {
+      Member admin = testAuthHelper.createAdmin();
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.exchange(
+              url("/admin/users?sort=nickname,sideways"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+    }
+  }
+
+  @Nested
+  @DisplayName("/admin/sentences")
+  class Sentences {
+
+    @Test
+    @DisplayName("문장 목록 - sentence 오름차순 정렬 - 200")
+    void 문장_오름차순() {
+      Member admin = testAuthHelper.createAdmin();
+      testAuthHelper.createActiveSentence("가장 먼저 오는 문장");
+      testAuthHelper.createActiveSentence("나중에 오는 문장");
+      testAuthHelper.createActiveSentence("마지막 문장");
+
+      ResponseEntity<SentenceListResponse> response =
+          restTemplate.exchange(
+              url("/admin/sentences?sort=sentence,asc&page=0&size=20"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              SentenceListResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      List<String> sentences =
+          response.getBody().sentences().stream().map(SentenceResponse::sentence).toList();
+      assertThat(sentences).isSortedAccordingTo(Comparator.naturalOrder());
+    }
+
+    @Test
+    @DisplayName("문장 목록 - usedAt 내림차순 정렬 - 200")
+    void 문장_출제일_내림차순() {
+      Member admin = testAuthHelper.createAdmin();
+      testAuthHelper.createTodaySentence("출제된 문장");
+      testAuthHelper.createActiveSentence("미출제 문장 1");
+      testAuthHelper.createActiveSentence("미출제 문장 2");
+
+      ResponseEntity<SentenceListResponse> response =
+          restTemplate.exchange(
+              url("/admin/sentences?sort=usedAt,desc&page=0&size=20"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              SentenceListResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody().sentences()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("문장 목록 - 화이트리스트 외 필드 - 400 VALIDATION_FAILED")
+    void 문장_화이트리스트외_400() {
+      Member admin = testAuthHelper.createAdmin();
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.exchange(
+              url("/admin/sentences?sort=password,desc"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+    }
+  }
+
+  @Nested
+  @DisplayName("/admin/system/audit-logs")
+  class AuditLogs {
+
+    @Test
+    @DisplayName("감사 로그 - action 오름차순 정렬 - 200")
+    void 감사로그_액션_오름차순() {
+      Member admin = testAuthHelper.createAdmin();
+      Member target = testAuthHelper.createMember();
+      adminAuditService.log(
+          admin, AuditAction.USER_BAN, target.getPublicId().toString(), null, "0.0.0.0");
+      adminAuditService.log(admin, AuditAction.SENTENCE_CREATE, "fake-id", "테스트 문장", "0.0.0.0");
+      adminAuditService.log(admin, AuditAction.RANKING_CACHE_RESET, null, null, "0.0.0.0");
+
+      ResponseEntity<AuditLogListResponse> response =
+          restTemplate.exchange(
+              url("/admin/system/audit-logs?sort=action,asc&page=0&size=20"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              AuditLogListResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      List<String> actions =
+          response.getBody().content().stream()
+              .map(AuditLogResponse::action)
+              .map(Enum::name)
+              .toList();
+      assertThat(actions).isSortedAccordingTo(Comparator.naturalOrder());
+    }
+
+    @Test
+    @DisplayName("감사 로그 - 화이트리스트 외 필드 (admin.nickname) - 400 VALIDATION_FAILED")
+    void 감사로그_화이트리스트외_400() {
+      Member admin = testAuthHelper.createAdmin();
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.exchange(
+              url("/admin/system/audit-logs?sort=admin.nickname,asc"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
+    }
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSortIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSortIntegrationTest.java
@@ -13,6 +13,7 @@ import com.gakkaweo.backend.common.exception.ErrorBody;
 import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.support.IntegrationTestBase;
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -151,12 +152,13 @@ class AdminSortIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("문장 목록 - usedAt 내림차순 정렬 - 200")
-    void 문장_출제일_내림차순() {
+    @DisplayName("문장 목록 - usedAt 내림차순 정렬 - 출제일 최신순 + NULL은 마지막")
+    void 문장_출제일_내림차순_NULL_마지막() {
       Member admin = testAuthHelper.createAdmin();
-      testAuthHelper.createTodaySentence("출제된 문장");
-      testAuthHelper.createActiveSentence("미출제 문장 1");
-      testAuthHelper.createActiveSentence("미출제 문장 2");
+      testAuthHelper.createUsedSentence("이전 출제", LocalDate.of(2026, 1, 1));
+      testAuthHelper.createUsedSentence("최근 출제", LocalDate.of(2026, 4, 1));
+      testAuthHelper.createActiveSentence("미출제 1");
+      testAuthHelper.createActiveSentence("미출제 2");
 
       ResponseEntity<SentenceListResponse> response =
           restTemplate.exchange(
@@ -166,7 +168,37 @@ class AdminSortIntegrationTest extends IntegrationTestBase {
               SentenceListResponse.class);
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-      assertThat(response.getBody().sentences()).isNotEmpty();
+      List<SentenceResponse> sentences = response.getBody().sentences();
+      assertThat(sentences).hasSize(4);
+      assertThat(sentences.get(0).usedAt()).isEqualTo(LocalDate.of(2026, 4, 1));
+      assertThat(sentences.get(1).usedAt()).isEqualTo(LocalDate.of(2026, 1, 1));
+      assertThat(sentences.get(2).usedAt()).isNull();
+      assertThat(sentences.get(3).usedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("문장 목록 - scheduledAt 내림차순 정렬 - 예약일 최신순 + NULL은 마지막")
+    void 문장_예약일_내림차순_NULL_마지막() {
+      Member admin = testAuthHelper.createAdmin();
+      testAuthHelper.createScheduledSentence("이른 예약", LocalDate.of(2026, 5, 1));
+      testAuthHelper.createScheduledSentence("늦은 예약", LocalDate.of(2026, 6, 1));
+      testAuthHelper.createActiveSentence("미예약 1");
+      testAuthHelper.createActiveSentence("미예약 2");
+
+      ResponseEntity<SentenceListResponse> response =
+          restTemplate.exchange(
+              url("/admin/sentences?sort=scheduledAt,desc&page=0&size=20"),
+              HttpMethod.GET,
+              new HttpEntity<>(testAuthHelper.cookieHeaderFor(admin)),
+              SentenceListResponse.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      List<SentenceResponse> sentences = response.getBody().sentences();
+      assertThat(sentences).hasSize(4);
+      assertThat(sentences.get(0).scheduledAt()).isEqualTo(LocalDate.of(2026, 6, 1));
+      assertThat(sentences.get(1).scheduledAt()).isEqualTo(LocalDate.of(2026, 5, 1));
+      assertThat(sentences.get(2).scheduledAt()).isNull();
+      assertThat(sentences.get(3).scheduledAt()).isNull();
     }
 
     @Test

--- a/backend/src/test/java/com/gakkaweo/backend/admin/sort/SortRequestParserTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/sort/SortRequestParserTest.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.admin.sort;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.gakkaweo.backend.admin.sort.SortRequestParser.SortSpec;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -36,6 +37,10 @@ class SortRequestParserTest {
     }
   }
 
+  private static SortSpec expected(String entityField, Sort.Direction direction) {
+    return new SortSpec(entityField, direction);
+  }
+
   @Nested
   @DisplayName("기본값 처리")
   class Defaults {
@@ -43,21 +48,21 @@ class SortRequestParserTest {
     @Test
     @DisplayName("null 입력 → 기본 필드/방향")
     void nullRaw_returnsDefault() {
-      Sort sort =
+      SortSpec spec =
           SortRequestParser.parse(
               null, TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC);
 
-      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.DESC, "createdAt"));
+      assertThat(spec).isEqualTo(expected("createdAt", Sort.Direction.DESC));
     }
 
     @Test
     @DisplayName("빈 문자열 → 기본 필드/방향")
     void blankRaw_returnsDefault() {
-      Sort sort =
+      SortSpec spec =
           SortRequestParser.parse(
               "   ", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC);
 
-      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.DESC, "createdAt"));
+      assertThat(spec).isEqualTo(expected("createdAt", Sort.Direction.DESC));
     }
   }
 
@@ -68,77 +73,77 @@ class SortRequestParserTest {
     @Test
     @DisplayName("필드 + asc")
     void fieldAndAsc() {
-      Sort sort =
+      SortSpec spec =
           SortRequestParser.parse(
               "nickname,asc", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC);
 
-      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "nickname"));
+      assertThat(spec).isEqualTo(expected("nickname", Sort.Direction.ASC));
     }
 
     @Test
     @DisplayName("필드 + desc")
     void fieldAndDesc() {
-      Sort sort =
+      SortSpec spec =
           SortRequestParser.parse(
               "nickname,desc", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC);
 
-      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.DESC, "nickname"));
+      assertThat(spec).isEqualTo(expected("nickname", Sort.Direction.DESC));
     }
 
     @Test
     @DisplayName("필드만 → 기본 방향 적용")
     void fieldOnly_usesDefaultDirection() {
-      Sort sort =
+      SortSpec spec =
           SortRequestParser.parse(
               "nickname", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.ASC);
 
-      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "nickname"));
+      assertThat(spec).isEqualTo(expected("nickname", Sort.Direction.ASC));
     }
 
     @Test
     @DisplayName("대소문자 무관 매핑 (필드)")
     void fieldKeyIsCaseInsensitive() {
-      Sort sort =
+      SortSpec spec =
           SortRequestParser.parse(
               "NickName,asc", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC);
 
-      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "nickname"));
+      assertThat(spec).isEqualTo(expected("nickname", Sort.Direction.ASC));
     }
 
     @Test
     @DisplayName("대소문자 무관 매핑 (방향)")
     void directionIsCaseInsensitive() {
-      Sort sort =
+      SortSpec spec =
           SortRequestParser.parse(
               "nickname,DESC", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.ASC);
 
-      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.DESC, "nickname"));
+      assertThat(spec).isEqualTo(expected("nickname", Sort.Direction.DESC));
     }
 
     @Test
     @DisplayName("앞뒤 공백 trim")
     void trimsWhitespace() {
-      Sort sort =
+      SortSpec spec =
           SortRequestParser.parse(
               "  nickname , asc ",
               TestSortField.class,
               TestSortField.CREATED_AT,
               Sort.Direction.DESC);
 
-      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "nickname"));
+      assertThat(spec).isEqualTo(expected("nickname", Sort.Direction.ASC));
     }
 
     @Test
     @DisplayName("fieldKey와 entityField가 다른 경우 entityField로 매핑")
     void mapsFieldKeyToEntityField() {
-      Sort sort =
+      SortSpec spec =
           SortRequestParser.parse(
               "memberNickname,asc",
               TestSortField.class,
               TestSortField.CREATED_AT,
               Sort.Direction.DESC);
 
-      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "member.nickname"));
+      assertThat(spec).isEqualTo(expected("member.nickname", Sort.Direction.ASC));
     }
   }
 

--- a/backend/src/test/java/com/gakkaweo/backend/admin/sort/SortRequestParserTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/sort/SortRequestParserTest.java
@@ -1,0 +1,221 @@
+package com.gakkaweo.backend.admin.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+class SortRequestParserTest {
+
+  enum TestSortField implements SortField {
+    CREATED_AT("createdAt", "createdAt"),
+    NICKNAME("nickname", "nickname"),
+    NESTED_ALIAS("memberNickname", "member.nickname");
+
+    private final String fieldKey;
+    private final String entityField;
+
+    TestSortField(String fieldKey, String entityField) {
+      this.fieldKey = fieldKey;
+      this.entityField = entityField;
+    }
+
+    @Override
+    public String fieldKey() {
+      return fieldKey;
+    }
+
+    @Override
+    public String entityField() {
+      return entityField;
+    }
+  }
+
+  @Nested
+  @DisplayName("기본값 처리")
+  class Defaults {
+
+    @Test
+    @DisplayName("null 입력 → 기본 필드/방향")
+    void nullRaw_returnsDefault() {
+      Sort sort =
+          SortRequestParser.parse(
+              null, TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC);
+
+      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
+    @Test
+    @DisplayName("빈 문자열 → 기본 필드/방향")
+    void blankRaw_returnsDefault() {
+      Sort sort =
+          SortRequestParser.parse(
+              "   ", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC);
+
+      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+  }
+
+  @Nested
+  @DisplayName("정상 입력")
+  class Valid {
+
+    @Test
+    @DisplayName("필드 + asc")
+    void fieldAndAsc() {
+      Sort sort =
+          SortRequestParser.parse(
+              "nickname,asc", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC);
+
+      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "nickname"));
+    }
+
+    @Test
+    @DisplayName("필드 + desc")
+    void fieldAndDesc() {
+      Sort sort =
+          SortRequestParser.parse(
+              "nickname,desc", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC);
+
+      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.DESC, "nickname"));
+    }
+
+    @Test
+    @DisplayName("필드만 → 기본 방향 적용")
+    void fieldOnly_usesDefaultDirection() {
+      Sort sort =
+          SortRequestParser.parse(
+              "nickname", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.ASC);
+
+      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "nickname"));
+    }
+
+    @Test
+    @DisplayName("대소문자 무관 매핑 (필드)")
+    void fieldKeyIsCaseInsensitive() {
+      Sort sort =
+          SortRequestParser.parse(
+              "NickName,asc", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC);
+
+      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "nickname"));
+    }
+
+    @Test
+    @DisplayName("대소문자 무관 매핑 (방향)")
+    void directionIsCaseInsensitive() {
+      Sort sort =
+          SortRequestParser.parse(
+              "nickname,DESC", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.ASC);
+
+      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.DESC, "nickname"));
+    }
+
+    @Test
+    @DisplayName("앞뒤 공백 trim")
+    void trimsWhitespace() {
+      Sort sort =
+          SortRequestParser.parse(
+              "  nickname , asc ",
+              TestSortField.class,
+              TestSortField.CREATED_AT,
+              Sort.Direction.DESC);
+
+      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "nickname"));
+    }
+
+    @Test
+    @DisplayName("fieldKey와 entityField가 다른 경우 entityField로 매핑")
+    void mapsFieldKeyToEntityField() {
+      Sort sort =
+          SortRequestParser.parse(
+              "memberNickname,asc",
+              TestSortField.class,
+              TestSortField.CREATED_AT,
+              Sort.Direction.DESC);
+
+      assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "member.nickname"));
+    }
+  }
+
+  @Nested
+  @DisplayName("잘못된 입력")
+  class Invalid {
+
+    @Test
+    @DisplayName("화이트리스트 외 필드 → VALIDATION_FAILED")
+    void unknownField_throws() {
+      assertThatThrownBy(
+              () ->
+                  SortRequestParser.parse(
+                      "password,desc",
+                      TestSortField.class,
+                      TestSortField.CREATED_AT,
+                      Sort.Direction.DESC))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.VALIDATION_FAILED);
+    }
+
+    @Test
+    @DisplayName("잘못된 방향 → VALIDATION_FAILED")
+    void invalidDirection_throws() {
+      assertThatThrownBy(
+              () ->
+                  SortRequestParser.parse(
+                      "nickname,sideways",
+                      TestSortField.class,
+                      TestSortField.CREATED_AT,
+                      Sort.Direction.DESC))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.VALIDATION_FAILED);
+    }
+
+    @Test
+    @DisplayName("필드 누락 (콤마로 시작) → VALIDATION_FAILED")
+    void emptyField_throws() {
+      assertThatThrownBy(
+              () ->
+                  SortRequestParser.parse(
+                      ",desc", TestSortField.class, TestSortField.CREATED_AT, Sort.Direction.DESC))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.VALIDATION_FAILED);
+    }
+
+    @Test
+    @DisplayName("3개 이상 토큰 → VALIDATION_FAILED")
+    void tooManyTokens_throws() {
+      assertThatThrownBy(
+              () ->
+                  SortRequestParser.parse(
+                      "nickname,asc,extra",
+                      TestSortField.class,
+                      TestSortField.CREATED_AT,
+                      Sort.Direction.DESC))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.VALIDATION_FAILED);
+    }
+
+    @Test
+    @DisplayName("빈 방향 토큰 (`nickname,`) → VALIDATION_FAILED")
+    void blankDirection_throws() {
+      assertThatThrownBy(
+              () ->
+                  SortRequestParser.parse(
+                      "nickname,",
+                      TestSortField.class,
+                      TestSortField.CREATED_AT,
+                      Sort.Direction.DESC))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.VALIDATION_FAILED);
+    }
+  }
+}

--- a/backend/src/test/java/com/gakkaweo/backend/support/TestAuthHelper.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/TestAuthHelper.java
@@ -120,4 +120,23 @@ public class TestAuthHelper {
     return transactionTemplate.execute(
         status -> dailySentenceRepository.save(new DailySentence(sentence)));
   }
+
+  public DailySentence createUsedSentence(String sentence, LocalDate usedAt) {
+    return transactionTemplate.execute(
+        status -> {
+          DailySentence s = new DailySentence(sentence);
+          s.setUsedAt(usedAt);
+          s.setStatus(DailySentenceStatus.USED);
+          return dailySentenceRepository.save(s);
+        });
+  }
+
+  public DailySentence createScheduledSentence(String sentence, LocalDate scheduledAt) {
+    return transactionTemplate.execute(
+        status -> {
+          DailySentence s = new DailySentence(sentence);
+          s.setScheduledAt(scheduledAt);
+          return dailySentenceRepository.save(s);
+        });
+  }
 }

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -282,6 +282,12 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **레이아웃**: 사이드바(w-56, 고정) + 콘텐츠 영역(flex-1). `flex gap-6 items-start`
 - **사이드바**: `border-4 shadow-brutal`. 탭: 대시보드/문장/사용자/시스템. 활성 탭 `bg-yellow-300 text-black`
 - **테이블**: `border-4 shadow-brutal` 래퍼. 헤더 `border-b-4 bg-gray-100 dark:bg-gray-800`. 행 `border-b-2 border-black/20` + hover `bg-yellow-50`
+- **테이블 정렬 헤더**: `features/admin/components/SortableHeader.tsx` + `useSortState()` 훅. 정렬 가능 컬럼만 `<SortableHeader>` 사용, 정렬 불가 컬럼은 정적 `<th>` 유지
+  - **비활성 인디케이터**: 라벨 옆 회색 `⇅` 아이콘 항상 노출하여 정렬 가능함을 시각화. hover 시 셀 배경 `bg-yellow-100 dark:bg-yellow-900/30` + 라벨 underline
+  - **활성 인디케이터**: 셀 배경 `bg-yellow-300 dark:bg-yellow-600` + 라벨 `underline underline-offset-4` + 방향 박스(`border-2 border-black bg-white` 안에 ▲/▼). 좌측 라인은 사용하지 않음
+  - **클릭 동작**: 같은 필드 재클릭 시 방향 토글, 다른 필드 클릭 시 `desc`로 진입. 정렬 변경 시 `setPage(0)` 리셋 필수
+  - **a11y**: `<th scope="col" aria-sort="ascending|descending|none">` + 헤더 라벨은 `<button type="button">` 래핑. 버튼 `title` 속성으로 호버 안내(`클릭하여 정렬` / `오름차순/내림차순 정렬 중`)
+  - **백엔드 계약**: `?sort=field,dir` (Spring 표준). 화이트리스트 외 필드/방향은 400. 도메인별 enum (`UserSortField`/`SentenceSortField`/`AuditLogSortField`)이 단일 진실
 - **위젯 카드**: `border-4 shadow-brutal-sm`. 라벨 `text-xs uppercase tracking-wide`. 수치 `text-3xl font-black tabular-nums`
 - **상태 배지**: `px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white`. ACTIVE=green-400, USED=blue-300, DISABLED=gray-300, ADMIN=red, USER=blue, 차단=gray-800
 - **다이얼로그**: `border-4 shadow-brutal max-w-lg`. 헤더 `border-b-4 px-6 py-5`. 푸터 `border-t-4`. `role="dialog" aria-modal="true"` + Escape 닫기 필수

--- a/frontend/src/features/admin/api.ts
+++ b/frontend/src/features/admin/api.ts
@@ -22,10 +22,13 @@ import type {
 
 // --- Sentence ---
 
-export function getSentences(status?: string, page = 0, size = 20) {
+export function getSentences(status?: string, sort?: string, page = 0, size = 20) {
   const params = new URLSearchParams();
   if (status) {
     params.set("status", status);
+  }
+  if (sort) {
+    params.set("sort", sort);
   }
   params.set("page", String(page));
   params.set("size", String(size));
@@ -93,13 +96,16 @@ export function emergencyReplace(newSentencePublicId: string, returnOldToPool: b
 
 // --- User ---
 
-export function getUsers(nickname?: string, banned?: boolean, page = 0, size = 20) {
+export function getUsers(nickname?: string, banned?: boolean, sort?: string, page = 0, size = 20) {
   const params = new URLSearchParams();
   if (nickname) {
     params.set("nickname", nickname);
   }
   if (banned !== undefined) {
     params.set("banned", String(banned));
+  }
+  if (sort) {
+    params.set("sort", sort);
   }
   params.set("page", String(page));
   params.set("size", String(size));
@@ -204,7 +210,7 @@ export function resetRateLimit() {
   return apiFetch<void>("/admin/system/rate-limit/reset", { method: "POST" });
 }
 
-export function getAuditLogs(action?: string, dateFrom?: string, dateTo?: string, page = 0, size = 20) {
+export function getAuditLogs(action?: string, dateFrom?: string, dateTo?: string, sort?: string, page = 0, size = 20) {
   const params = new URLSearchParams();
   if (action) {
     params.set("action", action);
@@ -214,6 +220,9 @@ export function getAuditLogs(action?: string, dateFrom?: string, dateTo?: string
   }
   if (dateTo) {
     params.set("dateTo", dateTo);
+  }
+  if (sort) {
+    params.set("sort", sort);
   }
   params.set("page", String(page));
   params.set("size", String(size));

--- a/frontend/src/features/admin/components/AuditLogViewer.tsx
+++ b/frontend/src/features/admin/components/AuditLogViewer.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/shared/ui/Button";
 import { useAuditLogs } from "@/features/admin/hooks/useAdminSystem";
+import { useSortState } from "@/features/admin/hooks/useSortState";
+import { SortableHeader } from "@/features/admin/components/SortableHeader";
 import type { AuditLog } from "@/features/admin/types";
 
 function AuditLogDetailDialog({ log, onClose }: { log: AuditLog; onClose: () => void }) {
@@ -77,8 +79,14 @@ export function AuditLogViewer() {
   const [actionFilter, setActionFilter] = useState("");
   const [page, setPage] = useState(0);
   const [selectedLog, setSelectedLog] = useState<AuditLog | null>(null);
+  const { sort, toggleSort } = useSortState();
 
-  const { data, isLoading } = useAuditLogs(actionFilter || undefined, undefined, undefined, page, 20);
+  const { data, isLoading } = useAuditLogs(actionFilter || undefined, undefined, undefined, sort, page, 20);
+
+  function handleSortChange(field: string) {
+    toggleSort(field);
+    setPage(0);
+  }
 
   return (
     <div className="mt-4 space-y-3">
@@ -120,9 +128,23 @@ export function AuditLogViewer() {
             <table className="w-full text-xs">
               <thead>
                 <tr className="border-b-2 border-black dark:border-white bg-gray-100 dark:bg-gray-800">
-                  <th className="px-3 py-2 font-black text-left">시간</th>
+                  <SortableHeader
+                    field="createdAt"
+                    label="시간"
+                    align="left"
+                    currentSort={sort}
+                    onSortChange={handleSortChange}
+                    className="px-3 py-2"
+                  />
                   <th className="px-3 py-2 font-black text-left">관리자</th>
-                  <th className="px-3 py-2 font-black text-left">액션</th>
+                  <SortableHeader
+                    field="action"
+                    label="액션"
+                    align="left"
+                    currentSort={sort}
+                    onSortChange={handleSortChange}
+                    className="px-3 py-2"
+                  />
                   <th className="px-3 py-2 font-black text-left">대상</th>
                   <th className="px-3 py-2 font-black text-left">상세</th>
                   <th className="px-3 py-2 font-black text-center w-16">보기</th>

--- a/frontend/src/features/admin/components/SentenceTab.tsx
+++ b/frontend/src/features/admin/components/SentenceTab.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { Button } from "@/shared/ui/Button";
 import { useSentences, useDeleteSentence } from "@/features/admin/hooks/useAdminSentences";
+import { useSortState } from "@/features/admin/hooks/useSortState";
+import { SortableHeader } from "@/features/admin/components/SortableHeader";
 import { SentenceDetailDialog } from "@/features/admin/components/SentenceDetailDialog";
 import { CsvUploadDialog } from "@/features/admin/components/CsvUploadDialog";
 import { SimilarityTestDialog } from "@/features/admin/components/SimilarityTestDialog";
@@ -30,10 +32,16 @@ export function SentenceTab() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isCsvOpen, setIsCsvOpen] = useState(false);
   const [isSimilarityOpen, setIsSimilarityOpen] = useState(false);
+  const { sort, toggleSort } = useSortState();
 
-  const { data, isLoading } = useSentences(statusFilter || undefined, page);
+  const { data, isLoading } = useSentences(statusFilter || undefined, sort, page);
   const deleteMutation = useDeleteSentence();
   const { addToast } = useToastStore();
+
+  function handleSortChange(field: string) {
+    toggleSort(field);
+    setPage(0);
+  }
 
   function handleDelete(publicId: string) {
     if (!window.confirm("정말 삭제하시겠습니까?")) {
@@ -87,10 +95,35 @@ export function SentenceTab() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b-4 border-black dark:border-white bg-gray-100 dark:bg-gray-800">
-                  <th className="text-left px-4 py-3 font-black">문장</th>
-                  <th className="text-center px-3 py-3 font-black w-24">상태</th>
-                  <th className="text-center px-3 py-3 font-black w-28">출제일</th>
-                  <th className="text-center px-3 py-3 font-black w-28">예약일</th>
+                  <SortableHeader
+                    field="sentence"
+                    label="문장"
+                    align="left"
+                    currentSort={sort}
+                    onSortChange={handleSortChange}
+                    className="px-4 py-3"
+                  />
+                  <SortableHeader
+                    field="status"
+                    label="상태"
+                    currentSort={sort}
+                    onSortChange={handleSortChange}
+                    className="px-3 py-3 w-24"
+                  />
+                  <SortableHeader
+                    field="usedAt"
+                    label="출제일"
+                    currentSort={sort}
+                    onSortChange={handleSortChange}
+                    className="px-3 py-3 w-28"
+                  />
+                  <SortableHeader
+                    field="scheduledAt"
+                    label="예약일"
+                    currentSort={sort}
+                    onSortChange={handleSortChange}
+                    className="px-3 py-3 w-28"
+                  />
                   <th className="text-center px-3 py-3 font-black w-36">액션</th>
                 </tr>
               </thead>

--- a/frontend/src/features/admin/components/SortableHeader.tsx
+++ b/frontend/src/features/admin/components/SortableHeader.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from "react";
+
+type Align = "left" | "center" | "right";
+
+type Props = {
+  field: string;
+  label: ReactNode;
+  currentSort: string | undefined;
+  onSortChange: (field: string) => void;
+  align?: Align;
+  className?: string;
+};
+
+const ALIGN_CLASS: Record<Align, string> = {
+  left: "text-left",
+  center: "text-center",
+  right: "text-right",
+};
+
+const JUSTIFY_CLASS: Record<Align, string> = {
+  left: "justify-start",
+  center: "justify-center",
+  right: "justify-end",
+};
+
+export function SortableHeader({ field, label, currentSort, onSortChange, align = "center", className = "" }: Props) {
+  const [activeField, activeDir] = currentSort?.split(",") ?? [];
+  const isActive = activeField === field;
+  const ariaSort = isActive ? (activeDir === "asc" ? "ascending" : "descending") : "none";
+
+  const cellClass = isActive ? "bg-yellow-300 dark:bg-yellow-600" : "hover:bg-yellow-100 dark:hover:bg-yellow-900/30";
+
+  return (
+    <th
+      scope="col"
+      aria-sort={ariaSort}
+      className={`${ALIGN_CLASS[align]} ${cellClass} font-black transition-colors ${className}`}
+    >
+      <button
+        type="button"
+        onClick={() => onSortChange(field)}
+        className={`w-full h-full inline-flex items-center gap-1.5 ${JUSTIFY_CLASS[align]} font-black ${
+          isActive ? "underline underline-offset-4" : "hover:underline"
+        }`}
+        title={isActive ? `${activeDir === "asc" ? "오름차순" : "내림차순"} 정렬 중` : "클릭하여 정렬"}
+      >
+        <span>{label}</span>
+        {isActive ? (
+          <span
+            className="inline-flex items-center justify-center min-w-[1.25rem] h-5 border-2 border-black dark:border-white bg-white dark:bg-gray-900 text-black dark:text-white text-[10px] font-black px-1 leading-none"
+            aria-hidden="true"
+          >
+            {activeDir === "asc" ? "▲" : "▼"}
+          </span>
+        ) : (
+          <span className="text-xs text-gray-400 dark:text-gray-500 leading-none" aria-hidden="true">
+            ⇅
+          </span>
+        )}
+      </button>
+    </th>
+  );
+}

--- a/frontend/src/features/admin/components/UserTab.tsx
+++ b/frontend/src/features/admin/components/UserTab.tsx
@@ -3,6 +3,8 @@ import type { FormEvent } from "react";
 import { Button } from "@/shared/ui/Button";
 import { Input } from "@/shared/ui/Input";
 import { useUsers } from "@/features/admin/hooks/useAdminUsers";
+import { useSortState } from "@/features/admin/hooks/useSortState";
+import { SortableHeader } from "@/features/admin/components/SortableHeader";
 import { UserDetailDialog } from "@/features/admin/components/UserDetailDialog";
 import { Pagination } from "@/features/admin/components/Pagination";
 import { resolveProfileUrl } from "@/shared/utils/url";
@@ -30,12 +32,18 @@ export function UserTab() {
   const [bannedFilter, setBannedFilter] = useState<boolean | undefined>(undefined);
   const [page, setPage] = useState(0);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const { sort, toggleSort } = useSortState();
 
-  const { data, isLoading } = useUsers(submittedSearch || undefined, bannedFilter, page);
+  const { data, isLoading } = useUsers(submittedSearch || undefined, bannedFilter, sort, page);
 
   function handleSearch(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setSubmittedSearch(search);
+    setPage(0);
+  }
+
+  function handleSortChange(field: string) {
+    toggleSort(field);
     setPage(0);
   }
 
@@ -76,11 +84,36 @@ export function UserTab() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b-4 border-black dark:border-white bg-gray-100 dark:bg-gray-800">
-                  <th className="text-left px-4 py-3 font-black">사용자</th>
+                  <SortableHeader
+                    field="nickname"
+                    label="사용자"
+                    align="left"
+                    currentSort={sort}
+                    onSortChange={handleSortChange}
+                    className="px-4 py-3"
+                  />
                   <th className="text-center px-3 py-3 font-black w-24">프로바이더</th>
-                  <th className="text-center px-3 py-3 font-black w-24">역할</th>
-                  <th className="text-center px-3 py-3 font-black w-20">상태</th>
-                  <th className="text-center px-3 py-3 font-black w-32">가입일</th>
+                  <SortableHeader
+                    field="role"
+                    label="역할"
+                    currentSort={sort}
+                    onSortChange={handleSortChange}
+                    className="px-3 py-3 w-24"
+                  />
+                  <SortableHeader
+                    field="banned"
+                    label="상태"
+                    currentSort={sort}
+                    onSortChange={handleSortChange}
+                    className="px-3 py-3 w-20"
+                  />
+                  <SortableHeader
+                    field="createdAt"
+                    label="가입일"
+                    currentSort={sort}
+                    onSortChange={handleSortChange}
+                    className="px-3 py-3 w-32"
+                  />
                   <th className="text-center px-3 py-3 font-black w-20">액션</th>
                 </tr>
               </thead>

--- a/frontend/src/features/admin/hooks/useAdminSentences.ts
+++ b/frontend/src/features/admin/hooks/useAdminSentences.ts
@@ -13,10 +13,10 @@ import {
   uploadCsv,
 } from "@/features/admin/api";
 
-export function useSentences(status?: string, page = 0, size = 20) {
+export function useSentences(status?: string, sort?: string, page = 0, size = 20) {
   return useQuery({
-    queryKey: ["admin", "sentences", status, page, size],
-    queryFn: () => getSentences(status, page, size),
+    queryKey: ["admin", "sentences", status, sort, page, size],
+    queryFn: () => getSentences(status, sort, page, size),
   });
 }
 

--- a/frontend/src/features/admin/hooks/useAdminSystem.ts
+++ b/frontend/src/features/admin/hooks/useAdminSystem.ts
@@ -75,9 +75,9 @@ export function useResetRateLimit() {
   return useMutation({ mutationFn: resetRateLimit });
 }
 
-export function useAuditLogs(action?: string, dateFrom?: string, dateTo?: string, page = 0, size = 20) {
+export function useAuditLogs(action?: string, dateFrom?: string, dateTo?: string, sort?: string, page = 0, size = 20) {
   return useQuery({
-    queryKey: ["admin", "system", "audit-logs", action, dateFrom, dateTo, page, size],
-    queryFn: () => getAuditLogs(action, dateFrom, dateTo, page, size),
+    queryKey: ["admin", "system", "audit-logs", action, dateFrom, dateTo, sort, page, size],
+    queryFn: () => getAuditLogs(action, dateFrom, dateTo, sort, page, size),
   });
 }

--- a/frontend/src/features/admin/hooks/useAdminUsers.ts
+++ b/frontend/src/features/admin/hooks/useAdminUsers.ts
@@ -11,10 +11,10 @@ import {
   unbanUser,
 } from "@/features/admin/api";
 
-export function useUsers(nickname?: string, banned?: boolean, page = 0, size = 20) {
+export function useUsers(nickname?: string, banned?: boolean, sort?: string, page = 0, size = 20) {
   return useQuery({
-    queryKey: ["admin", "users", nickname, banned, page, size],
-    queryFn: () => getUsers(nickname, banned, page, size),
+    queryKey: ["admin", "users", nickname, banned, sort, page, size],
+    queryFn: () => getUsers(nickname, banned, sort, page, size),
   });
 }
 

--- a/frontend/src/features/admin/hooks/useSortState.ts
+++ b/frontend/src/features/admin/hooks/useSortState.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from "react";
+
+export function useSortState(initial?: string) {
+  const [sort, setSort] = useState<string | undefined>(initial);
+
+  const toggleSort = useCallback((field: string) => {
+    setSort((prev) => {
+      if (!prev) {
+        return `${field},desc`;
+      }
+      const [prevField, prevDir] = prev.split(",");
+      if (prevField === field) {
+        return `${field},${prevDir === "desc" ? "asc" : "desc"}`;
+      }
+      return `${field},desc`;
+    });
+  }, []);
+
+  return { sort, toggleSort };
+}


### PR DESCRIPTION
## 관련 이슈

Closes #154

## 변경 사항

- **백엔드 정렬 인프라**: `admin/sort` 패키지에 `SortField` 인터페이스 + 도메인별 enum(`UserSortField`/`SentenceSortField`/`AuditLogSortField`) 화이트리스트 도입. `SortRequestParser`가 `?sort=field,dir`을 파싱하고 잘못된 필드/방향은 `BusinessException(VALIDATION_FAILED)` → 400으로 차단. entityField는 enum 정의 시점 하드코딩이라 외부 입력의 SQL/JPA Sort 직결 차단
- **3개 컨트롤러**(`AdminUser`/`Sentence`/`SystemController`)에 `sort` RequestParam + `@Operation` description으로 가능 필드/기본값/오류 명세. 서비스에서 `Sort.and(id desc)` tiebreaker로 페이지 경계 안정성 보장
- **V16 인덱스 추가**: `daily_sentences (status, created_at DESC)` 복합 + `daily_sentences (scheduled_at)` 단일
- **프론트엔드**: `useSortState` 훅 + `SortableHeader` 컴포넌트 신설. 비활성 컬럼은 회색 `⇅` 아이콘으로 정렬 가능 시각화, 활성 컬럼은 노란 배경 + 박스로 감싼 ▲/▼ + underline-offset으로 어떤 컬럼이 정렬 중인지 즉시 식별
- **테이블 적용**: `UserTab`(사용자/역할/상태/가입일) / `SentenceTab`(문장/상태/출제일/예약일, `usedAt` 포함) / `AuditLogViewer`(시간/액션). 정렬 변경 시 `setPage(0)` 리셋 일관 적용
- **a11y**: `<th scope="col" aria-sort="ascending|descending|none">` + `<button title>`로 호버 안내(`클릭하여 정렬` / `오름차순/내림차순 정렬 중`)
- **테스트**: `SortRequestParserTest` 14건(defaults/valid/invalid 그룹화 + nested entityField 매핑) + `AdminSortIntegrationTest` 8건(도메인별 정상/필터 결합/누락/화이트리스트 외/방향 오류 + Sentence usedAt)
- **문서**: `docs/design-system.md`에 테이블 정렬 헤더 subsection 추가 (인디케이터 스펙, 클릭 동작, a11y, 백엔드 계약)

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다