### PR TITLE
refactor: 백엔드 코드 일관성 일괄 정리

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSystemController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSystemController.java
@@ -21,7 +21,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -44,7 +43,6 @@ public class AdminSystemController {
   @Operation(summary = "공지 목록 조회")
   @AdminErrorResponses
   @GetMapping("/announcements")
-  @Transactional(readOnly = true)
   public ResponseEntity<List<AnnouncementResponse>> getAnnouncements() {
     return ResponseEntity.ok(adminSystemService.getAnnouncements());
   }
@@ -102,7 +100,6 @@ public class AdminSystemController {
   @Operation(summary = "시스템 상태 조회")
   @AdminErrorResponses
   @GetMapping("/status")
-  @Transactional(readOnly = true)
   public ResponseEntity<SystemStatusResponse> getSystemStatus() {
     return ResponseEntity.ok(adminSystemService.getSystemStatus());
   }
@@ -135,7 +132,6 @@ public class AdminSystemController {
           - 잘못된 필드/방향: 400 `VALIDATION_FAILED`""")
   @AdminErrorResponses
   @GetMapping("/audit-logs")
-  @Transactional(readOnly = true)
   public ResponseEntity<AuditLogListResponse> getAuditLogs(
       @RequestParam(required = false) String action,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminUserController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminUserController.java
@@ -8,6 +8,7 @@ import com.gakkaweo.backend.admin.dto.UserGameHistoryResponse;
 import com.gakkaweo.backend.admin.dto.UserListResponse;
 import com.gakkaweo.backend.admin.service.AdminUserService;
 import com.gakkaweo.backend.auth.security.CustomUserDetails;
+import com.gakkaweo.backend.auth.service.MemberRedisSyncer;
 import com.gakkaweo.backend.config.openapi.AdminErrorResponses;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -19,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -39,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminUserController {
 
   private final AdminUserService adminUserService;
+  private final MemberRedisSyncer memberRedisSyncer;
 
   @Operation(
       summary = "사용자 목록 조회",
@@ -50,7 +51,6 @@ public class AdminUserController {
           - 잘못된 필드/방향: 400 `VALIDATION_FAILED`""")
   @AdminErrorResponses
   @GetMapping
-  @Transactional(readOnly = true)
   public ResponseEntity<UserListResponse> getUsers(
       @RequestParam(required = false) String nickname,
       @RequestParam(required = false) Boolean banned,
@@ -63,7 +63,6 @@ public class AdminUserController {
   @Operation(summary = "사용자 상세 조회")
   @AdminErrorResponses
   @GetMapping("/{publicId}")
-  @Transactional(readOnly = true)
   public ResponseEntity<UserDetailResponse> getUserDetail(@PathVariable UUID publicId) {
     return ResponseEntity.ok(adminUserService.getUserDetail(publicId));
   }
@@ -71,7 +70,6 @@ public class AdminUserController {
   @Operation(summary = "사용자 게임 이력 조회")
   @AdminErrorResponses
   @GetMapping("/{publicId}/history")
-  @Transactional(readOnly = true)
   public ResponseEntity<UserGameHistoryResponse> getUserHistory(@PathVariable UUID publicId) {
     return ResponseEntity.ok(adminUserService.getUserHistory(publicId));
   }
@@ -173,7 +171,7 @@ public class AdminUserController {
     AdminUserResponse response =
         adminUserService.forceChangeNickname(
             publicId, userDetails.publicId(), request, httpRequest.getRemoteAddr());
-    adminUserService.syncNicknameToRedis(publicId, response.nickname());
+    memberRedisSyncer.updateNickname(publicId, response.nickname());
     return ResponseEntity.ok(response);
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/admin/event/AuditLogNotificationListener.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/event/AuditLogNotificationListener.java
@@ -22,7 +22,7 @@ public class AuditLogNotificationListener {
 
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
   public void onAuditLog(AuditLogEvent event) {
-    if (!notificationProperties.getAuditAlert().enabled()) {
+    if (!notificationProperties.auditAlert().enabled()) {
       return;
     }
 

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminAuditService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminAuditService.java
@@ -29,6 +29,21 @@ public class AdminAuditService {
   @Transactional
   public void log(
       Member admin, AuditAction action, String targetId, String detail, String ipAddress) {
+    doLog(admin, action, targetId, detail, ipAddress);
+  }
+
+  @Transactional
+  public void log(
+      UUID adminPublicId, AuditAction action, String targetId, String detail, String ipAddress) {
+    Member admin =
+        memberRepository
+            .findByPublicId(adminPublicId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    doLog(admin, action, targetId, detail, ipAddress);
+  }
+
+  private void doLog(
+      Member admin, AuditAction action, String targetId, String detail, String ipAddress) {
     AuditLog auditLog =
         new AuditLog(admin, action, action.targetType(), targetId, detail, ipAddress);
     auditLogRepository.save(auditLog);
@@ -47,15 +62,5 @@ public class AdminAuditService {
             detail,
             ipAddress,
             clock.instant()));
-  }
-
-  @Transactional
-  public void log(
-      UUID adminPublicId, AuditAction action, String targetId, String detail, String ipAddress) {
-    Member admin =
-        memberRepository
-            .findByPublicId(adminPublicId)
-            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-    log(admin, action, targetId, detail, ipAddress);
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -17,6 +17,7 @@ import com.gakkaweo.backend.admin.sort.SortSpecBuilder;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.common.redis.RedisKeyConstants;
+import com.gakkaweo.backend.common.util.EnumParser;
 import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
@@ -48,6 +49,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 @RequiredArgsConstructor
 public class AdminSentenceService {
 
+  private static final BigDecimal DUPLICATE_THRESHOLD = new BigDecimal("80.0");
+
   private final DailySentenceRepository dailySentenceRepository;
   private final GameSessionRepository gameSessionRepository;
   private final GuessHistoryRepository guessHistoryRepository;
@@ -60,16 +63,11 @@ public class AdminSentenceService {
 
   @Transactional(readOnly = true)
   public SentenceListResponse getSentences(String status, String sort, int page, int size) {
-    final DailySentenceStatus statusEnum;
-    if (status != null && !status.isBlank()) {
-      try {
-        statusEnum = DailySentenceStatus.valueOf(status.toUpperCase());
-      } catch (IllegalArgumentException e) {
-        throw new BusinessException(ErrorCode.VALIDATION_FAILED);
-      }
-    } else {
-      statusEnum = null;
-    }
+    final DailySentenceStatus statusEnum =
+        (status != null && !status.isBlank())
+            ? EnumParser.parseOrThrow(
+                DailySentenceStatus.class, status, ErrorCode.VALIDATION_FAILED)
+            : null;
 
     SortRequestParser.SortSpec sortSpec =
         SortRequestParser.parse(
@@ -217,12 +215,11 @@ public class AdminSentenceService {
         dailySentenceRepository.findAll().stream().map(DailySentence::getSentence).toList();
 
     List<DuplicateCheckResponse.SimilarEntry> similarEntries = new ArrayList<>();
-    BigDecimal threshold = new BigDecimal("80.0");
 
     for (String existing : existingSentences) {
       try {
         BigDecimal score = similarityService.testSimilarity(existing, request.sentence());
-        if (score.compareTo(threshold) >= 0) {
+        if (score.compareTo(DUPLICATE_THRESHOLD) >= 0) {
           similarEntries.add(new DuplicateCheckResponse.SimilarEntry(existing, score));
         }
       } catch (Exception e) {

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -13,6 +13,7 @@ import com.gakkaweo.backend.admin.sort.SortSpecBuilder;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.common.redis.RedisKeyConstants;
+import com.gakkaweo.backend.common.util.EnumParser;
 import com.gakkaweo.backend.domain.admin.entity.Announcement;
 import com.gakkaweo.backend.domain.admin.entity.AnnouncementType;
 import com.gakkaweo.backend.domain.admin.entity.AuditAction;
@@ -70,16 +71,10 @@ public class AdminSystemService {
 
   private static Specification<AuditLog> auditLogFilters(
       String action, Instant dateFrom, Instant dateTo) {
-    final AuditAction actionEnum;
-    if (action != null && !action.isBlank()) {
-      try {
-        actionEnum = AuditAction.valueOf(action);
-      } catch (IllegalArgumentException e) {
-        throw new BusinessException(ErrorCode.VALIDATION_FAILED);
-      }
-    } else {
-      actionEnum = null;
-    }
+    final AuditAction actionEnum =
+        (action != null && !action.isBlank())
+            ? EnumParser.parseOrThrow(AuditAction.class, action, ErrorCode.VALIDATION_FAILED)
+            : null;
     return (root, query, cb) -> {
       if (Long.class != query.getResultType()) {
         root.fetch("admin", JoinType.LEFT);
@@ -113,7 +108,7 @@ public class AdminSystemService {
     AnnouncementResponse response =
         transactionTemplate.execute(
             status -> {
-              Member admin = findMember(adminPublicId);
+              Member admin = findByPublicIdOrThrow(adminPublicId);
               Announcement announcement =
                   new Announcement(
                       admin,
@@ -180,7 +175,7 @@ public class AdminSystemService {
       Instant now = clock.instant();
       if (!response.startsAt().isAfter(now)
           && (response.endsAt() == null || !response.endsAt().isBefore(now))) {
-        AnnouncementType type = AnnouncementType.valueOf(response.type());
+        AnnouncementType type = parseAnnouncementType(response.type());
         eventPublisher.publishEvent(
             new AnnouncementEvent(response.id(), response.title(), response.content(), type));
       }
@@ -283,7 +278,7 @@ public class AdminSystemService {
         .orElseThrow(() -> new BusinessException(ErrorCode.ANNOUNCEMENT_NOT_FOUND));
   }
 
-  private Member findMember(UUID publicId) {
+  private Member findByPublicIdOrThrow(UUID publicId) {
     return memberRepository
         .findByPublicId(publicId)
         .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
@@ -296,11 +291,7 @@ public class AdminSystemService {
   }
 
   private AnnouncementType parseAnnouncementType(String type) {
-    try {
-      return AnnouncementType.valueOf(type);
-    } catch (IllegalArgumentException e) {
-      throw new BusinessException(ErrorCode.VALIDATION_FAILED);
-    }
+    return EnumParser.parseOrThrow(AnnouncementType.class, type, ErrorCode.VALIDATION_FAILED);
   }
 
   private boolean isCurrentlyActiveByTime(Instant startsAt, Instant endsAt) {

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -11,10 +11,11 @@ import com.gakkaweo.backend.admin.dto.UserListResponse;
 import com.gakkaweo.backend.admin.sort.SortRequestParser;
 import com.gakkaweo.backend.admin.sort.SortSpecBuilder;
 import com.gakkaweo.backend.admin.sort.UserSortField;
+import com.gakkaweo.backend.auth.service.MemberRedisSyncer;
 import com.gakkaweo.backend.auth.service.ProfileImageService;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
-import com.gakkaweo.backend.common.redis.RedisKeyConstants;
+import com.gakkaweo.backend.common.util.EnumParser;
 import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import com.gakkaweo.backend.domain.admin.repository.SentenceUploadRepository;
 import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
@@ -30,11 +31,9 @@ import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import jakarta.persistence.criteria.Predicate;
 import java.time.Clock;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +43,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,8 +58,8 @@ public class AdminUserService {
   private final RefreshTokenRepository refreshTokenRepository;
   private final SentenceUploadRepository sentenceUploadRepository;
   private final ProfileImageService profileImageService;
+  private final MemberRedisSyncer memberRedisSyncer;
   private final NicknameValidator nicknameValidator;
-  private final StringRedisTemplate redisTemplate;
   private final ApplicationEventPublisher eventPublisher;
   private final RankingService rankingService;
   private final AdminAuditService adminAuditService;
@@ -101,7 +99,7 @@ public class AdminUserService {
 
   @Transactional(readOnly = true)
   public UserDetailResponse getUserDetail(UUID publicId) {
-    Member member = findMember(publicId);
+    Member member = findByPublicIdOrThrow(publicId);
 
     long totalParticipations = gameSessionRepository.countByMember(member);
     long totalClears = gameSessionRepository.countClearedByMember(member);
@@ -118,7 +116,7 @@ public class AdminUserService {
 
   @Transactional(readOnly = true)
   public UserGameHistoryResponse getUserHistory(UUID publicId) {
-    Member member = findMember(publicId);
+    Member member = findByPublicIdOrThrow(publicId);
 
     List<GameSession> sessions = gameSessionRepository.findByMemberWithSentence(member);
     List<GameHistoryEntry> history = sessions.stream().map(GameHistoryEntry::from).toList();
@@ -131,13 +129,9 @@ public class AdminUserService {
       UUID targetPublicId, UUID adminPublicId, RoleChangeRequest request, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
-    Member member = findMember(targetPublicId);
-    MemberRole newRole;
-    try {
-      newRole = MemberRole.valueOf(request.role());
-    } catch (IllegalArgumentException e) {
-      throw new BusinessException(ErrorCode.VALIDATION_FAILED);
-    }
+    Member member = findByPublicIdOrThrow(targetPublicId);
+    MemberRole newRole =
+        EnumParser.parseOrThrow(MemberRole.class, request.role(), ErrorCode.VALIDATION_FAILED);
 
     if (member.getRole() == newRole) {
       throw new BusinessException(ErrorCode.ROLE_ALREADY_ASSIGNED);
@@ -157,13 +151,13 @@ public class AdminUserService {
   public void banUser(UUID targetPublicId, UUID adminPublicId, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
-    Member member = findMember(targetPublicId);
+    Member member = findByPublicIdOrThrow(targetPublicId);
     Long memberId = member.getId();
 
     // clearAutomatically=true로 영속성 컨텍스트 초기화됨 → delete 먼저, 재조회 후 set
     refreshTokenRepository.deleteByMemberId(memberId);
 
-    Member reloaded = findMember(targetPublicId);
+    Member reloaded = findByPublicIdOrThrow(targetPublicId);
     reloaded.setBanned(true);
     reloaded.setBannedAt(clock.instant());
 
@@ -176,7 +170,7 @@ public class AdminUserService {
   public void unbanUser(UUID targetPublicId, UUID adminPublicId, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
-    Member member = findMember(targetPublicId);
+    Member member = findByPublicIdOrThrow(targetPublicId);
     member.setBanned(false);
     member.setBannedAt(null);
 
@@ -189,7 +183,7 @@ public class AdminUserService {
   public void forceDeleteUser(UUID targetPublicId, UUID adminPublicId, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
-    Member member = findMember(targetPublicId);
+    Member member = findByPublicIdOrThrow(targetPublicId);
 
     gameSessionRepository.anonymizeByMember(member);
     sentenceUploadRepository.anonymizeByAdmin(member);
@@ -218,7 +212,7 @@ public class AdminUserService {
       UUID targetPublicId, UUID adminPublicId, ForceNicknameRequest request, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
-    Member member = findMember(targetPublicId);
+    Member member = findByPublicIdOrThrow(targetPublicId);
     String nickname = nicknameValidator.normalize(request.nickname());
     nicknameValidator.validate(nickname);
 
@@ -244,25 +238,11 @@ public class AdminUserService {
     return toUserResponse(member);
   }
 
-  public void syncNicknameToRedis(UUID publicId, String nickname) {
-    try {
-      LocalDate today = LocalDate.now(clock);
-      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
-
-      if (redisTemplate.hasKey(detailKey)) {
-        redisTemplate.opsForHash().put(detailKey, "nickname", nickname);
-        eventPublisher.publishEvent(new RankingUpdateEvent());
-      }
-    } catch (Exception e) {
-      log.warn("닉네임 Redis 동기화 실패: publicId={}", publicId, e);
-    }
-  }
-
   @Transactional
   public void forceDeleteProfileImage(UUID targetPublicId, UUID adminPublicId, String ipAddress) {
     preventSelfAction(targetPublicId, adminPublicId);
 
-    Member member = findMember(targetPublicId);
+    Member member = findByPublicIdOrThrow(targetPublicId);
     member.setProfileUrl(null);
     adminAuditService.log(
         adminPublicId,
@@ -274,24 +254,10 @@ public class AdminUserService {
 
   public void cleanupProfileImageAndRedis(UUID publicId) {
     profileImageService.delete(publicId);
-    syncProfileUrlToRedis(publicId, null);
+    memberRedisSyncer.updateProfileUrl(publicId, null);
   }
 
-  private void syncProfileUrlToRedis(UUID publicId, String profileUrl) {
-    try {
-      LocalDate today = LocalDate.now(clock);
-      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
-
-      if (redisTemplate.hasKey(detailKey)) {
-        redisTemplate.opsForHash().put(detailKey, "profileUrl", Objects.toString(profileUrl, ""));
-        eventPublisher.publishEvent(new RankingUpdateEvent());
-      }
-    } catch (Exception e) {
-      log.warn("프로필 URL Redis 동기화 실패: publicId={}", publicId, e);
-    }
-  }
-
-  private Member findMember(UUID publicId) {
+  private Member findByPublicIdOrThrow(UUID publicId) {
     return memberRepository
         .findByPublicId(publicId)
         .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));

--- a/backend/src/main/java/com/gakkaweo/backend/admin/sort/SortRequestParser.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/sort/SortRequestParser.java
@@ -9,8 +9,6 @@ public final class SortRequestParser {
 
   private SortRequestParser() {}
 
-  public record SortSpec(String entityField, Sort.Direction direction) {}
-
   public static <E extends Enum<E> & SortField> SortSpec parse(
       String raw, Class<E> enumType, E defaultField, Sort.Direction defaultDirection) {
     if (raw == null || raw.isBlank()) {
@@ -51,4 +49,6 @@ public final class SortRequestParser {
 
     return new SortSpec(matched.entityField(), direction);
   }
+
+  public record SortSpec(String entityField, Sort.Direction direction) {}
 }

--- a/backend/src/main/java/com/gakkaweo/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.gakkaweo.backend.auth.security.CustomUserDetails;
 import com.gakkaweo.backend.auth.service.AccountService;
 import com.gakkaweo.backend.auth.service.AuthService;
 import com.gakkaweo.backend.auth.service.LocalAuthService;
+import com.gakkaweo.backend.auth.service.MemberRedisSyncer;
 import com.gakkaweo.backend.auth.service.ProfileImageService;
 import com.gakkaweo.backend.auth.util.CookieUtils;
 import com.gakkaweo.backend.config.openapi.StandardErrorResponses;
@@ -47,6 +48,7 @@ public class AuthController {
   private final LocalAuthService localAuthService;
   private final AccountService accountService;
   private final ProfileImageService profileImageService;
+  private final MemberRedisSyncer memberRedisSyncer;
   private final CookieUtils cookieUtils;
 
   @Operation(
@@ -169,7 +171,7 @@ public class AuthController {
       @Valid @RequestBody NicknameUpdateRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     AuthResponse response = authService.changeNickname(userDetails.publicId(), request.nickname());
-    authService.syncNicknameToRedis(userDetails.publicId(), response.nickname());
+    memberRedisSyncer.updateNickname(userDetails.publicId(), response.nickname());
     return ResponseEntity.ok(response);
   }
 
@@ -188,7 +190,7 @@ public class AuthController {
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     String profileUrl = profileImageService.save(userDetails.publicId(), file);
     AuthResponse response = authService.updateProfileUrl(userDetails.publicId(), profileUrl);
-    authService.syncProfileUrlToRedis(userDetails.publicId(), response.profileUrl());
+    memberRedisSyncer.updateProfileUrl(userDetails.publicId(), response.profileUrl());
     return ResponseEntity.ok(response);
   }
 
@@ -200,7 +202,7 @@ public class AuthController {
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     AuthResponse response = authService.updateProfileUrl(userDetails.publicId(), null);
     profileImageService.delete(userDetails.publicId());
-    authService.syncProfileUrlToRedis(userDetails.publicId(), null);
+    memberRedisSyncer.updateProfileUrl(userDetails.publicId(), null);
     return ResponseEntity.ok(response);
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/CustomOAuth2UserService.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
+  private static final String OAUTH2_BANNED_ERROR_CODE = "member_banned";
+
   private final OAuthMemberService oAuthMemberService;
 
   @Override
@@ -31,10 +33,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     if (Boolean.TRUE.equals(member.getBanned())) {
       throw new OAuth2AuthenticationException(
-          new OAuth2Error(
-              ErrorCode.MEMBER_BANNED.name().toLowerCase(),
-              ErrorCode.MEMBER_BANNED.getMessage(),
-              null));
+          new OAuth2Error(OAUTH2_BANNED_ERROR_CODE, ErrorCode.MEMBER_BANNED.getMessage(), null));
     }
 
     return new CustomOAuth2User(member, oAuth2User.getAttributes());

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AuthService.java
@@ -10,16 +10,12 @@ import com.gakkaweo.backend.domain.auth.entity.RefreshToken;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import com.gakkaweo.backend.domain.member.validation.NicknameValidator;
-import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
 import io.jsonwebtoken.Claims;
 import java.time.Clock;
 import java.time.Duration;
-import java.time.LocalDate;
-import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -35,7 +31,6 @@ public class AuthService {
   private final MemberRepository memberRepository;
   private final NicknameValidator nicknameValidator;
   private final StringRedisTemplate redisTemplate;
-  private final ApplicationEventPublisher eventPublisher;
   private final Clock clock;
 
   @Transactional
@@ -126,33 +121,5 @@ public class AuthService {
     member.setProfileUrl(profileUrl);
 
     return AuthResponse.from(member);
-  }
-
-  public void syncProfileUrlToRedis(UUID publicId, String profileUrl) {
-    try {
-      LocalDate today = LocalDate.now(clock);
-      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
-
-      if (redisTemplate.hasKey(detailKey)) {
-        redisTemplate.opsForHash().put(detailKey, "profileUrl", Objects.toString(profileUrl, ""));
-        eventPublisher.publishEvent(new RankingUpdateEvent());
-      }
-    } catch (Exception e) {
-      log.warn("프로필 URL Redis 동기화 실패: publicId={}", publicId, e);
-    }
-  }
-
-  public void syncNicknameToRedis(UUID publicId, String nickname) {
-    try {
-      LocalDate today = LocalDate.now(clock);
-      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
-
-      if (redisTemplate.hasKey(detailKey)) {
-        redisTemplate.opsForHash().put(detailKey, "nickname", nickname);
-        eventPublisher.publishEvent(new RankingUpdateEvent());
-      }
-    } catch (Exception e) {
-      log.warn("닉네임 Redis 동기화 실패: publicId={}", publicId, e);
-    }
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/MemberRedisSyncer.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/MemberRedisSyncer.java
@@ -1,0 +1,44 @@
+package com.gakkaweo.backend.auth.service;
+
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
+import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MemberRedisSyncer {
+
+  private final StringRedisTemplate redisTemplate;
+  private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
+
+  public void updateProfileUrl(UUID publicId, String profileUrl) {
+    updateRankingDetailField(publicId, "profileUrl", Objects.toString(profileUrl, ""));
+  }
+
+  public void updateNickname(UUID publicId, String nickname) {
+    updateRankingDetailField(publicId, "nickname", nickname);
+  }
+
+  private void updateRankingDetailField(UUID publicId, String field, String value) {
+    try {
+      LocalDate today = LocalDate.now(clock);
+      String detailKey = RedisKeyConstants.rankingDetailKey(today, publicId);
+      if (redisTemplate.hasKey(detailKey)) {
+        redisTemplate.opsForHash().put(detailKey, field, value);
+        eventPublisher.publishEvent(new RankingUpdateEvent());
+      }
+    } catch (Exception e) {
+      log.warn("랭킹 detail Redis 동기화 실패: publicId={}, field={}", publicId, field, e);
+    }
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/common/redis/RedisKeyConstants.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/redis/RedisKeyConstants.java
@@ -1,16 +1,16 @@
 package com.gakkaweo.backend.common.redis;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.Set;
 import java.util.UUID;
 
 public final class RedisKeyConstants {
 
-  public static final String BLACKLIST_PREFIX = "blacklist:jti:";
-  public static final String RANKING_KEY_PREFIX = "ranking:";
-  public static final String RANKING_DETAIL_PREFIX = "ranking_detail:";
-  public static final String SIMILARITY_CACHE_PREFIX = "similarity:";
-
+  private static final String BLACKLIST_PREFIX = "blacklist:jti:";
+  private static final String RANKING_KEY_PREFIX = "ranking:";
+  private static final String RANKING_DETAIL_PREFIX = "ranking_detail:";
+  private static final String SIMILARITY_CACHE_PREFIX = "similarity:";
   private static final String RANKING_MEMBER_PREFIX = "member:";
 
   private static final Set<String> KNOWN_PREFIXES =
@@ -44,5 +44,37 @@ public final class RedisKeyConstants {
 
   public static String similarityCacheKey(Long sentenceId, String hash) {
     return SIMILARITY_CACHE_PREFIX + sentenceId + ":" + hash;
+  }
+
+  public static String rankingScanPattern() {
+    return RANKING_KEY_PREFIX + "*";
+  }
+
+  public static String rankingDetailScanPattern() {
+    return RANKING_DETAIL_PREFIX + "*";
+  }
+
+  public static LocalDate extractDateFromRankingKey(String key) {
+    if (!key.startsWith(RANKING_KEY_PREFIX)) {
+      return null;
+    }
+    return parseLeadingDate(key.substring(RANKING_KEY_PREFIX.length()));
+  }
+
+  public static LocalDate extractDateFromDetailKey(String key) {
+    if (!key.startsWith(RANKING_DETAIL_PREFIX)) {
+      return null;
+    }
+    return parseLeadingDate(key.substring(RANKING_DETAIL_PREFIX.length()));
+  }
+
+  private static LocalDate parseLeadingDate(String body) {
+    int colonIdx = body.indexOf(':');
+    String datePart = colonIdx == -1 ? body : body.substring(0, colonIdx);
+    try {
+      return LocalDate.parse(datePart);
+    } catch (DateTimeParseException e) {
+      return null;
+    }
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/common/util/EnumParser.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/util/EnumParser.java
@@ -1,0 +1,22 @@
+package com.gakkaweo.backend.common.util;
+
+import com.gakkaweo.backend.common.exception.BusinessException;
+import com.gakkaweo.backend.common.exception.ErrorCode;
+import java.util.Locale;
+
+public final class EnumParser {
+
+  private EnumParser() {}
+
+  public static <E extends Enum<E>> E parseOrThrow(
+      Class<E> enumClass, String value, ErrorCode errorCode) {
+    if (value == null) {
+      throw new BusinessException(errorCode);
+    }
+    try {
+      return Enum.valueOf(enumClass, value.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new BusinessException(errorCode);
+    }
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/config/openapi/SwaggerConfigController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/openapi/SwaggerConfigController.java
@@ -1,9 +1,7 @@
 package com.gakkaweo.backend.config.openapi;
 
 import io.swagger.v3.oas.annotations.Hidden;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
@@ -24,17 +22,18 @@ public class SwaggerConfigController {
   private final SwaggerUiConfigProperties swaggerUiConfigProperties;
 
   @GetMapping("/v3/api-docs/swagger-config")
-  public ResponseEntity<Map<String, Object>> swaggerConfig() {
-    Map<String, Object> config = new LinkedHashMap<>();
-    config.put("configUrl", "/v3/api-docs/swagger-config");
-    config.put("urls", filterUrlsByRole());
-    config.put("operationsSorter", swaggerUiConfigProperties.getOperationsSorter());
-    config.put("tagsSorter", swaggerUiConfigProperties.getTagsSorter());
-    config.put("validatorUrl", "");
+  public ResponseEntity<SwaggerConfig> swaggerConfig() {
+    SwaggerConfig config =
+        new SwaggerConfig(
+            "/v3/api-docs/swagger-config",
+            filterUrlsByRole(),
+            swaggerUiConfigProperties.getOperationsSorter(),
+            swaggerUiConfigProperties.getTagsSorter(),
+            "");
     return ResponseEntity.ok().cacheControl(CacheControl.noStore()).body(config);
   }
 
-  private List<Map<String, String>> filterUrlsByRole() {
+  private List<SwaggerConfig.SwaggerUrl> filterUrlsByRole() {
     boolean isAdmin = hasAdminRole();
 
     return groupedOpenApis.stream()
@@ -50,12 +49,9 @@ public class SwaggerConfigController {
               return true;
             })
         .map(
-            group -> {
-              Map<String, String> entry = new LinkedHashMap<>();
-              entry.put("url", "/v3/api-docs/" + group.getGroup());
-              entry.put("name", group.getDisplayName());
-              return entry;
-            })
+            group ->
+                new SwaggerConfig.SwaggerUrl(
+                    "/v3/api-docs/" + group.getGroup(), group.getDisplayName()))
         .toList();
   }
 
@@ -67,5 +63,15 @@ public class SwaggerConfigController {
     return authentication.getAuthorities().stream()
         .map(GrantedAuthority::getAuthority)
         .anyMatch("ROLE_ADMIN"::equals);
+  }
+
+  public record SwaggerConfig(
+      String configUrl,
+      List<SwaggerUrl> urls,
+      String operationsSorter,
+      String tagsSorter,
+      String validatorUrl) {
+
+    public record SwaggerUrl(String url, String name) {}
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/GameConstants.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/GameConstants.java
@@ -1,0 +1,10 @@
+package com.gakkaweo.backend.domain.game;
+
+import java.math.BigDecimal;
+
+public final class GameConstants {
+
+  public static final BigDecimal PERFECT_SIMILARITY = new BigDecimal("100");
+
+  private GameConstants() {}
+}

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.domain.game.entity;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.gakkaweo.backend.domain.game.GameConstants;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -83,7 +84,7 @@ public class GameSession {
   }
 
   public void updateClearedAt(Instant now) {
-    if (this.bestSimilarity.compareTo(new BigDecimal("100")) < 0) {
+    if (this.bestSimilarity.compareTo(GameConstants.PERFECT_SIMILARITY) < 0) {
       this.clearedAt = now;
     }
   }

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -4,6 +4,7 @@ import static com.gakkaweo.backend.common.time.TimeConstants.KST;
 
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.domain.game.GameConstants;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.entity.GameSession;
 import com.gakkaweo.backend.domain.game.entity.GuessHistory;
@@ -56,7 +57,7 @@ public class DailyGameService {
   private final Clock clock;
 
   private static boolean isPerfect(BigDecimal similarity) {
-    return similarity.compareTo(new BigDecimal("100")) >= 0;
+    return similarity.compareTo(GameConstants.PERFECT_SIMILARITY) >= 0;
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/ServerErrorNotifier.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/ServerErrorNotifier.java
@@ -28,7 +28,7 @@ public class ServerErrorNotifier {
 
   public void notify(Exception ex, HttpServletRequest request) {
     try {
-      NotificationProperties.ErrorAlert config = notificationProperties.getErrorAlert();
+      NotificationProperties.ErrorAlert config = notificationProperties.errorAlert();
       if (!config.enabled()) {
         return;
       }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/config/NotificationProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/config/NotificationProperties.java
@@ -1,17 +1,10 @@
 package com.gakkaweo.backend.infra.notification.config;
 
 import java.time.Duration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.notification")
-@Getter
-@RequiredArgsConstructor
-public class NotificationProperties {
-
-  private final AuditAlert auditAlert;
-  private final ErrorAlert errorAlert;
+public record NotificationProperties(AuditAlert auditAlert, ErrorAlert errorAlert) {
 
   public record AuditAlert(boolean enabled) {}
 

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/dedup/NotificationDeduplicationCache.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/dedup/NotificationDeduplicationCache.java
@@ -38,7 +38,7 @@ public class NotificationDeduplicationCache {
 
   @Scheduled(fixedDelayString = "${app.notification.dedup.cleanup-interval-ms:300000}")
   public void cleanup() {
-    Duration retention = notificationProperties.getErrorAlert().cooldown().multipliedBy(2);
+    Duration retention = notificationProperties.errorAlert().cooldown().multipliedBy(2);
     Instant expiry = clock.instant().minus(retention);
     int before = lastSentAt.size();
     lastSentAt.entrySet().removeIf(entry -> entry.getValue().isBefore(expiry));

--- a/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupScheduler.java
@@ -9,10 +9,10 @@ import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
 import java.time.Clock;
 import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.Cursor;
@@ -64,8 +64,16 @@ public class RedisCleanupScheduler {
     try {
       purgeRetry.executeRunnable(
           () -> {
-            purgedRanking[0] = purgeStaleKeys(RedisKeyConstants.RANKING_KEY_PREFIX + "*", cutoff);
-            purgedDetail[0] = purgeStaleKeys(RedisKeyConstants.RANKING_DETAIL_PREFIX + "*", cutoff);
+            purgedRanking[0] =
+                purgeStaleKeys(
+                    RedisKeyConstants.rankingScanPattern(),
+                    RedisKeyConstants::extractDateFromRankingKey,
+                    cutoff);
+            purgedDetail[0] =
+                purgeStaleKeys(
+                    RedisKeyConstants.rankingDetailScanPattern(),
+                    RedisKeyConstants::extractDateFromDetailKey,
+                    cutoff);
           });
     } catch (Exception e) {
       purgeFailed = true;
@@ -102,12 +110,13 @@ public class RedisCleanupScheduler {
     return count;
   }
 
-  private int purgeStaleKeys(String pattern, LocalDate cutoff) {
+  private int purgeStaleKeys(
+      String pattern, Function<String, LocalDate> dateExtractor, LocalDate cutoff) {
     List<String> targets = new ArrayList<>();
     try (Cursor<String> cursor = openCursor(pattern)) {
       while (cursor.hasNext()) {
         String key = cursor.next();
-        LocalDate keyDate = extractDate(key);
+        LocalDate keyDate = dateExtractor.apply(key);
         if (keyDate == null) {
           log.warn("Redis 키 날짜 파싱 실패 (orphan으로 분류 권장): {}", key);
           continue;
@@ -139,24 +148,6 @@ public class RedisCleanupScheduler {
       }
     }
     return false;
-  }
-
-  private LocalDate extractDate(String key) {
-    String body;
-    if (key.startsWith(RedisKeyConstants.RANKING_DETAIL_PREFIX)) {
-      body = key.substring(RedisKeyConstants.RANKING_DETAIL_PREFIX.length());
-    } else if (key.startsWith(RedisKeyConstants.RANKING_KEY_PREFIX)) {
-      body = key.substring(RedisKeyConstants.RANKING_KEY_PREFIX.length());
-    } else {
-      return null;
-    }
-    int colonIdx = body.indexOf(':');
-    String datePart = colonIdx == -1 ? body : body.substring(0, colonIdx);
-    try {
-      return LocalDate.parse(datePart);
-    } catch (DateTimeParseException e) {
-      return null;
-    }
   }
 
   private void notifyDiscord(RedisCleanupReport report) {

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -5,6 +5,7 @@ import static com.gakkaweo.backend.common.time.TimeConstants.KST;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.common.redis.RedisKeyConstants;
+import com.gakkaweo.backend.domain.game.GameConstants;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.entity.GameSession;
 import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
@@ -42,7 +43,6 @@ public class RankingService {
   private static final int TOP_RANKING_SIZE = 10;
   private static final Duration EXPIRE_TTL = Duration.ofHours(1);
   private static final Duration LIVE_TTL = Duration.ofHours(30);
-  private static final BigDecimal PERFECT_SIMILARITY = new BigDecimal("100");
 
   private final StringRedisTemplate redisTemplate;
   private final DailySentenceRepository dailySentenceRepository;
@@ -352,7 +352,7 @@ public class RankingService {
       BigDecimal similarity, int attemptCount, long elapsedSeconds, Long clearedAtSeconds) {
     long similarityComponent = similarity.multiply(BigDecimal.TEN).longValue() * 1_000_000_000L;
 
-    if (clearedAtSeconds != null && similarity.compareTo(PERFECT_SIMILARITY) >= 0) {
+    if (clearedAtSeconds != null && similarity.compareTo(GameConstants.PERFECT_SIMILARITY) >= 0) {
       return similarityComponent - clearedAtSeconds;
     }
 

--- a/backend/src/test/java/com/gakkaweo/backend/admin/sort/SortRequestParserTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/sort/SortRequestParserTest.java
@@ -13,6 +13,10 @@ import org.springframework.data.domain.Sort;
 
 class SortRequestParserTest {
 
+  private static SortSpec expected(String entityField, Sort.Direction direction) {
+    return new SortSpec(entityField, direction);
+  }
+
   enum TestSortField implements SortField {
     CREATED_AT("createdAt", "createdAt"),
     NICKNAME("nickname", "nickname"),
@@ -35,10 +39,6 @@ class SortRequestParserTest {
     public String entityField() {
       return entityField;
     }
-  }
-
-  private static SortSpec expected(String entityField, Sort.Direction direction) {
-    return new SortSpec(entityField, direction);
   }
 
   @Nested

--- a/backend/src/test/java/com/gakkaweo/backend/game/DailySentenceSchedulerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/game/DailySentenceSchedulerTest.java
@@ -2,6 +2,7 @@ package com.gakkaweo.backend.game;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.gakkaweo.backend.common.redis.RedisKeyConstants;
 import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import com.gakkaweo.backend.domain.game.entity.DailySentenceStatus;
 import com.gakkaweo.backend.domain.game.entity.GameSession;
@@ -20,6 +21,7 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @DisplayName("DailySentenceScheduler 통합 테스트")
@@ -31,6 +33,7 @@ class DailySentenceSchedulerTest extends IntegrationTestBase {
   @Autowired TransactionTemplate transactionTemplate;
   @Autowired Clock schedulerClock;
   @Autowired RankingService rankingService;
+  @Autowired StringRedisTemplate redisTemplate;
 
   @Test
   @DisplayName("executeMidnightJob - 전날 세션 EXPIRED + 오늘 문장 USED + DayChangeEvent 발행")
@@ -152,6 +155,61 @@ class DailySentenceSchedulerTest extends IntegrationTestBase {
     GameSession sessionAfterFirst =
         gameSessionRepository.findByMemberAndSentence(member, yesterdaySentence).orElseThrow();
     Integer rankAfterFirst = sessionAfterFirst.getFinalRank();
+    assertThat(totalAfterFirst).isNotNull().isGreaterThanOrEqualTo(1);
+    assertThat(rankAfterFirst).isNotNull().isGreaterThanOrEqualTo(1);
+
+    scheduler.executeMidnightJob();
+
+    DailySentence afterSecond =
+        dailySentenceRepository.findById(yesterdaySentence.getId()).orElseThrow();
+    GameSession sessionAfterSecond =
+        gameSessionRepository.findByMemberAndSentence(member, yesterdaySentence).orElseThrow();
+
+    assertThat(afterSecond.getTotalPlayers()).isEqualTo(totalAfterFirst);
+    assertThat(sessionAfterSecond.getFinalRank()).isEqualTo(rankAfterFirst);
+  }
+
+  @Test
+  @DisplayName("executeMidnightJob - Redis 키 만료 후 두 번째 호출(empty snapshot)도 첫 결과 유지 (멱등)")
+  void 스냅샷_저장_멱등성_empty_snapshot() {
+    TestClock testClock = (TestClock) schedulerClock;
+    LocalDate yesterday = LocalDate.now(testClock);
+
+    Member member = testAuthHelper.createMember();
+    DailySentence yesterdaySentence =
+        transactionTemplate.execute(
+            status -> {
+              DailySentence s = new DailySentence("어제 정답 문장 멱등 empty");
+              s.setUsedAt(yesterday);
+              s.setStatus(DailySentenceStatus.USED);
+              dailySentenceRepository.save(s);
+              GameSession gs = new GameSession(member, s);
+              gs.updateBestSimilarity(new BigDecimal("100.0"));
+              gs.markCleared(testClock.instant());
+              gameSessionRepository.save(gs);
+              return s;
+            });
+    GameSession session =
+        gameSessionRepository.findByMemberAndSentence(member, yesterdaySentence).orElseThrow();
+    rankingService.updateRanking(session, member);
+
+    testAuthHelper.createActiveSentence("오늘 후보 멱등 empty");
+    testClock.advanceBy(Duration.ofDays(1));
+
+    scheduler.executeMidnightJob();
+
+    Integer totalAfterFirst =
+        dailySentenceRepository.findById(yesterdaySentence.getId()).orElseThrow().getTotalPlayers();
+    Integer rankAfterFirst =
+        gameSessionRepository
+            .findByMemberAndSentence(member, yesterdaySentence)
+            .orElseThrow()
+            .getFinalRank();
+    assertThat(totalAfterFirst).isNotNull().isGreaterThanOrEqualTo(1);
+    assertThat(rankAfterFirst).isNotNull().isGreaterThanOrEqualTo(1);
+
+    redisTemplate.delete(RedisKeyConstants.rankingKey(yesterday));
+    redisTemplate.delete(RedisKeyConstants.rankingDetailKey(yesterday, member.getPublicId()));
 
     scheduler.executeMidnightJob();
 

--- a/backend/src/test/java/com/gakkaweo/backend/game/DailySentenceSchedulerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/game/DailySentenceSchedulerTest.java
@@ -118,6 +118,53 @@ class DailySentenceSchedulerTest extends IntegrationTestBase {
   }
 
   @Test
+  @DisplayName("executeMidnightJob - 두 번 호출해도 finalRank/totalPlayers 동일 (멱등)")
+  void 스냅샷_저장_멱등성() {
+    TestClock testClock = (TestClock) schedulerClock;
+    LocalDate yesterday = LocalDate.now(testClock);
+
+    Member member = testAuthHelper.createMember();
+    DailySentence yesterdaySentence =
+        transactionTemplate.execute(
+            status -> {
+              DailySentence s = new DailySentence("어제 정답 문장 멱등");
+              s.setUsedAt(yesterday);
+              s.setStatus(DailySentenceStatus.USED);
+              dailySentenceRepository.save(s);
+              GameSession session = new GameSession(member, s);
+              session.updateBestSimilarity(new BigDecimal("100.0"));
+              session.markCleared(testClock.instant());
+              gameSessionRepository.save(session);
+              return s;
+            });
+    GameSession session =
+        gameSessionRepository.findByMemberAndSentence(member, yesterdaySentence).orElseThrow();
+    rankingService.updateRanking(session, member);
+
+    testAuthHelper.createActiveSentence("오늘 후보 멱등");
+    testClock.advanceBy(Duration.ofDays(1));
+
+    scheduler.executeMidnightJob();
+
+    DailySentence afterFirst =
+        dailySentenceRepository.findById(yesterdaySentence.getId()).orElseThrow();
+    Integer totalAfterFirst = afterFirst.getTotalPlayers();
+    GameSession sessionAfterFirst =
+        gameSessionRepository.findByMemberAndSentence(member, yesterdaySentence).orElseThrow();
+    Integer rankAfterFirst = sessionAfterFirst.getFinalRank();
+
+    scheduler.executeMidnightJob();
+
+    DailySentence afterSecond =
+        dailySentenceRepository.findById(yesterdaySentence.getId()).orElseThrow();
+    GameSession sessionAfterSecond =
+        gameSessionRepository.findByMemberAndSentence(member, yesterdaySentence).orElseThrow();
+
+    assertThat(afterSecond.getTotalPlayers()).isEqualTo(totalAfterFirst);
+    assertThat(sessionAfterSecond.getFinalRank()).isEqualTo(rankAfterFirst);
+  }
+
+  @Test
   @DisplayName("executeMidnightJob - 예약 문장(scheduledAt=today)이 우선 선정")
   void 예약문장_우선선정() {
     TestClock testClock = (TestClock) schedulerClock;

--- a/backend/src/test/java/com/gakkaweo/backend/support/BulkDataFixture.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/BulkDataFixture.java
@@ -1,5 +1,6 @@
 package com.gakkaweo.backend.support;
 
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
@@ -15,13 +16,13 @@ import org.springframework.stereotype.Component;
 public class BulkDataFixture {
 
   private static final int BATCH = 1000;
-  private static final List<String> AUDIT_ACTIONS =
+  private static final List<AuditAction> AUDIT_ACTIONS =
       List.of(
-          "BAN_MEMBER",
-          "UNBAN_MEMBER",
-          "SENTENCE_UPLOAD",
-          "SENTENCE_DELETE",
-          "ANNOUNCEMENT_CREATE");
+          AuditAction.USER_BAN,
+          AuditAction.USER_UNBAN,
+          AuditAction.CSV_UPLOAD,
+          AuditAction.SENTENCE_DELETE,
+          AuditAction.ANNOUNCEMENT_CREATE);
   private final JdbcTemplate jdbc;
   private final Clock clock;
 
@@ -53,7 +54,8 @@ public class BulkDataFixture {
     insertAuditLogs(adminId, auditLogCount, base);
     insertSentenceUploads(adminId, sentenceUploadCount, base);
 
-    return new PopulatedIds(memberIds, sentenceIds, sessionIds, adminId, AUDIT_ACTIONS.get(0));
+    return new PopulatedIds(
+        memberIds, sentenceIds, sessionIds, adminId, AUDIT_ACTIONS.get(0).name());
   }
 
   private List<Long> insertMembers(int count, int bannedCount, Instant base) {
@@ -220,14 +222,14 @@ public class BulkDataFixture {
             + " VALUES (?, ?, ?, ?, ?, ?, ?)";
     List<Object[]> batch = new ArrayList<>(BATCH);
     for (int i = 0; i < count; i++) {
-      String action = AUDIT_ACTIONS.get(i % AUDIT_ACTIONS.size());
+      AuditAction action = AUDIT_ACTIONS.get(i % AUDIT_ACTIONS.size());
       addAndMaybeFlush(
           sql,
           batch,
           new Object[] {
             adminId,
-            action,
-            "MEMBER",
+            action.name(),
+            action.targetType().name(),
             String.valueOf(i),
             "detail_" + i,
             "127.0.0.1",


### PR DESCRIPTION
## 관련 이슈

Closes #156

## 변경 사항

이전 PR에서 의도적으로 분리한 후속 정리 12건 + 신규 발견 3건을 한 PR로 묶어 일괄 처리. 동작 변경 0, 코드 일관성/응집/가독성 향상.

### Redis 키 prefix 캡슐화 복원 (cddd736)
- `RedisKeyConstants` 4개 prefix를 `private`으로 응집
- ranking/detail SCAN 패턴 + 날짜 추출 헬퍼 4개 추가 (`rankingScanPattern`, `rankingDetailScanPattern`, `extractDateFromRankingKey`, `extractDateFromDetailKey`)
- `RedisCleanupScheduler`가 prefix 직접 참조 대신 `Function<String, LocalDate>` 주입 패턴으로 헬퍼 사용

### 매직 BigDecimal 상수화 (dcd94bf)
- `domain/game/GameConstants.PERFECT_SIMILARITY` 신설
- `RankingService` private 사본 제거 후 공용 상수 참조
- `DailyGameService.isPerfect`, `GameSession.updateClearedAt` 매직값 제거

### EnumParser 도입 + 어드민 일관성 정리 (bc54f18)
- `common/util/EnumParser.parseOrThrow` 신설 (대소문자 비관적 + IAE→BusinessException 일원화, `Locale.ROOT` 명시)
- `valueOf` 직접 호출 4건 헬퍼 경유 (`AdminSentenceService.getSentences`, `AdminSystemService.auditLogFilters`/`parseAnnouncementType`)
- `CustomOAuth2UserService`의 `ErrorCode.MEMBER_BANNED.name().toLowerCase()` 안티패턴 제거 → `OAUTH2_BANNED_ERROR_CODE` 명시 상수 분리
- `AdminSentenceService.DUPLICATE_THRESHOLD` 클래스 상수 추출
- `AdminSystemService` 멤버 조회 헬퍼 네이밍 통일 (`findMember` → `findByPublicIdOrThrow`)
- `AdminAuditService` self-invocation 제거 (private `doLog` 헬퍼 추출, 두 public `log` 오버로드가 위임 → 향후 `REQUIRES_NEW` 도입 시 silent 무시 위험 차단)

### Redis 동기화 헬퍼 통합 + 어드민 트랜잭션 일관화 (e8b29d9)
- `auth/service/MemberRedisSyncer` 신설 (`updateProfileUrl`/`updateNickname` 의미 메서드 + 공용 `updateRankingDetailField` 응집)
- `AuthService`/`AdminUserService`의 `sync*ToRedis` 메서드 4곳 제거, 호출 사이트(`AuthController`/`AdminUserController`)에서 syncer 직접 호출
- `AdminUserService` 멤버 조회 헬퍼 네이밍 통일 (`findMember` → `findByPublicIdOrThrow`) + EnumParser 적용 (`changeRole`)
- 어드민 컨트롤러 메서드 레벨 `@Transactional(readOnly=true)` 6곳 제거 (서비스 레이어에 동일 어노테이션 존재, `REQUIRED` 전파로 동작 동일)

### DTO/설정 record 전환 + 픽스처 동기화 + 멱등성 테스트 (eb7a0e0)
- `SwaggerConfigController` `Map<String,Object>` → `record SwaggerConfig` (inner `SwaggerUrl`)
- `NotificationProperties` 클래스 → record (호출자 3곳 accessor 마이그레이션: `ServerErrorNotifier`/`NotificationDeduplicationCache`/`AuditLogNotificationListener`)
- `BulkDataFixture.AUDIT_ACTIONS`를 `AuditAction` enum 직접 참조 (target_type도 `enum.targetType().name()`로 정확 매핑, 기존 하드코딩 `"BAN_MEMBER"`/`"UNBAN_MEMBER"`/`"SENTENCE_UPLOAD"` 잔존 동기화)
- `DailySentenceSchedulerTest` 멱등성 테스트 추가 (`스냅샷_저장_멱등성`: `executeMidnightJob` 두 번 호출 시 `finalRank`/`totalPlayers` 동일 검증)

## 본 PR에서 분리한 항목 (별 이슈로 진행)

- LocalAuthService AOP self-invocation + BCrypt TX 격리 — 보안/동작 변경 검증 영역
- DTO `from(Page<T>)` 팩토리 13곳 일괄 — 변경 면적 大
- `AuditingEntityListener` 도입 — 9개 엔티티 일괄, 인프라 변경
- SUPERADMIN role 도입 — 권한 모델 변경, 보안 영역
- Spring 컴포넌트 Lombok 일관성 일괄 (`JwtProvider` 등 5건) — 신규 후속

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (전체 테스트 BUILD SUCCESSFUL, 회귀 0)
- [x] 불필요한 코드나 주석을 제거했다 (sync 메서드 4곳/매직값/하드코딩 잔존 정리)
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다 (`AdminAuditAtomicityTest`/`AdminSortIntegrationTest` 회귀 0)