### PR TITLE
fix: SUPERADMIN 계정의 어드민 패널 접근 회귀 수정

### DIFF
--- a/frontend/src/app/guards.tsx
+++ b/frontend/src/app/guards.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
+import { hasAdminAccess } from "@/shared/utils/role";
 
 function LoadingFallback() {
   return <div className="max-w-md mx-auto py-12 text-center text-gray-400 font-bold animate-pulse">로딩 중...</div>;
@@ -27,7 +28,7 @@ export function RequireAdminAuth({ children }: { children: ReactNode }) {
     return <LoadingFallback />;
   }
 
-  if (!isAuthenticated || user?.role !== "ADMIN") {
+  if (!isAuthenticated || !hasAdminAccess(user?.role)) {
     return <Navigate to="/" replace />;
   }
 

--- a/frontend/src/app/layout/Header.tsx
+++ b/frontend/src/app/layout/Header.tsx
@@ -3,13 +3,14 @@ import { Link, useLocation } from "react-router-dom";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { getLastProvider, PROVIDER_COLORS } from "@/shared/config/providers";
 import { KakaoIcon, GoogleIcon, NaverIcon, GakkaweoIcon } from "@/shared/config/providerIcons";
+import { hasAdminAccess } from "@/shared/utils/role";
 import { SettingsModal } from "@/app/layout/SettingsModal";
 
 export function Header() {
   const { user, isAuthenticated } = useAuthStore();
   const location = useLocation();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const isAdmin = user?.role === "ADMIN";
+  const isAdmin = hasAdminAccess(user?.role);
   const provider = getLastProvider();
   const providerColors = provider ? PROVIDER_COLORS[provider] : null;
   const ProviderIcon = provider

--- a/frontend/src/shared/utils/role.ts
+++ b/frontend/src/shared/utils/role.ts
@@ -1,0 +1,3 @@
+export function hasAdminAccess(role: string | undefined): boolean {
+  return role === "ADMIN" || role === "SUPERADMIN";
+}


### PR DESCRIPTION
## 관련 이슈

Closes #163

## 변경 사항

- `shared/utils/role.ts` 신설: `hasAdminAccess(role)` 헬퍼로 어드민 진입 자격 판정 단일화 (BE `RoleHierarchy(SUPERADMIN > ADMIN > USER)`와 일관)
- `Header.tsx`: `user?.role === "ADMIN"` → `hasAdminAccess(user?.role)`로 교체. SUPERADMIN 계정에서 헤더 "관리" 버튼이 노출되도록 수정
- `guards.tsx`: `RequireAdminAuth`의 `user?.role !== "ADMIN"` → `!hasAdminAccess(user?.role)`로 교체. SUPERADMIN의 `/admin` 직접 진입 시 리다이렉트되던 회귀 수정
- 통합 테스트는 BE `hasRole("ADMIN")` path matcher의 자동 포괄만 검증해 FE 라우팅 가드 회귀를 잡지 못했음. 헬퍼로 응집해 향후 동일 누락 재발 방지

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다