### PR TITLE
refactor: AuditingEntityListener 도입 + BaseEntity 추출

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/config/AuditConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/AuditConfig.java
@@ -1,0 +1,22 @@
+package com.gakkaweo.backend.config;
+
+import java.time.Clock;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
+@RequiredArgsConstructor
+public class AuditConfig {
+
+  private final Clock clock;
+
+  @Bean
+  public DateTimeProvider auditingDateTimeProvider() {
+    return () -> Optional.of(clock.instant());
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/Announcement.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/Announcement.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.domain.admin.entity;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.gakkaweo.backend.domain.common.entity.BaseTimeEntity;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,7 +13,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import lombok.AccessLevel;
@@ -24,7 +24,7 @@ import lombok.Setter;
 @Table(name = "announcements")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Announcement {
+public class Announcement extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = IDENTITY)
@@ -57,8 +57,6 @@ public class Announcement {
 
   @Setter private Instant endsAt;
 
-  private Instant createdAt;
-
   public Announcement(
       Member admin,
       String title,
@@ -72,10 +70,5 @@ public class Announcement {
     this.type = type;
     this.startsAt = startsAt;
     this.endsAt = endsAt;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditLog.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditLog.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.gakkaweo.backend.domain.common.entity.BaseTimeEntity;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,9 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "audit_logs")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AuditLog {
+public class AuditLog extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = IDENTITY)
@@ -50,8 +49,6 @@ public class AuditLog {
   @Column(length = 45)
   private String ipAddress;
 
-  private Instant createdAt;
-
   public AuditLog(
       Member admin,
       AuditAction action,
@@ -65,10 +62,5 @@ public class AuditLog {
     this.targetId = targetId;
     this.detail = detail;
     this.ipAddress = ipAddress;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/SentenceUpload.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/SentenceUpload.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.domain.admin.entity;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.gakkaweo.backend.domain.common.entity.BaseTimeEntity;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,9 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "sentence_uploads")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SentenceUpload {
+public class SentenceUpload extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = IDENTITY)
@@ -37,16 +36,9 @@ public class SentenceUpload {
   @Column(nullable = false)
   private Integer recordCount;
 
-  private Instant createdAt;
-
   public SentenceUpload(Member admin, String fileName, Integer recordCount) {
     this.admin = admin;
     this.fileName = fileName;
     this.recordCount = recordCount;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/auth/entity/RefreshToken.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/auth/entity/RefreshToken.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.domain.auth.entity;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.gakkaweo.backend.domain.common.entity.BaseTimeEntity;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,7 +11,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
@@ -23,7 +23,7 @@ import lombok.Setter;
 @Table(name = "refresh_tokens")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken {
+public class RefreshToken extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = IDENTITY)
@@ -42,8 +42,6 @@ public class RefreshToken {
   @Column(nullable = false)
   private Instant expiresAt;
 
-  private Instant createdAt;
-
   @Setter private boolean revoked = false;
 
   public RefreshToken(Member member, String tokenHash, UUID familyId, Instant expiresAt) {
@@ -51,10 +49,5 @@ public class RefreshToken {
     this.tokenHash = tokenHash;
     this.familyId = familyId;
     this.expiresAt = expiresAt;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/common/entity/BaseAuditableEntity.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/common/entity/BaseAuditableEntity.java
@@ -1,0 +1,16 @@
+package com.gakkaweo.backend.domain.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import lombok.Getter;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseAuditableEntity extends BaseTimeEntity {
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  protected Instant updatedAt;
+}

--- a/backend/src/main/java/com/gakkaweo/backend/domain/common/entity/BaseTimeEntity.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/common/entity/BaseTimeEntity.java
@@ -1,0 +1,19 @@
+package com.gakkaweo.backend.domain.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  protected Instant createdAt;
+}

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/DailySentence.java
@@ -2,15 +2,14 @@ package com.gakkaweo.backend.domain.game.entity;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.gakkaweo.backend.domain.common.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -22,7 +21,7 @@ import lombok.Setter;
 @Table(name = "daily_sentences")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DailySentence {
+public class DailySentence extends BaseTimeEntity {
 
   @Column(unique = true, nullable = false, updatable = false)
   private final UUID publicId = UUID.randomUUID();
@@ -51,18 +50,11 @@ public class DailySentence {
   @Column(nullable = true)
   private Integer totalPlayers;
 
-  private Instant createdAt;
-
   public DailySentence(String sentence) {
     this.sentence = sentence;
   }
 
   public void recordTotalPlayers(int totalPlayers) {
     this.totalPlayers = totalPlayers;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GameSession.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.domain.game.entity;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.gakkaweo.backend.domain.common.entity.BaseAuditableEntity;
 import com.gakkaweo.backend.domain.game.GameConstants;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import jakarta.persistence.Column;
@@ -13,8 +14,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
@@ -31,7 +30,7 @@ import lombok.NoArgsConstructor;
     uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "sentence_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GameSession {
+public class GameSession extends BaseAuditableEntity {
 
   @Column(unique = true, nullable = false, updatable = false)
   private final UUID publicId = UUID.randomUUID();
@@ -63,10 +62,6 @@ public class GameSession {
   private Integer finalRank;
 
   @Version private Integer version;
-
-  private Instant createdAt;
-
-  private Instant updatedAt;
 
   public GameSession(Member member, DailySentence sentence) {
     this.member = member;
@@ -104,16 +99,5 @@ public class GameSession {
 
   public void recordFinalRank(int finalRank) {
     this.finalRank = finalRank;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = Instant.now();
-    this.updatedAt = Instant.now();
-  }
-
-  @PreUpdate
-  protected void onUpdate() {
-    this.updatedAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GuessHistory.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/game/entity/GuessHistory.java
@@ -3,16 +3,15 @@ package com.gakkaweo.backend.domain.game.entity;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.gakkaweo.backend.domain.common.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "guess_history")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GuessHistory {
+public class GuessHistory extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = IDENTITY)
@@ -40,18 +39,11 @@ public class GuessHistory {
   @Column(nullable = false)
   private Integer attemptNumber;
 
-  private Instant createdAt;
-
   public GuessHistory(
       GameSession session, String guessText, BigDecimal similarity, Integer attemptNumber) {
     this.session = session;
     this.guessText = guessText;
     this.similarity = similarity;
     this.attemptNumber = attemptNumber;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/LocalAccount.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/LocalAccount.java
@@ -3,15 +3,14 @@ package com.gakkaweo.backend.domain.member.entity;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.gakkaweo.backend.domain.common.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "local_accounts")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LocalAccount {
+public class LocalAccount extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = IDENTITY)
@@ -36,16 +35,9 @@ public class LocalAccount {
   @Column(nullable = false, length = 72)
   private String passwordHash;
 
-  private Instant createdAt;
-
   public LocalAccount(Member member, String username, String passwordHash) {
     this.member = member;
     this.username = username;
     this.passwordHash = passwordHash;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/Member.java
@@ -2,14 +2,13 @@ package com.gakkaweo.backend.domain.member.entity;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.gakkaweo.backend.domain.common.entity.BaseAuditableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
@@ -22,7 +21,7 @@ import lombok.Setter;
 @Table(name = "members")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseAuditableEntity {
 
   @Column(unique = true, nullable = false, updatable = false)
   private final UUID publicId = UUID.randomUUID();
@@ -50,22 +49,7 @@ public class Member {
 
   @Setter private Instant bannedAt;
 
-  private Instant createdAt;
-
-  private Instant updatedAt;
-
   public Member(String nickname) {
     this.nickname = nickname;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = Instant.now();
-    this.updatedAt = Instant.now();
-  }
-
-  @PreUpdate
-  protected void onUpdate() {
-    this.updatedAt = Instant.now();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/SocialAccount.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/member/entity/SocialAccount.java
@@ -5,13 +5,13 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
@@ -19,6 +19,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(
@@ -26,6 +28,7 @@ import lombok.Setter;
     uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class SocialAccount {
 
   @Id
@@ -47,16 +50,13 @@ public class SocialAccount {
   @Column(length = 255)
   private String email;
 
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
   private Instant connectedAt;
 
   public SocialAccount(Member member, SocialProvider provider, String providerId) {
     this.member = member;
     this.provider = provider;
     this.providerId = providerId;
-  }
-
-  @PrePersist
-  protected void onCreate() {
-    this.connectedAt = Instant.now();
   }
 }

--- a/backend/src/test/java/com/gakkaweo/backend/domain/common/entity/EntityAuditingIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/domain/common/entity/EntityAuditingIntegrationTest.java
@@ -1,0 +1,124 @@
+package com.gakkaweo.backend.domain.common.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gakkaweo.backend.domain.admin.entity.AuditAction;
+import com.gakkaweo.backend.domain.admin.entity.AuditLog;
+import com.gakkaweo.backend.domain.admin.entity.AuditTargetType;
+import com.gakkaweo.backend.domain.admin.repository.AuditLogRepository;
+import com.gakkaweo.backend.domain.auth.entity.RefreshToken;
+import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
+import com.gakkaweo.backend.domain.member.entity.Member;
+import com.gakkaweo.backend.domain.member.entity.SocialAccount;
+import com.gakkaweo.backend.domain.member.entity.SocialProvider;
+import com.gakkaweo.backend.domain.member.repository.MemberRepository;
+import com.gakkaweo.backend.domain.member.repository.SocialAccountRepository;
+import com.gakkaweo.backend.support.IntegrationTestBase;
+import com.gakkaweo.backend.support.TestClock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@DisplayName("엔티티 Auditing 자동 채움 통합 테스트")
+class EntityAuditingIntegrationTest extends IntegrationTestBase {
+
+  @Autowired private MemberRepository memberRepository;
+  @Autowired private RefreshTokenRepository refreshTokenRepository;
+  @Autowired private SocialAccountRepository socialAccountRepository;
+  @Autowired private AuditLogRepository auditLogRepository;
+  @Autowired private TransactionTemplate transactionTemplate;
+
+  @Test
+  @DisplayName("BaseTimeEntity 상속체 - createdAt이 Clock instant로 자동 채움")
+  void baseTimeEntity_createdAt_자동채움() {
+    Instant fixed = Instant.parse("2026-05-01T00:00:00Z");
+    ((TestClock) clock).setInstant(fixed);
+
+    Member member = transactionTemplate.execute(s -> memberRepository.save(new Member("토큰소유자")));
+
+    RefreshToken token =
+        transactionTemplate.execute(
+            s ->
+                refreshTokenRepository.save(
+                    new RefreshToken(
+                        member,
+                        "hash-" + UUID.randomUUID(),
+                        UUID.randomUUID(),
+                        fixed.plusSeconds(3600))));
+
+    RefreshToken loaded = refreshTokenRepository.findById(token.getId()).orElseThrow();
+    assertThat(loaded.getCreatedAt()).isEqualTo(fixed);
+  }
+
+  @Test
+  @DisplayName("BaseAuditableEntity 상속체 - createdAt + updatedAt 동시 채움 후 update 시 updatedAt만 변경")
+  void baseAuditableEntity_createdAt_updatedAt_동시채움_그리고_업데이트() {
+    Instant created = Instant.parse("2026-05-01T00:00:00Z");
+    ((TestClock) clock).setInstant(created);
+
+    Member saved = transactionTemplate.execute(s -> memberRepository.save(new Member("회원1")));
+
+    Member afterInsert = memberRepository.findById(saved.getId()).orElseThrow();
+    assertThat(afterInsert.getCreatedAt()).isEqualTo(created);
+    assertThat(afterInsert.getUpdatedAt()).isEqualTo(created);
+
+    Instant later = created.plus(Duration.ofMinutes(10));
+    ((TestClock) clock).setInstant(later);
+
+    transactionTemplate.executeWithoutResult(
+        s -> {
+          Member m = memberRepository.findById(saved.getId()).orElseThrow();
+          m.setNickname("회원1-수정");
+        });
+
+    Member afterUpdate = memberRepository.findById(saved.getId()).orElseThrow();
+    assertThat(afterUpdate.getCreatedAt()).isEqualTo(created);
+    assertThat(afterUpdate.getUpdatedAt()).isEqualTo(later);
+  }
+
+  @Test
+  @DisplayName("SocialAccount - connectedAt이 Clock instant로 자동 채움")
+  void socialAccount_connectedAt_자동채움() {
+    Instant fixed = Instant.parse("2026-05-01T12:34:56Z");
+    ((TestClock) clock).setInstant(fixed);
+
+    Member member = transactionTemplate.execute(s -> memberRepository.save(new Member("소셜회원")));
+
+    SocialAccount saved =
+        transactionTemplate.execute(
+            s ->
+                socialAccountRepository.save(
+                    new SocialAccount(member, SocialProvider.KAKAO, "kakao-" + UUID.randomUUID())));
+
+    SocialAccount loaded = socialAccountRepository.findById(saved.getId()).orElseThrow();
+    assertThat(loaded.getConnectedAt()).isEqualTo(fixed);
+  }
+
+  @Test
+  @DisplayName("AuditLog - createdAt이 Clock instant로 자동 채움 (#150 후속 회귀 가드)")
+  void auditLog_createdAt_자동채움() {
+    Instant fixed = Instant.parse("2026-05-01T09:00:00Z");
+    ((TestClock) clock).setInstant(fixed);
+
+    Member admin = transactionTemplate.execute(s -> memberRepository.save(new Member("운영자")));
+
+    AuditLog saved =
+        transactionTemplate.execute(
+            s ->
+                auditLogRepository.save(
+                    new AuditLog(
+                        admin,
+                        AuditAction.SENTENCE_CREATE,
+                        AuditTargetType.SENTENCE,
+                        "1",
+                        "test-detail",
+                        "127.0.0.1")));
+
+    AuditLog loaded = auditLogRepository.findById(saved.getId()).orElseThrow();
+    assertThat(loaded.getCreatedAt()).isEqualTo(fixed);
+  }
+}


### PR DESCRIPTION
## 관련 이슈

Closes #165

## 변경 사항

- `AuditConfig` 신설 — `@EnableJpaAuditing` + `DateTimeProvider` 빈으로 Spring Data JPA Auditing 활성화. 시간 공급자가 `Clock` 빈을 통과하도록 구성하여 엔티티 시간 채움이 프로젝트 표준(Clock 빈)과 정렬됨
- `BaseTimeEntity` / `BaseAuditableEntity` 신설 — `@MappedSuperclass`로 `createdAt`(+`updatedAt`) 시간 필드를 부모 클래스에 응집. `@CreatedDate` / `@LastModifiedDate` 자동 채움
- 9개 엔티티 BaseEntity 상속 적용 — `@PrePersist`/`@PreUpdate` + `Instant.now()` 보일러플레이트 일괄 제거
  - `BaseTimeEntity`: RefreshToken, Announcement, AuditLog, SentenceUpload, DailySentence, GuessHistory, LocalAccount
  - `BaseAuditableEntity`: Member, GameSession
- `SocialAccount` 자체 매핑 — `connectedAt`은 OAuth 첫 연결 시각이라는 비즈니스 의미가 명확하여 BaseEntity 미상속. `@EntityListeners(AuditingEntityListener.class)` + `@CreatedDate`로 동일한 자동 채움 효과 유지
- AuditLog Clock 누락(#150 후속) 자연 해결 — 별도 PR 불요
- `EntityAuditingIntegrationTest` 추가 — TestClock 통한 시점 제어로 4개 케이스 회귀 가드(BaseTime / BaseAuditable / SocialAccount / AuditLog)
- 코드 변화: 86줄 감소 (24 추가 / 110 삭제)
- DB 스키마 변경 없음 — `@MappedSuperclass`는 자식 테이블에 컬럼 매핑만 하므로 Flyway 마이그레이션 불요

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (전체 352 테스트 통과, 신규 4 케이스 포함)
- [x] 불필요한 코드나 주석을 제거했다 (`Instant`/`@PrePersist`/`@PreUpdate` import + 메서드 + 필드 제거)
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다 (`getCreatedAt()`/`getUpdatedAt()` 호출자 모두 부모 `@Getter`로 호환, JPA Criteria `root.get("createdAt")`도 `@MappedSuperclass` 필드 정상 매핑)

## 참고자료

- 향후 시간 정책 변경(예: KST→UTC) 시 `ClockConfig` 한 곳만 수정하면 전 엔티티에 일괄 적용
- BaseEntity 상속 한 줄로 신규 엔티티의 시간 필드 누락 재발 구조적 차단