### PR TITLE
refactor: Spring 컴포넌트 Lombok 일관성 정리

### DIFF
--- a/.env.prod.sample
+++ b/.env.prod.sample
@@ -49,6 +49,9 @@ SIMILARITY_THRESHOLD=95.0
 # 프로필 이미지 저장 경로. prod는 docker 볼륨 마운트 지점
 UPLOAD_PROFILE_DIR=/data/uploads/profiles
 
+# SSE 동시 연결 상한 (랭킹 스트림). 초과 시 SSE_MAX_CONNECTIONS 에러
+SSE_MAX_CONNECTIONS=500
+
 # Rate Limiting (분당 요청 수. 그룹별 적용 경로: GUESS=/daily/guess, READ=GET 엔드포인트, SSE=/ranking/stream, AUTH=/auth/**, ADMIN=/admin/**)
 RATE_LIMIT_GUESS=40
 RATE_LIMIT_READ=90

--- a/.env.sample
+++ b/.env.sample
@@ -49,6 +49,9 @@ SIMILARITY_THRESHOLD=95.0
 # 프로필 이미지 저장 경로. prod는 docker 볼륨 마운트 지점
 UPLOAD_PROFILE_DIR=./uploads/profiles
 
+# SSE 동시 연결 상한 (랭킹 스트림). 초과 시 SSE_MAX_CONNECTIONS 에러
+SSE_MAX_CONNECTIONS=500
+
 # Rate Limiting (분당 요청 수. 그룹별 적용 경로: GUESS=/daily/guess, READ=GET 엔드포인트, SSE=/ranking/stream, AUTH=/auth/**, ADMIN=/admin/**)
 RATE_LIMIT_GUESS=40
 RATE_LIMIT_READ=90

--- a/backend/lombok.config
+++ b/backend/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value

--- a/backend/lombok.config
+++ b/backend/lombok.config
@@ -1,1 +1,0 @@
-lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/CookieAuthorizationRequestRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/CookieAuthorizationRequestRepository.java
@@ -12,6 +12,7 @@ import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
@@ -19,6 +20,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class CookieAuthorizationRequestRepository
     implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
@@ -27,12 +29,6 @@ public class CookieAuthorizationRequestRepository
 
   private final CookieProperties cookieProperties;
   private final ObjectMapper objectMapper;
-
-  public CookieAuthorizationRequestRepository(
-      CookieProperties cookieProperties, ObjectMapper objectMapper) {
-    this.cookieProperties = cookieProperties;
-    this.objectMapper = objectMapper;
-  }
 
   @Override
   public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
@@ -14,17 +15,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
   private final OAuth2Properties oAuth2Properties;
   private final CookieAuthorizationRequestRepository authorizationRequestRepository;
-
-  public OAuth2LoginFailureHandler(
-      OAuth2Properties oAuth2Properties,
-      CookieAuthorizationRequestRepository authorizationRequestRepository) {
-    this.oAuth2Properties = oAuth2Properties;
-    this.authorizationRequestRepository = authorizationRequestRepository;
-  }
 
   @Override
   public void onAuthenticationFailure(

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/service/NicknameGenerator.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/service/NicknameGenerator.java
@@ -3,9 +3,11 @@ package com.gakkaweo.backend.domain.member.service;
 import com.gakkaweo.backend.domain.member.repository.MemberRepository;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class NicknameGenerator {
 
   private static final int MAX_RETRIES = 3;
@@ -25,10 +27,6 @@ public class NicknameGenerator {
           "무지개", "폭포", "하늘", "새벽", "노을", "안개", "번개");
 
   private final MemberRepository memberRepository;
-
-  public NicknameGenerator(MemberRepository memberRepository) {
-    this.memberRepository = memberRepository;
-  }
 
   public String generate() {
     ThreadLocalRandom random = ThreadLocalRandom.current();

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
@@ -5,6 +5,7 @@ import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.ranking.dto.HeartbeatResponse;
 import com.gakkaweo.backend.ranking.dto.RankingResponse;
 import com.gakkaweo.backend.ranking.service.RankingService;
+import com.gakkaweo.backend.ranking.sse.config.SseProperties;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.util.ArrayList;
@@ -15,7 +16,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -28,9 +28,7 @@ public class SseConnectionManager {
 
   private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
   private final RankingService rankingService;
-
-  @Value("${app.sse.max-connections:500}")
-  private final int maxConnections;
+  private final SseProperties sseProperties;
 
   private final ScheduledExecutorService heartbeatExecutor =
       Executors.newSingleThreadScheduledExecutor(
@@ -57,7 +55,7 @@ public class SseConnectionManager {
   }
 
   public synchronized SseEmitter register() {
-    if (emitters.size() >= maxConnections) {
+    if (emitters.size() >= sseProperties.getMaxConnections()) {
       throw new BusinessException(ErrorCode.SSE_MAX_CONNECTIONS);
     }
 

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -20,13 +21,17 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class SseConnectionManager {
 
   private static final long HEARTBEAT_INTERVAL_SECONDS = 10;
 
   private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
   private final RankingService rankingService;
+
+  @Value("${app.sse.max-connections:500}")
   private final int maxConnections;
+
   private final ScheduledExecutorService heartbeatExecutor =
       Executors.newSingleThreadScheduledExecutor(
           r -> {
@@ -34,12 +39,6 @@ public class SseConnectionManager {
             t.setDaemon(true);
             return t;
           });
-
-  public SseConnectionManager(
-      RankingService rankingService, @Value("${app.sse.max-connections:500}") int maxConnections) {
-    this.rankingService = rankingService;
-    this.maxConnections = maxConnections;
-  }
 
   @PostConstruct
   void startHeartbeat() {

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/config/SseProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/config/SseProperties.java
@@ -1,0 +1,17 @@
+package com.gakkaweo.backend.ranking.sse.config;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "app.sse")
+@Validated
+@Getter
+@RequiredArgsConstructor
+public class SseProperties {
+
+  @Min(1)
+  private final int maxConnections;
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -92,6 +92,8 @@ app:
     hint-max-count: ${HINT_MAX_COUNT:5}
   upload:
     profile-dir: ${UPLOAD_PROFILE_DIR:./uploads/profiles}
+  sse:
+    max-connections: ${SSE_MAX_CONNECTIONS:500}
   rate-limit:
     guess-per-minute: ${RATE_LIMIT_GUESS:40}
     read-per-minute: ${RATE_LIMIT_READ:120}


### PR DESCRIPTION
## 관련 이슈

Closes #159

## 변경 사항

- `CookieAuthorizationRequestRepository`, `NicknameGenerator`, `SseConnectionManager`, `OAuth2LoginFailureHandler` 4건의 명시 생성자를 `@RequiredArgsConstructor`로 통일
- `SseConnectionManager`의 필드-레벨 `@Value`를 `SseProperties`(`@ConfigurationProperties` + `@Validated` + `@Min(1)`)로 추출. 백엔드 14+개 Properties와 패턴 일관
- 백엔드 전체 필드-레벨 `@Value` 사용 0건이 되어 `lombok.config` 워크어라운드 제거 (gemini의 `stopBubbling` 지적도 자연 해소)
- `application.yaml`에 `app.sse.max-connections` 명시 + `.env.sample` / `.env.prod.sample`에 `SSE_MAX_CONNECTIONS` 문서화
- `JwtProvider`, `SimilarityService`는 생성자에서 final 필드를 derive(`Keys.hmacShaKeyFor` / `circuitBreakerRegistry.circuitBreaker`)하므로 명시 생성자 유지

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (전체 테스트 329/0 실패 통과)
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다 (DI 시그니처 동일, OAuth2 / 닉네임 / SSE 통합 테스트 회귀 0)