### PR TITLE
feat: SUPERADMIN 권한 분리

### DIFF
--- a/.env.prod.sample
+++ b/.env.prod.sample
@@ -2,8 +2,8 @@
 # 프로덕션 환경변수 (.env.prod)
 # ============================================================
 
-# 초기 시딩 (최초 admin 계정 자동 생성용, 이후부터 무시)
-# 설정 시 8자 이상 필수. 보안상 최초 admin 생성 후 제거 권장
+# 초기 시딩 (최초 SUPERADMIN 계정 자동 생성용, 이후부터 무시)
+# 설정 시 8자 이상 필수. 보안상 최초 SUPERADMIN 생성 후 제거 권장
 SEED_ADMIN_PASSWORD=INPUT_YOUR_INITIAL_ADMIN_PASSWORD
 
 # PostgreSQL - DB_USER, DB_PASSWORD 필수

--- a/.env.sample
+++ b/.env.sample
@@ -2,8 +2,8 @@
 # 로컬 개발 환경변수 (.env)
 # ============================================================
 
-# 초기 시딩 (최초 admin 계정 자동 생성용, 이후부터 무시)
-# 설정 시 8자 이상 필수. 보안상 최초 admin 생성 후 제거 권장
+# 초기 시딩 (최초 SUPERADMIN 계정 자동 생성용, 이후부터 무시)
+# 설정 시 8자 이상 필수. 보안상 최초 SUPERADMIN 생성 후 제거 권장
 SEED_ADMIN_PASSWORD=INPUT_YOUR_INITIAL_ADMIN_PASSWORD
 
 # PostgreSQL - DB_USER, DB_PASSWORD 필수

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ pnpm dev
 최초 실행 시 `InitialDataSeeder`가 다음을 자동으로 처리합니다.
 
 - **기본 문장 5개** 자동 삽입 (`backend/src/main/resources/seed/sentences.txt`). 파일을 편집해 문장을 추가·교체할 수 있으며, 중복은 자동 skip됩니다.
-- `.env`에 `SEED_ADMIN_PASSWORD`(8자 이상)를 설정하면 **admin 계정이 자동 생성**됩니다 (username: `admin`, 닉네임 자동 생성). 이후 `/admin` 접근이 가능합니다.
+- `.env`에 `SEED_ADMIN_PASSWORD`(8자 이상)를 설정하면 **SUPERADMIN 계정이 자동 생성**됩니다 (username: `admin`, 닉네임 자동 생성). 이후 `/admin` 접근이 가능합니다.
 - 비밀번호 8자 미만이거나 시드 파일이 없으면 서버 실행이 중단됩니다.
 
 ---
@@ -245,4 +245,4 @@ pnpm dev
 
 ---
 
-_마지막 업데이트: 2026-04-16_
+_마지막 업데이트: 2026-04-28_

--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSentenceController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSentenceController.java
@@ -224,12 +224,14 @@ public class AdminSentenceController {
   }
 
   @Operation(
-      summary = "긴급 교체",
+      summary = "긴급 교체 (SUPERADMIN 전용)",
       description =
           """
+          진행 중인 게임에 즉시 영향을 주는 액션이라 SUPERADMIN만 호출 가능.
           기존 세션+추측 삭제, Redis 랭킹 초기화, DAY_CHANGE SSE 브로드캐스트
 
           에러 코드:
+          - `ACCESS_DENIED` (403): SUPERADMIN 권한 없음
           - `SENTENCE_NOT_FOUND` (404): 문장 없음
           - `SENTENCE_ALREADY_USED` (400): 교체 대상이 이미 출제됨""")
   @AdminErrorResponses

--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSystemController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminSystemController.java
@@ -104,7 +104,9 @@ public class AdminSystemController {
     return ResponseEntity.ok(adminSystemService.getSystemStatus());
   }
 
-  @Operation(summary = "랭킹 캐시 리셋")
+  @Operation(
+      summary = "랭킹 캐시 리셋 (SUPERADMIN 전용)",
+      description = "Redis Sorted Set 전체 초기화. 운영 사고 가능성으로 SUPERADMIN만 호출 가능.")
   @AdminErrorResponses
   @PostMapping("/ranking-cache/reset")
   public ResponseEntity<Void> resetRankingCache(
@@ -113,7 +115,9 @@ public class AdminSystemController {
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "Rate Limit 초기화")
+  @Operation(
+      summary = "Rate Limit 초기화 (SUPERADMIN 전용)",
+      description = "어뷰저 IP 차단을 해제하는 효과로 보안 영향이 있어 SUPERADMIN만 호출 가능.")
   @AdminErrorResponses
   @PostMapping("/rate-limit/reset")
   public ResponseEntity<Void> resetRateLimit(

--- a/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminUserController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/controller/AdminUserController.java
@@ -81,7 +81,8 @@ public class AdminUserController {
           에러 코드:
           - `MEMBER_NOT_FOUND` (404): 사용자 없음
           - `ADMIN_SELF_ACTION` (400): 자기 자신의 역할 변경 불가
-          - `ROLE_ALREADY_ASSIGNED` (400): 이미 동일한 역할""")
+          - `ROLE_ALREADY_ASSIGNED` (400): 이미 동일한 역할
+          - `INSUFFICIENT_ROLE` (403): 대상 ADMIN/SUPERADMIN에 대한 변경 권한 부족 (SUPERADMIN만 ADMIN을 변경 가능)""")
   @AdminErrorResponses
   @PatchMapping("/{publicId}/role")
   public ResponseEntity<AdminUserResponse> changeRole(
@@ -101,7 +102,8 @@ public class AdminUserController {
           """
           에러 코드:
           - `MEMBER_NOT_FOUND` (404): 사용자 없음
-          - `ADMIN_SELF_ACTION` (400): 자기 자신 차단 불가""")
+          - `ADMIN_SELF_ACTION` (400): 자기 자신 차단 불가
+          - `INSUFFICIENT_ROLE` (403): 대상 ADMIN/SUPERADMIN에 대한 변경 권한 부족""")
   @AdminErrorResponses
   @PostMapping("/{publicId}/ban")
   public ResponseEntity<Void> banUser(
@@ -118,7 +120,8 @@ public class AdminUserController {
           """
           에러 코드:
           - `MEMBER_NOT_FOUND` (404): 사용자 없음
-          - `ADMIN_SELF_ACTION` (400): 자기 자신 해제 불가""")
+          - `ADMIN_SELF_ACTION` (400): 자기 자신 해제 불가
+          - `INSUFFICIENT_ROLE` (403): 대상 ADMIN/SUPERADMIN에 대한 변경 권한 부족""")
   @AdminErrorResponses
   @DeleteMapping("/{publicId}/ban")
   public ResponseEntity<Void> unbanUser(
@@ -130,12 +133,15 @@ public class AdminUserController {
   }
 
   @Operation(
-      summary = "강제 탈퇴",
+      summary = "강제 탈퇴 (SUPERADMIN 전용)",
       description =
           """
+          회복 불가능한 데이터 영구 삭제 액션이라 SUPERADMIN만 호출 가능.
           에러 코드:
+          - `ACCESS_DENIED` (403): SUPERADMIN 권한 없음 (path-level)
           - `MEMBER_NOT_FOUND` (404): 사용자 없음
-          - `ADMIN_SELF_ACTION` (400): 자기 자신 탈퇴 불가""")
+          - `ADMIN_SELF_ACTION` (400): 자기 자신 탈퇴 불가
+          - `INSUFFICIENT_ROLE` (403): 대상이 SUPERADMIN인 경우""")
   @AdminErrorResponses
   @DeleteMapping("/{publicId}")
   public ResponseEntity<Void> forceDeleteUser(
@@ -160,7 +166,8 @@ public class AdminUserController {
           - `MEMBER_NOT_FOUND` (404): 사용자 없음
           - `ADMIN_SELF_ACTION` (400): 자기 자신의 닉네임 변경 불가
           - `NICKNAME_DUPLICATED` (409): 이미 사용 중인 닉네임
-          - `NICKNAME_FORBIDDEN` (400): 사용할 수 없는 닉네임""")
+          - `NICKNAME_FORBIDDEN` (400): 사용할 수 없는 닉네임
+          - `INSUFFICIENT_ROLE` (403): 대상 ADMIN/SUPERADMIN에 대한 변경 권한 부족""")
   @AdminErrorResponses
   @PatchMapping("/{publicId}/nickname")
   public ResponseEntity<AdminUserResponse> forceChangeNickname(
@@ -181,7 +188,8 @@ public class AdminUserController {
           """
           에러 코드:
           - `MEMBER_NOT_FOUND` (404): 사용자 없음
-          - `ADMIN_SELF_ACTION` (400): 자기 자신의 이미지 삭제 불가""")
+          - `ADMIN_SELF_ACTION` (400): 자기 자신의 이미지 삭제 불가
+          - `INSUFFICIENT_ROLE` (403): 대상 ADMIN/SUPERADMIN에 대한 변경 권한 부족""")
   @AdminErrorResponses
   @DeleteMapping("/{publicId}/profile-image")
   public ResponseEntity<Void> forceDeleteProfileImage(

--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/AdminUserResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/AdminUserResponse.java
@@ -14,7 +14,7 @@ public record AdminUserResponse(
         String profileUrl,
     @Schema(
             description = "역할",
-            allowableValues = {"USER", "ADMIN"},
+            allowableValues = {"USER", "ADMIN", "SUPERADMIN"},
             example = "USER")
         String role,
     @Schema(description = "차단 여부", example = "false") Boolean banned,

--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/RoleChangeRequest.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/RoleChangeRequest.java
@@ -6,8 +6,9 @@ import jakarta.validation.constraints.Pattern;
 
 @Schema(description = "역할 변경 요청")
 public record RoleChangeRequest(
+    // SUPERADMIN은 의도적으로 제외 — DB 마이그레이션 또는 운영 SQL로만 부여 가능
     @Schema(
-            description = "변경할 역할",
+            description = "변경할 역할 (SUPERADMIN은 API로 부여 불가)",
             allowableValues = {"USER", "ADMIN"},
             example = "ADMIN")
         @NotBlank

--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/UserDetailResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/UserDetailResponse.java
@@ -14,7 +14,7 @@ public record UserDetailResponse(
         String profileUrl,
     @Schema(
             description = "역할",
-            allowableValues = {"USER", "ADMIN"},
+            allowableValues = {"USER", "ADMIN", "SUPERADMIN"},
             example = "USER")
         String role,
     @Schema(description = "차단 여부", example = "false") Boolean banned,

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -133,6 +133,7 @@ public class AdminUserService {
     requireSufficientRoleOver(adminPublicId, member);
     MemberRole newRole =
         EnumParser.parseOrThrow(MemberRole.class, request.role(), ErrorCode.VALIDATION_FAILED);
+    requireRoleAssignmentAllowed(adminPublicId, newRole);
 
     if (member.getRole() == newRole) {
       throw new BusinessException(ErrorCode.ROLE_ALREADY_ASSIGNED);
@@ -275,12 +276,20 @@ public class AdminUserService {
     }
   }
 
-  /**
-   * 행위자가 대상에 대한 변경 액션을 수행할 수 있는지 검증한다.
-   *
-   * <p>USER 대상은 모든 ADMIN/SUPERADMIN 통과. ADMIN 대상은 SUPERADMIN만 통과. SUPERADMIN 대상은 누구든 변경 불가(동급
-   * SUPERADMIN 포함).
-   */
+  // SUPERADMIN 부여는 API 차단(운영 SQL 전용), ADMIN 승격은 SUPERADMIN 행위자만.
+  private void requireRoleAssignmentAllowed(UUID adminPublicId, MemberRole newRole) {
+    if (newRole == MemberRole.SUPERADMIN) {
+      throw new BusinessException(ErrorCode.INSUFFICIENT_ROLE);
+    }
+    if (newRole == MemberRole.ADMIN) {
+      Member admin = findByPublicIdOrThrow(adminPublicId);
+      if (admin.getRole() != MemberRole.SUPERADMIN) {
+        throw new BusinessException(ErrorCode.INSUFFICIENT_ROLE);
+      }
+    }
+  }
+
+  // 대상이 ADMIN/SUPERADMIN이면 행위자가 더 높은 등급일 때만 변경 액션 허용.
   private void requireSufficientRoleOver(UUID adminPublicId, Member target) {
     MemberRole targetRole = target.getRole();
     if (targetRole == MemberRole.USER) {

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -130,6 +130,7 @@ public class AdminUserService {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findByPublicIdOrThrow(targetPublicId);
+    requireSufficientRoleOver(adminPublicId, member);
     MemberRole newRole =
         EnumParser.parseOrThrow(MemberRole.class, request.role(), ErrorCode.VALIDATION_FAILED);
 
@@ -152,6 +153,7 @@ public class AdminUserService {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findByPublicIdOrThrow(targetPublicId);
+    requireSufficientRoleOver(adminPublicId, member);
     Long memberId = member.getId();
 
     // clearAutomatically=true로 영속성 컨텍스트 초기화됨 → delete 먼저, 재조회 후 set
@@ -171,6 +173,7 @@ public class AdminUserService {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findByPublicIdOrThrow(targetPublicId);
+    requireSufficientRoleOver(adminPublicId, member);
     member.setBanned(false);
     member.setBannedAt(null);
 
@@ -184,6 +187,7 @@ public class AdminUserService {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findByPublicIdOrThrow(targetPublicId);
+    requireSufficientRoleOver(adminPublicId, member);
 
     gameSessionRepository.anonymizeByMember(member);
     sentenceUploadRepository.anonymizeByAdmin(member);
@@ -213,6 +217,7 @@ public class AdminUserService {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findByPublicIdOrThrow(targetPublicId);
+    requireSufficientRoleOver(adminPublicId, member);
     String nickname = nicknameValidator.normalize(request.nickname());
     nicknameValidator.validate(nickname);
 
@@ -243,6 +248,7 @@ public class AdminUserService {
     preventSelfAction(targetPublicId, adminPublicId);
 
     Member member = findByPublicIdOrThrow(targetPublicId);
+    requireSufficientRoleOver(adminPublicId, member);
     member.setProfileUrl(null);
     adminAuditService.log(
         adminPublicId,
@@ -267,6 +273,24 @@ public class AdminUserService {
     if (targetPublicId.equals(adminPublicId)) {
       throw new BusinessException(ErrorCode.ADMIN_SELF_ACTION);
     }
+  }
+
+  /**
+   * 행위자가 대상에 대한 변경 액션을 수행할 수 있는지 검증한다.
+   *
+   * <p>USER 대상은 모든 ADMIN/SUPERADMIN 통과. ADMIN 대상은 SUPERADMIN만 통과. SUPERADMIN 대상은 누구든 변경 불가(동급
+   * SUPERADMIN 포함).
+   */
+  private void requireSufficientRoleOver(UUID adminPublicId, Member target) {
+    MemberRole targetRole = target.getRole();
+    if (targetRole == MemberRole.USER) {
+      return;
+    }
+    Member admin = findByPublicIdOrThrow(adminPublicId);
+    if (targetRole == MemberRole.ADMIN && admin.getRole() == MemberRole.SUPERADMIN) {
+      return;
+    }
+    throw new BusinessException(ErrorCode.INSUFFICIENT_ROLE);
   }
 
   private AdminUserResponse toUserResponse(Member member) {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/dto/AuthResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/dto/AuthResponse.java
@@ -13,7 +13,7 @@ public record AuthResponse(
         String profileUrl,
     @Schema(
             description = "역할",
-            allowableValues = {"USER", "ADMIN"},
+            allowableValues = {"USER", "ADMIN", "SUPERADMIN"},
             example = "USER")
         String role) {
 

--- a/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/exception/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
   MEMBER_BANNED(HttpStatus.FORBIDDEN, "차단된 계정입니다"),
   ADMIN_SELF_ACTION(HttpStatus.BAD_REQUEST, "자기 자신에 대한 작업은 수행할 수 없습니다"),
   ROLE_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "이미 동일한 역할입니다"),
+  INSUFFICIENT_ROLE(HttpStatus.FORBIDDEN, "이 작업을 수행할 권한이 부족합니다"),
 
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");
 

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -17,6 +17,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -42,6 +46,24 @@ public class SecurityConfig {
   private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
   private final RestAccessDeniedHandler restAccessDeniedHandler;
   private final OpenApiProperties openApiProperties;
+
+  @Bean
+  static RoleHierarchy roleHierarchy() {
+    return RoleHierarchyImpl.withDefaultRolePrefix()
+        .role("SUPERADMIN")
+        .implies("ADMIN")
+        .role("ADMIN")
+        .implies("USER")
+        .build();
+  }
+
+  @Bean
+  static MethodSecurityExpressionHandler methodSecurityExpressionHandler(
+      RoleHierarchy roleHierarchy) {
+    DefaultMethodSecurityExpressionHandler handler = new DefaultMethodSecurityExpressionHandler();
+    handler.setRoleHierarchy(roleHierarchy);
+    return handler;
+  }
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -82,6 +104,15 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/announcements/active")
                     .permitAll()
+                    // SUPERADMIN 전용 (회복 불가/운영·보안 영향 큰 액션). /admin/** 매처보다 먼저 평가되어야 함
+                    .requestMatchers(HttpMethod.DELETE, "/admin/users/*")
+                    .hasRole("SUPERADMIN")
+                    .requestMatchers(HttpMethod.POST, "/admin/sentences/emergency-replace")
+                    .hasRole("SUPERADMIN")
+                    .requestMatchers(HttpMethod.POST, "/admin/system/ranking-cache/reset")
+                    .hasRole("SUPERADMIN")
+                    .requestMatchers(HttpMethod.POST, "/admin/system/rate-limit/reset")
+                    .hasRole("SUPERADMIN")
                     .requestMatchers("/admin/**")
                     .hasRole("ADMIN")
                     .requestMatchers("/daily/**")

--- a/backend/src/main/java/com/gakkaweo/backend/config/openapi/AdminErrorResponses.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/openapi/AdminErrorResponses.java
@@ -46,11 +46,20 @@ import java.lang.annotation.Target;
           @Content(
               mediaType = "application/json",
               schema = @Schema(implementation = ErrorBody.class),
-              examples =
-                  @ExampleObject(
-                      value =
-                          """
-              {"status":403,"code":"ACCESS_DENIED","message":"접근 권한이 없습니다","timestamp":"2026-04-17T12:00:00Z"}"""))),
+              examples = {
+                @ExampleObject(
+                    name = "path-deny",
+                    summary = "경로 권한 부족 (Spring Security path matcher)",
+                    value =
+                        """
+              {"status":403,"code":"ACCESS_DENIED","message":"접근 권한이 없습니다","timestamp":"2026-04-17T12:00:00Z"}"""),
+                @ExampleObject(
+                    name = "domain-deny",
+                    summary = "도메인 룰 권한 부족 (대상 보호 / SUPERADMIN-only 액션)",
+                    value =
+                        """
+              {"status":403,"code":"INSUFFICIENT_ROLE","message":"이 작업을 수행할 권한이 부족합니다","timestamp":"2026-04-17T12:00:00Z"}""")
+              })),
   @ApiResponse(
       responseCode = "404",
       description = "리소스 없음",

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/MemberRole.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/MemberRole.java
@@ -2,5 +2,6 @@ package com.gakkaweo.backend.domain.member.entity;
 
 public enum MemberRole {
   USER,
-  ADMIN
+  ADMIN,
+  SUPERADMIN
 }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/seeding/InitialDataSeeder.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/seeding/InitialDataSeeder.java
@@ -119,10 +119,10 @@ public class InitialDataSeeder {
     transactionTemplate.executeWithoutResult(
         status -> {
           Member member = memberRepository.save(new Member(nickname));
-          member.setRole(MemberRole.ADMIN);
+          member.setRole(MemberRole.SUPERADMIN);
           localAccountRepository.save(new LocalAccount(member, ADMIN_USERNAME, passwordHash));
         });
 
-    log.info("admin 시딩 완료: nickname={}, username={}", nickname, ADMIN_USERNAME);
+    log.info("SUPERADMIN 시딩 완료: nickname={}, username={}", nickname, ADMIN_USERNAME);
   }
 }

--- a/backend/src/main/resources/db/migration/V17__promote_admin_to_superadmin.sql
+++ b/backend/src/main/resources/db/migration/V17__promote_admin_to_superadmin.sql
@@ -1,0 +1,6 @@
+-- 기존 ADMIN 계정을 SUPERADMIN으로 일괄 승격
+-- 권한 분리 도입 시점에 기존 ADMIN을 SUPERADMIN으로 옮긴다.
+-- 이후 신규 SUPERADMIN은 운영 SQL로만 부여 가능 (API/시딩에서는 새 SUPERADMIN을 생성하지 않음).
+UPDATE members
+SET role = 'SUPERADMIN'
+WHERE role = 'ADMIN';

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditAtomicityTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditAtomicityTest.java
@@ -67,7 +67,7 @@ class AdminAuditAtomicityTest extends IntegrationTestBase {
   @Test
   @DisplayName("역할 변경 중 audit 실패 시 Member.role 변경이 롤백된다")
   void 역할변경_audit실패_롤백() {
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     Member target = testAuthHelper.createMember();
     HttpHeaders headers = authedJson(admin);
 

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditRecordingTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditRecordingTest.java
@@ -81,7 +81,7 @@ class AdminAuditRecordingTest extends IntegrationTestBase {
   @DisplayName("랭킹 캐시 리셋 → RANKING_CACHE_RESET 기록")
   void 랭킹리셋_감사() {
     testAuthHelper.createTodaySentence("오늘 문장");
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
 
     restTemplate.exchange(

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditRecordingTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditRecordingTest.java
@@ -27,7 +27,7 @@ class AdminAuditRecordingTest extends IntegrationTestBase {
   @Test
   @DisplayName("역할 변경 → ROLE_CHANGE 기록")
   void 역할변경_감사() {
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     Member target = testAuthHelper.createMember();
     HttpHeaders headers = authedJson(admin);
 

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSentenceIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSentenceIntegrationTest.java
@@ -459,7 +459,7 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
   @Test
   @DisplayName("emergencyReplace - returnOldToPool=true (이전 문장 ACTIVE 복귀, DayChangeEvent 발행)")
   void 긴급교체_풀복귀() {
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     DailySentence old = testAuthHelper.createTodaySentence("교체 대상 (기존)");
     DailySentence replacement = testAuthHelper.createActiveSentence("교체 후보 (새 문장)");
 
@@ -489,7 +489,7 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
   @Test
   @DisplayName("emergencyReplace - returnOldToPool=false (이전 문장 DISABLED)")
   void 긴급교체_비활성처리() {
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     DailySentence old = testAuthHelper.createTodaySentence("교체 대상 2");
     DailySentence replacement = testAuthHelper.createActiveSentence("교체 후보 2");
 
@@ -511,7 +511,7 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
   @Test
   @DisplayName("emergencyReplace - 오늘 문장 없으면 SENTENCE_NOT_FOUND")
   void 긴급교체_오늘문장없음() {
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     DailySentence replacement = testAuthHelper.createActiveSentence("후보");
 
     HttpHeaders headers = authedJson(admin);
@@ -529,7 +529,7 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
   @Test
   @DisplayName("emergencyReplace - 존재하지 않는 newSentencePublicId SENTENCE_NOT_FOUND")
   void 긴급교체_없는문장() {
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     testAuthHelper.createTodaySentence("오늘");
 
     HttpHeaders headers = authedJson(admin);
@@ -547,7 +547,7 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
   @Test
   @DisplayName("emergencyReplace - newSentence가 이미 사용됨이면 SENTENCE_ALREADY_USED")
   void 긴급교체_이미사용() {
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     testAuthHelper.createTodaySentence("오늘");
     DailySentence alreadyUsed =
         transactionTemplate.execute(
@@ -573,7 +573,7 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
   @Test
   @DisplayName("emergencyReplace - newSentence가 DISABLED면 SENTENCE_NOT_FOUND")
   void 긴급교체_비활성문장() {
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     testAuthHelper.createTodaySentence("오늘");
     DailySentence disabled =
         transactionTemplate.execute(
@@ -593,6 +593,25 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     assertThat(response.getBody().code()).isEqualTo("SENTENCE_NOT_FOUND");
+  }
+
+  @Test
+  @DisplayName("emergencyReplace - ADMIN 호출 시 403 ACCESS_DENIED (path-level)")
+  void 긴급교체_ADMIN_거부() {
+    Member admin = testAuthHelper.createAdmin();
+    testAuthHelper.createTodaySentence("오늘");
+    DailySentence replacement = testAuthHelper.createActiveSentence("후보");
+
+    HttpHeaders headers = authedJson(admin);
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/sentences/emergency-replace"),
+            HttpMethod.POST,
+            new HttpEntity<>(new EmergencyReplaceRequest(replacement.getPublicId(), true), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("ACCESS_DENIED");
   }
 
   private HttpHeaders authedJson(Member admin) {

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSystemIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSystemIntegrationTest.java
@@ -111,10 +111,10 @@ class AdminSystemIntegrationTest extends IntegrationTestBase {
   }
 
   @Test
-  @DisplayName("랭킹 캐시 리셋 - 200")
+  @DisplayName("랭킹 캐시 리셋 - SUPERADMIN 200")
   void 랭킹캐시_리셋() {
     testAuthHelper.createTodaySentence("오늘 문장");
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
 
     ResponseEntity<Void> response =
@@ -140,7 +140,7 @@ class AdminSystemIntegrationTest extends IntegrationTestBase {
           gameSessionRepository.save(session);
         });
 
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
 
     ResponseEntity<Void> response =
@@ -164,9 +164,9 @@ class AdminSystemIntegrationTest extends IntegrationTestBase {
   }
 
   @Test
-  @DisplayName("Rate Limit 리셋 - 200")
+  @DisplayName("Rate Limit 리셋 - SUPERADMIN 200")
   void 레이트리밋_리셋() {
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
 
     ResponseEntity<Void> response =
@@ -177,6 +177,41 @@ class AdminSystemIntegrationTest extends IntegrationTestBase {
             Void.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("랭킹 캐시 리셋 - ADMIN 호출 시 403 ACCESS_DENIED (path-level)")
+  void 랭킹캐시_리셋_ADMIN_거부() {
+    testAuthHelper.createTodaySentence("오늘 문장");
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/system/ranking-cache/reset"),
+            HttpMethod.POST,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("ACCESS_DENIED");
+  }
+
+  @Test
+  @DisplayName("Rate Limit 리셋 - ADMIN 호출 시 403 ACCESS_DENIED (path-level)")
+  void 레이트리밋_리셋_ADMIN_거부() {
+    Member admin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/system/rate-limit/reset"),
+            HttpMethod.POST,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("ACCESS_DENIED");
   }
 
   @Test

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminUserIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminUserIntegrationTest.java
@@ -10,6 +10,7 @@ import com.gakkaweo.backend.admin.dto.UserGameHistoryResponse;
 import com.gakkaweo.backend.admin.dto.UserListResponse;
 import com.gakkaweo.backend.common.exception.ErrorBody;
 import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.entity.MemberRole;
 import com.gakkaweo.backend.domain.member.entity.SocialAccount;
 import com.gakkaweo.backend.domain.member.entity.SocialProvider;
 import com.gakkaweo.backend.domain.member.repository.MemberRepository;
@@ -128,9 +129,9 @@ class AdminUserIntegrationTest extends IntegrationTestBase {
   }
 
   @Test
-  @DisplayName("강제 탈퇴 - 사용자 삭제")
+  @DisplayName("강제 탈퇴 - SUPERADMIN이 USER 삭제")
   void 강제탈퇴() {
-    Member admin = testAuthHelper.createAdmin();
+    Member admin = testAuthHelper.createSuperAdmin();
     Member target = testAuthHelper.createMember();
     HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
 
@@ -143,6 +144,25 @@ class AdminUserIntegrationTest extends IntegrationTestBase {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(memberRepository.findByPublicId(target.getPublicId())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("권한 가드 - ADMIN이 USER 강제탈퇴 → 403 ACCESS_DENIED (path-level)")
+  void 권한가드_ADMIN_USER_forceDelete() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId()),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("ACCESS_DENIED");
+    assertThat(memberRepository.findByPublicId(target.getPublicId())).isPresent();
   }
 
   @Test
@@ -337,6 +357,242 @@ class AdminUserIntegrationTest extends IntegrationTestBase {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody().provider()).isEqualTo("LOCAL");
+  }
+
+  @Test
+  @DisplayName("권한 가드 - ADMIN이 다른 ADMIN role 변경 → 403 INSUFFICIENT_ROLE")
+  void 권한가드_ADMIN_대_ADMIN_role변경() {
+    Member admin = testAuthHelper.createAdmin();
+    Member targetAdmin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetAdmin.getPublicId() + "/role"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new RoleChangeRequest("USER"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("INSUFFICIENT_ROLE");
+  }
+
+  @Test
+  @DisplayName("권한 가드 - ADMIN이 SUPERADMIN role 변경 → 403 INSUFFICIENT_ROLE")
+  void 권한가드_ADMIN_대_SUPERADMIN_role변경() {
+    Member admin = testAuthHelper.createAdmin();
+    Member targetSuper = testAuthHelper.createSuperAdmin();
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetSuper.getPublicId() + "/role"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new RoleChangeRequest("USER"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("INSUFFICIENT_ROLE");
+  }
+
+  @Test
+  @DisplayName("권한 가드 - SUPERADMIN이 다른 SUPERADMIN role 변경 → 403 INSUFFICIENT_ROLE")
+  void 권한가드_SUPERADMIN_대_SUPERADMIN_role변경() {
+    Member superAdmin = testAuthHelper.createSuperAdmin();
+    Member targetSuper = testAuthHelper.createSuperAdmin();
+    HttpHeaders headers = authedJson(superAdmin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetSuper.getPublicId() + "/role"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new RoleChangeRequest("USER"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("INSUFFICIENT_ROLE");
+  }
+
+  @Test
+  @DisplayName("권한 가드 - SUPERADMIN이 ADMIN role 변경 → 200")
+  void 권한가드_SUPERADMIN_대_ADMIN_role변경() {
+    Member superAdmin = testAuthHelper.createSuperAdmin();
+    Member targetAdmin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(superAdmin);
+
+    ResponseEntity<AdminUserResponse> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetAdmin.getPublicId() + "/role"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new RoleChangeRequest("USER"), headers),
+            AdminUserResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().role()).isEqualTo("USER");
+  }
+
+  @Test
+  @DisplayName("권한 가드 - SUPERADMIN이 USER ban → 200 (회귀)")
+  void 권한가드_SUPERADMIN_대_USER_ban() {
+    Member superAdmin = testAuthHelper.createSuperAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(superAdmin);
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/ban"),
+            HttpMethod.POST,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("권한 가드 - ADMIN이 다른 ADMIN ban → 403 INSUFFICIENT_ROLE")
+  void 권한가드_ADMIN_대_ADMIN_ban() {
+    Member admin = testAuthHelper.createAdmin();
+    Member targetAdmin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetAdmin.getPublicId() + "/ban"),
+            HttpMethod.POST,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("INSUFFICIENT_ROLE");
+  }
+
+  @Test
+  @DisplayName("권한 가드 - SUPERADMIN이 ADMIN ban → 200")
+  void 권한가드_SUPERADMIN_대_ADMIN_ban() {
+    Member superAdmin = testAuthHelper.createSuperAdmin();
+    Member targetAdmin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(superAdmin);
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetAdmin.getPublicId() + "/ban"),
+            HttpMethod.POST,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    Member reloaded = memberRepository.findByPublicId(targetAdmin.getPublicId()).orElseThrow();
+    assertThat(reloaded.getBanned()).isTrue();
+  }
+
+  @Test
+  @DisplayName("권한 가드 - ADMIN이 다른 ADMIN unban → 403 INSUFFICIENT_ROLE")
+  void 권한가드_ADMIN_대_ADMIN_unban() {
+    Member admin = testAuthHelper.createAdmin();
+    Member targetAdmin = testAuthHelper.createMember(MemberRole.ADMIN, true);
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetAdmin.getPublicId() + "/ban"),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("INSUFFICIENT_ROLE");
+  }
+
+  @Test
+  @DisplayName("권한 가드 - SUPERADMIN이 ADMIN forceDelete → 200 (회귀)")
+  void 권한가드_SUPERADMIN_대_ADMIN_forceDelete() {
+    Member superAdmin = testAuthHelper.createSuperAdmin();
+    Member targetAdmin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(superAdmin);
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetAdmin.getPublicId()),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(memberRepository.findByPublicId(targetAdmin.getPublicId())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("권한 가드 - SUPERADMIN이 다른 SUPERADMIN forceDelete → 403 INSUFFICIENT_ROLE")
+  void 권한가드_SUPERADMIN_대_SUPERADMIN_forceDelete() {
+    Member superAdmin = testAuthHelper.createSuperAdmin();
+    Member targetSuper = testAuthHelper.createSuperAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(superAdmin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetSuper.getPublicId()),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("INSUFFICIENT_ROLE");
+    assertThat(memberRepository.findByPublicId(targetSuper.getPublicId())).isPresent();
+  }
+
+  @Test
+  @DisplayName("권한 가드 - ADMIN이 다른 ADMIN forceDelete → 403 ACCESS_DENIED (path-level)")
+  void 권한가드_ADMIN_대_ADMIN_forceDelete() {
+    Member admin = testAuthHelper.createAdmin();
+    Member targetAdmin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetAdmin.getPublicId()),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("ACCESS_DENIED");
+    assertThat(memberRepository.findByPublicId(targetAdmin.getPublicId())).isPresent();
+  }
+
+  @Test
+  @DisplayName("권한 가드 - ADMIN이 다른 ADMIN nickname 변경 → 403 INSUFFICIENT_ROLE")
+  void 권한가드_ADMIN_대_ADMIN_nickname() {
+    Member admin = testAuthHelper.createAdmin();
+    Member targetAdmin = testAuthHelper.createAdmin();
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetAdmin.getPublicId() + "/nickname"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new ForceNicknameRequest("새닉네임"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("INSUFFICIENT_ROLE");
+  }
+
+  @Test
+  @DisplayName("권한 가드 - ADMIN이 다른 ADMIN profile-image 삭제 → 403 INSUFFICIENT_ROLE")
+  void 권한가드_ADMIN_대_ADMIN_profileImage() {
+    Member admin = testAuthHelper.createAdmin();
+    Member targetAdmin = testAuthHelper.createAdmin();
+    HttpHeaders headers = testAuthHelper.cookieHeaderFor(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + targetAdmin.getPublicId() + "/profile-image"),
+            HttpMethod.DELETE,
+            new HttpEntity<>(headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("INSUFFICIENT_ROLE");
   }
 
   private HttpHeaders authedJson(Member admin) {

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminUserIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminUserIntegrationTest.java
@@ -35,12 +35,12 @@ class AdminUserIntegrationTest extends IntegrationTestBase {
   @Autowired TransactionTemplate transactionTemplate;
 
   @Test
-  @DisplayName("역할 변경 - USER → ADMIN 성공")
+  @DisplayName("역할 변경 - SUPERADMIN이 USER → ADMIN 승격 성공")
   void 역할변경_성공() {
-    Member admin = testAuthHelper.createAdmin();
+    Member superAdmin = testAuthHelper.createSuperAdmin();
     Member target = testAuthHelper.createMember();
 
-    HttpHeaders headers = authedJson(admin);
+    HttpHeaders headers = authedJson(superAdmin);
 
     ResponseEntity<AdminUserResponse> response =
         restTemplate.exchange(
@@ -429,6 +429,42 @@ class AdminUserIntegrationTest extends IntegrationTestBase {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody().role()).isEqualTo("USER");
+  }
+
+  @Test
+  @DisplayName("권한 가드 - ADMIN이 USER → ADMIN 승격 시도 → 403 INSUFFICIENT_ROLE")
+  void 권한가드_ADMIN의_ADMIN승격_차단() {
+    Member admin = testAuthHelper.createAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = authedJson(admin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/role"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new RoleChangeRequest("ADMIN"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().code()).isEqualTo("INSUFFICIENT_ROLE");
+  }
+
+  @Test
+  @DisplayName("권한 가드 - SUPERADMIN 부여 시도 (DTO 패턴 위반) → 400 VALIDATION_FAILED")
+  void 권한가드_SUPERADMIN_부여_DTO차단() {
+    Member superAdmin = testAuthHelper.createSuperAdmin();
+    Member target = testAuthHelper.createMember();
+    HttpHeaders headers = authedJson(superAdmin);
+
+    ResponseEntity<ErrorBody> response =
+        restTemplate.exchange(
+            url("/admin/users/" + target.getPublicId() + "/role"),
+            HttpMethod.PATCH,
+            new HttpEntity<>(new RoleChangeRequest("SUPERADMIN"), headers),
+            ErrorBody.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody().code()).isEqualTo("VALIDATION_FAILED");
   }
 
   @Test

--- a/backend/src/test/java/com/gakkaweo/backend/support/TestAuthHelper.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/TestAuthHelper.java
@@ -42,6 +42,10 @@ public class TestAuthHelper {
     return createMember(MemberRole.ADMIN, false);
   }
 
+  public Member createSuperAdmin() {
+    return createMember(MemberRole.SUPERADMIN, false);
+  }
+
   public Member createBannedMember() {
     return createMember(MemberRole.USER, true);
   }
@@ -51,8 +55,8 @@ public class TestAuthHelper {
     return transactionTemplate.execute(
         status -> {
           Member member = new Member(nickname);
-          if (role == MemberRole.ADMIN) {
-            member.setRole(MemberRole.ADMIN);
+          if (role != MemberRole.USER) {
+            member.setRole(role);
           }
           if (banned) {
             member.setBanned(true);

--- a/docs/decisions/backend.md
+++ b/docs/decisions/backend.md
@@ -100,6 +100,39 @@ Family 기반 Refresh Token Rotation을 구현했다.
 
 - 차단 시 refresh_token을 폐기하고 access_token을 블랙리스트에 등록하여 즉시 세션을 종료한다.
 
+## 권한 모델
+
+`USER` < `ADMIN` < `SUPERADMIN`. Spring Security `RoleHierarchy`로 자동 포괄. API 응답 `role`은 prefix 없이 노출하고 내부에서만 `ROLE_`을 쓴다.
+
+### 가드 3층
+
+| 층 | 위치 | 거부 코드 |
+| --- | --- | --- |
+| Path matcher | `SecurityConfig` (`/admin/**` = ADMIN, 위험 액션 = SUPERADMIN) | `ACCESS_DENIED` |
+| 대상 보호 | `AdminUserService.requireSufficientRoleOver` | `INSUFFICIENT_ROLE` |
+| 부여 정책 | `AdminUserService.requireRoleAssignmentAllowed` | `INSUFFICIENT_ROLE` |
+
+> 거부 사유가 다르므로 응답 코드를 분리해 클라이언트가 구분할 수 있게 했다.
+
+### 액션별 매트릭스
+
+| 액션 | Path | 대상 보호 | 부여 정책 |
+| --- | --- | --- | --- |
+| 역할 변경 | `ADMIN` | ✓ | ✓ (SUPERADMIN-only) |
+| 차단/해제, 닉네임 강제, 프로필 강제 삭제 | `ADMIN` | ✓ | — |
+| 강제 탈퇴 | `SUPERADMIN` | ✓ | — |
+| 긴급 교체, 랭킹 캐시 리셋, Rate Limit 초기화 | `SUPERADMIN` | — | — |
+
+`ADMIN`은 가역적이고 단일 사용자에 한정된 액션, `SUPERADMIN`은 비가역(강제 탈퇴, 긴급 교체, 캐시 리셋), 시스템 광역(Rate Limit), 권한 부여 메타-액션(역할 변경)을 수행한다.
+
+> 역할 변경은 가역적이지만 다른 액션의 전제 조건이 되는 권한 부여이므로 SUPERADMIN으로 분리했다.
+
+### SUPERADMIN 부여 채널
+
+`SUPERADMIN`은 운영 SQL로만 부여한다. API는 DTO `@Pattern("USER|ADMIN")` 1차 + 서비스 `requireRoleAssignmentAllowed` 2차로 차단하고, 시딩은 최초 admin 한 건만 만든다. `USER → ADMIN` 승격도 SUPERADMIN 행위자만 가능하다.
+
+> 부여 채널을 운영 SQL로 좁히면 단일 ADMIN 탈취가 권한 상승으로 이어지지 않는다. ADMIN끼리의 상호 임명도 권한 확산 통제가 어려워 같은 정책으로 묶었다.
+
 ## 랭킹 시스템
 
 ### Redis Sorted Set 스코어 인코딩

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -289,7 +289,8 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
   - **a11y**: `<th scope="col" aria-sort="ascending|descending|none">` + 헤더 라벨은 `<button type="button">` 래핑. 버튼 `title` 속성으로 호버 안내(`클릭하여 정렬` / `오름차순/내림차순 정렬 중`)
   - **백엔드 계약**: `?sort=field,dir` (Spring 표준). 화이트리스트 외 필드/방향은 400. 도메인별 enum (`UserSortField`/`SentenceSortField`/`AuditLogSortField`)이 단일 진실
 - **위젯 카드**: `border-4 shadow-brutal-sm`. 라벨 `text-xs uppercase tracking-wide`. 수치 `text-3xl font-black tabular-nums`
-- **상태 배지**: `px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white`. ACTIVE=green-400, USED=blue-300, DISABLED=gray-300, ADMIN=red, USER=blue, 차단=gray-800
+- **상태 배지**: `px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white`. ACTIVE=green-400, USED=blue-300, DISABLED=gray-300, SUPERADMIN=purple-400, ADMIN=red-400, USER=blue-300, 차단=gray-800
+- **SUPERADMIN 전용 액션 가시성**: 강제 탈퇴, 긴급 교체, 랭킹 캐시 리셋, Rate Limit 초기화는 `useAuthStore().user?.role === "SUPERADMIN"` 검사로 disabled 분기. 비-SUPERADMIN ADMIN에게는 안내 문구(`text-amber-600 dark:text-amber-400`) 노출
 - **다이얼로그**: `border-4 shadow-brutal max-w-lg`. 헤더 `border-b-4 px-6 py-5`. 푸터 `border-t-4`. `role="dialog" aria-modal="true"` + Escape 닫기 필수
 - **텍스트 링크 액션**: 테이블 행 내 액션은 `text-indigo-600 dark:text-indigo-400 font-black text-xs hover:underline`
 - **Pagination**: `Button sm secondary` 이전/다음 + `tabular-nums` 페이지 표시

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -290,7 +290,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
   - **백엔드 계약**: `?sort=field,dir` (Spring 표준). 화이트리스트 외 필드/방향은 400. 도메인별 enum (`UserSortField`/`SentenceSortField`/`AuditLogSortField`)이 단일 진실
 - **위젯 카드**: `border-4 shadow-brutal-sm`. 라벨 `text-xs uppercase tracking-wide`. 수치 `text-3xl font-black tabular-nums`
 - **상태 배지**: `px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white`. ACTIVE=green-400, USED=blue-300, DISABLED=gray-300, SUPERADMIN=purple-400, ADMIN=red-400, USER=blue-300, 차단=gray-800
-- **SUPERADMIN 전용 액션 가시성**: 강제 탈퇴, 긴급 교체, 랭킹 캐시 리셋, Rate Limit 초기화는 `useAuthStore().user?.role === "SUPERADMIN"` 검사로 disabled 분기. 비-SUPERADMIN ADMIN에게는 안내 문구(`text-amber-600 dark:text-amber-400`) 노출
+- **SUPERADMIN 전용 액션 가시성**: 강제 탈퇴, 긴급 교체, 랭킹 캐시 리셋, Rate Limit 초기화, 역할 변경은 `useAuthStore().user?.role === "SUPERADMIN"` 검사로 disabled 분기. 비-SUPERADMIN ADMIN에게는 안내 문구(`text-amber-600 dark:text-amber-400`) 노출
 - **다이얼로그**: `border-4 shadow-brutal max-w-lg`. 헤더 `border-b-4 px-6 py-5`. 푸터 `border-t-4`. `role="dialog" aria-modal="true"` + Escape 닫기 필수
 - **텍스트 링크 액션**: 테이블 행 내 액션은 `text-indigo-600 dark:text-indigo-400 font-black text-xs hover:underline`
 - **Pagination**: `Button sm secondary` 이전/다음 + `tabular-nums` 페이지 표시

--- a/frontend/src/features/admin/components/SentenceDetailDialog.tsx
+++ b/frontend/src/features/admin/components/SentenceDetailDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/features/admin/hooks/useAdminSentences";
 import type { SentenceResponse } from "@/features/admin/types";
 import { useToastStore } from "@/shared/stores/useToastStore";
+import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { ApiError } from "@/shared/api/client";
 
 interface SentenceDetailDialogProps {
@@ -32,6 +33,7 @@ export function SentenceDetailDialog({ sentence, onClose }: SentenceDetailDialog
   const emergencyReplace = useEmergencyReplace();
   const { data: stats } = useSentenceStats(sentence?.publicId ?? null);
   const { addToast } = useToastStore();
+  const isSuperAdmin = useAuthStore((s) => s.user?.role === "SUPERADMIN");
 
   const isSaving = createMutation.isPending || updateMutation.isPending;
 
@@ -205,15 +207,21 @@ export function SentenceDetailDialog({ sentence, onClose }: SentenceDetailDialog
               )}
 
               {!sentence.usedAt && sentence.status === "ACTIVE" && (
-                <div className="border-t-2 border-black/20 dark:border-white/20 pt-4">
+                <div className="border-t-2 border-black/20 dark:border-white/20 pt-4 space-y-2">
                   <Button
                     size="sm"
                     variant="danger"
                     onClick={handleEmergencyReplace}
+                    disabled={!isSuperAdmin}
                     isLoading={emergencyReplace.isPending}
                   >
                     긴급 교체 (이 문장으로)
                   </Button>
+                  {!isSuperAdmin && (
+                    <p className="text-xs font-bold text-amber-600 dark:text-amber-400">
+                      SUPERADMIN만 긴급 교체를 수행할 수 있습니다.
+                    </p>
+                  )}
                 </div>
               )}
             </>

--- a/frontend/src/features/admin/components/SystemTab.tsx
+++ b/frontend/src/features/admin/components/SystemTab.tsx
@@ -11,6 +11,7 @@ import { AuditLogViewer } from "@/features/admin/components/AuditLogViewer";
 import { useDeleteAnnouncement } from "@/features/admin/hooks/useAdminSystem";
 import type { AnnouncementResponse } from "@/features/admin/types";
 import { useToastStore } from "@/shared/stores/useToastStore";
+import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { ApiError } from "@/shared/api/client";
 
 function StatusIndicator({ healthy, label }: { healthy: boolean; label: string }) {
@@ -50,6 +51,7 @@ export function SystemTab() {
   const resetRate = useResetRateLimit();
   const deleteMutation = useDeleteAnnouncement();
   const { addToast } = useToastStore();
+  const isSuperAdmin = useAuthStore((s) => s.user?.role === "SUPERADMIN");
 
   const [announcementEdit, setAnnouncementEdit] = useState<AnnouncementResponse | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -114,13 +116,32 @@ export function SystemTab() {
               </p>
             </div>
           </div>
-          <div className="flex gap-2 mt-4">
-            <Button size="sm" variant="secondary" onClick={handleResetCache} isLoading={resetCache.isPending}>
-              랭킹 캐시 리셋
-            </Button>
-            <Button size="sm" variant="secondary" onClick={handleResetRate} isLoading={resetRate.isPending}>
-              Rate Limit 초기화
-            </Button>
+          <div className="space-y-2 mt-4">
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={handleResetCache}
+                disabled={!isSuperAdmin}
+                isLoading={resetCache.isPending}
+              >
+                랭킹 캐시 리셋
+              </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={handleResetRate}
+                disabled={!isSuperAdmin}
+                isLoading={resetRate.isPending}
+              >
+                Rate Limit 초기화
+              </Button>
+            </div>
+            {!isSuperAdmin && (
+              <p className="text-xs font-bold text-amber-600 dark:text-amber-400">
+                SUPERADMIN만 시스템 리셋을 수행할 수 있습니다.
+              </p>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/features/admin/components/UserDetailDialog.tsx
+++ b/frontend/src/features/admin/components/UserDetailDialog.tsx
@@ -12,9 +12,33 @@ import {
   useForceDeleteUser,
 } from "@/features/admin/hooks/useAdminUsers";
 import { useToastStore } from "@/shared/stores/useToastStore";
+import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { ApiError } from "@/shared/api/client";
 import { resolveProfileUrl } from "@/shared/utils/url";
 import { getSimilarityColor } from "@/shared/utils/similarity";
+
+function canModify(actorRole: string | undefined, targetRole: string): boolean {
+  if (targetRole === "SUPERADMIN") {
+    return false;
+  }
+  if (targetRole === "USER") {
+    return true;
+  }
+  if (targetRole === "ADMIN" && actorRole === "SUPERADMIN") {
+    return true;
+  }
+  return false;
+}
+
+function roleLabel(role: string): string {
+  if (role === "SUPERADMIN") {
+    return "최고관리자";
+  }
+  if (role === "ADMIN") {
+    return "관리자";
+  }
+  return "일반";
+}
 
 interface UserDetailDialogProps {
   publicId: string;
@@ -34,6 +58,7 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
   const profileMutation = useForceDeleteProfileImage();
   const deleteMutation = useForceDeleteUser();
   const { addToast } = useToastStore();
+  const actorRole = useAuthStore((s) => s.user?.role);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -113,8 +138,7 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
             <div>
               <p className="text-lg font-black">{user.nickname}</p>
               <p className="text-xs text-gray-500 dark:text-gray-400 font-medium">
-                {user.provider} / {user.role === "ADMIN" ? "관리자" : "일반"} /{" "}
-                {new Date(user.createdAt).toLocaleDateString("ko-KR")}
+                {user.provider} / {roleLabel(user.role)} / {new Date(user.createdAt).toLocaleDateString("ko-KR")}
               </p>
               {user.email && (
                 <p className="text-xs text-gray-500 dark:text-gray-400 font-medium mt-0.5">{user.email}</p>
@@ -144,6 +168,11 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
 
           {/* 액션 */}
           <div className="border-t-2 border-black/20 dark:border-white/20 pt-4 space-y-3">
+            {!canModify(actorRole, user.role) && (
+              <p className="text-xs font-bold text-amber-600 dark:text-amber-400">
+                이 사용자에 대한 변경 권한이 부족합니다.
+              </p>
+            )}
             {/* 역할 변경 */}
             <div className="flex gap-2 items-center">
               <span className="text-sm font-bold w-20">역할:</span>
@@ -160,6 +189,7 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
                     `${user.role === "ADMIN" ? "일반 사용자" : "관리자"}로 변경하시겠습니까?`,
                   )
                 }
+                disabled={!canModify(actorRole, user.role) || user.role === "SUPERADMIN"}
                 isLoading={roleMutation.isPending}
               >
                 {user.role === "ADMIN" ? "일반으로" : "관리자로"}
@@ -183,6 +213,7 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
                       "차단을 해제하시겠습니까?",
                     )
                   }
+                  disabled={!canModify(actorRole, user.role)}
                   isLoading={unbanMutation.isPending}
                 >
                   차단 해제
@@ -201,6 +232,7 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
                       "이 사용자를 차단하시겠습니까?",
                     )
                   }
+                  disabled={!canModify(actorRole, user.role)}
                   isLoading={banMutation.isPending}
                 >
                   차단
@@ -235,7 +267,7 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
                     `닉네임을 "${newNickname.trim()}"(으)로 변경하시겠습니까?`,
                   )
                 }
-                disabled={!newNickname.trim()}
+                disabled={!newNickname.trim() || !canModify(actorRole, user.role)}
                 isLoading={nicknameMutation.isPending}
               >
                 변경
@@ -259,6 +291,7 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
                       "프로필 이미지를 삭제하시겠습니까?",
                     )
                   }
+                  disabled={!canModify(actorRole, user.role)}
                   isLoading={profileMutation.isPending}
                 >
                   이미지 삭제
@@ -266,29 +299,37 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
               </div>
             )}
 
-            {/* 강제 탈퇴 */}
-            <div className="flex gap-2 items-center">
-              <span className="text-sm font-bold w-20">탈퇴:</span>
-              <Button
-                size="sm"
-                variant="danger"
-                onClick={() =>
-                  handleAction(
-                    () =>
-                      deleteMutation.mutate(publicId, {
-                        onSuccess: () => {
-                          addToast("강제 탈퇴되었습니다.", "success");
-                          onClose();
-                        },
-                        onError,
-                      }),
-                    "이 사용자를 강제 탈퇴시키겠습니까? 되돌릴 수 없습니다.",
-                  )
-                }
-                isLoading={deleteMutation.isPending}
-              >
-                강제 탈퇴
-              </Button>
+            {/* 강제 탈퇴 (SUPERADMIN 전용) */}
+            <div className="flex flex-col gap-1">
+              <div className="flex gap-2 items-center">
+                <span className="text-sm font-bold w-20">탈퇴:</span>
+                <Button
+                  size="sm"
+                  variant="danger"
+                  onClick={() =>
+                    handleAction(
+                      () =>
+                        deleteMutation.mutate(publicId, {
+                          onSuccess: () => {
+                            addToast("강제 탈퇴되었습니다.", "success");
+                            onClose();
+                          },
+                          onError,
+                        }),
+                      "이 사용자를 강제 탈퇴시키겠습니까? 되돌릴 수 없습니다.",
+                    )
+                  }
+                  disabled={actorRole !== "SUPERADMIN" || user.role === "SUPERADMIN"}
+                  isLoading={deleteMutation.isPending}
+                >
+                  강제 탈퇴
+                </Button>
+              </div>
+              {actorRole !== "SUPERADMIN" && (
+                <p className="text-xs font-bold text-amber-600 dark:text-amber-400 pl-[5.5rem]">
+                  SUPERADMIN만 강제 탈퇴를 수행할 수 있습니다.
+                </p>
+              )}
             </div>
           </div>
 

--- a/frontend/src/features/admin/components/UserDetailDialog.tsx
+++ b/frontend/src/features/admin/components/UserDetailDialog.tsx
@@ -30,6 +30,20 @@ function canModify(actorRole: string | undefined, targetRole: string): boolean {
   return false;
 }
 
+function canChangeRole(actorRole: string | undefined, targetRole: string): boolean {
+  if (actorRole !== "SUPERADMIN") {
+    return false;
+  }
+  return targetRole !== "SUPERADMIN";
+}
+
+function roleToggle(targetRole: string): { label: string; nextRole: "USER" | "ADMIN" } {
+  if (targetRole === "ADMIN") {
+    return { label: "일반으로 강등", nextRole: "USER" };
+  }
+  return { label: "관리자로 승격", nextRole: "ADMIN" };
+}
+
 function roleLabel(role: string): string {
   if (role === "SUPERADMIN") {
     return "최고관리자";
@@ -174,26 +188,44 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
               </p>
             )}
             {/* 역할 변경 */}
-            <div className="flex gap-2 items-center">
-              <span className="text-sm font-bold w-20">역할:</span>
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() =>
-                  handleAction(
-                    () =>
-                      roleMutation.mutate(
-                        { publicId, role: user.role === "ADMIN" ? "USER" : "ADMIN" },
-                        { onSuccess: () => addToast("역할이 변경되었습니다.", "success"), onError },
-                      ),
-                    `${user.role === "ADMIN" ? "일반 사용자" : "관리자"}로 변경하시겠습니까?`,
-                  )
-                }
-                disabled={!canModify(actorRole, user.role) || user.role === "SUPERADMIN"}
-                isLoading={roleMutation.isPending}
-              >
-                {user.role === "ADMIN" ? "일반으로" : "관리자로"}
-              </Button>
+            <div className="flex flex-col gap-1">
+              <div className="flex gap-2 items-center">
+                <span className="text-sm font-bold w-20">역할:</span>
+                {user.role === "SUPERADMIN" ? (
+                  <Button size="sm" variant="secondary" disabled>
+                    변경 불가
+                  </Button>
+                ) : (
+                  (() => {
+                    const toggle = roleToggle(user.role);
+                    return (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() =>
+                          handleAction(
+                            () =>
+                              roleMutation.mutate(
+                                { publicId, role: toggle.nextRole },
+                                { onSuccess: () => addToast("역할이 변경되었습니다.", "success"), onError },
+                              ),
+                            `${toggle.label}하시겠습니까?`,
+                          )
+                        }
+                        disabled={!canChangeRole(actorRole, user.role)}
+                        isLoading={roleMutation.isPending}
+                      >
+                        {toggle.label}
+                      </Button>
+                    );
+                  })()
+                )}
+              </div>
+              {user.role !== "SUPERADMIN" && actorRole !== "SUPERADMIN" && (
+                <p className="text-xs font-bold text-amber-600 dark:text-amber-400 pl-[5.5rem]">
+                  SUPERADMIN만 역할을 변경할 수 있습니다.
+                </p>
+              )}
             </div>
 
             {/* 차단/해제 */}

--- a/frontend/src/features/admin/components/UserTab.tsx
+++ b/frontend/src/features/admin/components/UserTab.tsx
@@ -10,10 +10,16 @@ import { Pagination } from "@/features/admin/components/Pagination";
 import { resolveProfileUrl } from "@/shared/utils/url";
 
 function RoleBadge({ role }: { role: string }) {
-  const color = role === "ADMIN" ? "bg-red-400 text-black" : "bg-blue-300 text-black";
+  const color =
+    role === "SUPERADMIN"
+      ? "bg-purple-400 text-black"
+      : role === "ADMIN"
+        ? "bg-red-400 text-black"
+        : "bg-blue-300 text-black";
+  const label = role === "SUPERADMIN" ? "SUPERADMIN" : role === "ADMIN" ? "ADMIN" : "USER";
   return (
     <span className={`inline-block px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white ${color}`}>
-      {role === "ADMIN" ? "ADMIN" : "USER"}
+      {label}
     </span>
   );
 }

--- a/frontend/src/shared/api/types.ts
+++ b/frontend/src/shared/api/types.ts
@@ -4,7 +4,7 @@ export interface MeResponse {
   publicId: string;
   nickname: string;
   profileUrl: string | null;
-  role: "USER" | "ADMIN";
+  role: "USER" | "ADMIN" | "SUPERADMIN";
 }
 
 // --- Daily Game ---


### PR DESCRIPTION
## 관련 이슈

Closes #161

## 변경 사항

- `MemberRole`에 `SUPERADMIN` 추가, V17로 기존 ADMIN을 SUPERADMIN으로 일괄 승격
- `SecurityConfig`에 `RoleHierarchy`(SUPERADMIN > ADMIN > USER) 빈 + SUPERADMIN 전용 path matcher 4개 추가
  - `DELETE /admin/users/*` (강제 탈퇴)
  - `POST /admin/sentences/emergency-replace` (긴급 정답 교체)
  - `POST /admin/system/ranking-cache/reset` (랭킹 캐시 리셋)
  - `POST /admin/system/rate-limit/reset` (Rate Limit 초기화)
- `AdminUserService`에 도메인 가드(`requireSufficientRoleOver`) 추가 - SUPERADMIN 대상 변경/SUPERADMIN끼리 변경 차단, ADMIN 대상은 SUPERADMIN만 변경 가능
- `ErrorCode.INSUFFICIENT_ROLE` 신설 - path/role 거부(`ACCESS_DENIED`)와 도메인 룰 거부 의미 분리
- 시딩을 ADMIN -> SUPERADMIN으로 변경, 신규 SUPERADMIN은 시딩/SQL로만 부여 (API/시딩에서 추가 SUPERADMIN 생성 불가)
- DTO `allowableValues`에 SUPERADMIN 반영 (`AdminUserResponse`, `UserDetailResponse`, `AuthResponse`), `RoleChangeRequest`는 USER/ADMIN만 노출
- 권한 매트릭스 통합 테스트 추가, 격상된 4개 엔드포인트 테스트는 SUPERADMIN 기준으로 갱신
- 어드민 UI에 SUPERADMIN 권한 분기 반영
  - `RoleBadge` purple-400 매핑
  - `UserDetailDialog`의 `canModify` 헬퍼로 ADMIN/SUPERADMIN 대상 보호
  - `SystemTab`/`SentenceDetailDialog`의 SUPERADMIN 전용 액션은 `useAuthStore` 기반 disabled + 안내 문구 노출
- README 시딩 안내, `design-system.md` 배지/가시성 규칙 갱신

### 후속 정리 (코드 리뷰 반영)

- 역할 부여 가드 추가 (`requireRoleAssignmentAllowed`): SUPERADMIN 부여를 서비스 레벨에서도 차단(defense-in-depth), `USER → ADMIN` 승격은 SUPERADMIN 행위자만 수행 가능. 권한 매트릭스 통합 테스트 2건 추가 + 영향 받는 기존 테스트 3건 갱신
- `AdminErrorResponses` 403 ExampleObject를 `path-deny`(`ACCESS_DENIED`)/`domain-deny`(`INSUFFICIENT_ROLE`) 두 개로 분리
- 어드민 사용자 상세 다이얼로그 역할 변경 라벨/안내 정비 — `canChangeRole` 헬퍼 도입, SUPERADMIN→"변경 불가" / ADMIN→"일반으로 강등" / USER→"관리자로 승격"으로 분기, 비-SUPERADMIN 행위자에게 amber 안내 문구 노출
- `docs/decisions/backend.md`에 권한 모델 절 신설(위계, 가드 3층, 액션 매트릭스, 분류 원칙, SUPERADMIN 부여 채널). `design-system.md` 가시성 목록에 역할 변경 추가

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다