### PR TITLE
feat: 어드민 enum 한글 라벨 SoT 통합 + 감사 로그 날짜 필터

### DIFF
--- a/frontend/src/features/admin/components/AnnouncementDialog.tsx
+++ b/frontend/src/features/admin/components/AnnouncementDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Button } from "@/shared/ui/Button";
 import { Input } from "@/shared/ui/Input";
 import { useCreateAnnouncement, useUpdateAnnouncement } from "@/features/admin/hooks/useAdminSystem";
+import { ANNOUNCEMENT_TYPE_LABELS } from "@/features/admin/labels";
 import type { AnnouncementResponse } from "@/features/admin/types";
 import { useToastStore } from "@/shared/stores/useToastStore";
 import { ApiError } from "@/shared/api/client";
@@ -119,9 +120,11 @@ export function AnnouncementDialog({ announcement, onClose }: AnnouncementDialog
                 onChange={(e) => setType(e.target.value as "INFO" | "MAINTENANCE" | "WARNING")}
                 className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5"
               >
-                <option value="INFO">안내</option>
-                <option value="MAINTENANCE">점검</option>
-                <option value="WARNING">경고</option>
+                {Object.entries(ANNOUNCEMENT_TYPE_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
               </select>
             </div>
             <div

--- a/frontend/src/features/admin/components/AnnouncementDialog.tsx
+++ b/frontend/src/features/admin/components/AnnouncementDialog.tsx
@@ -118,7 +118,7 @@ export function AnnouncementDialog({ announcement, onClose }: AnnouncementDialog
               <select
                 value={type}
                 onChange={(e) => setType(e.target.value as "INFO" | "MAINTENANCE" | "WARNING")}
-                className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5"
+                className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5 shadow-brutal-sm dark:[color-scheme:dark]"
               >
                 {Object.entries(ANNOUNCEMENT_TYPE_LABELS).map(([value, label]) => (
                   <option key={value} value={value}>
@@ -163,7 +163,7 @@ export function AnnouncementDialog({ announcement, onClose }: AnnouncementDialog
                 type="datetime-local"
                 value={startsAt}
                 onChange={(e) => setStartsAt(e.target.value)}
-                className="w-full border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold"
+                className="w-full border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold shadow-brutal-sm dark:[color-scheme:dark]"
               />
             </div>
             <div>
@@ -172,7 +172,7 @@ export function AnnouncementDialog({ announcement, onClose }: AnnouncementDialog
                 type="datetime-local"
                 value={endsAt}
                 onChange={(e) => setEndsAt(e.target.value)}
-                className="w-full border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold"
+                className="w-full border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold shadow-brutal-sm dark:[color-scheme:dark]"
               />
             </div>
           </div>

--- a/frontend/src/features/admin/components/AuditLogViewer.tsx
+++ b/frontend/src/features/admin/components/AuditLogViewer.tsx
@@ -6,6 +6,14 @@ import { SortableHeader } from "@/features/admin/components/SortableHeader";
 import { AUDIT_ACTION_LABELS, getAuditActionLabel, getAuditTargetTypeLabel } from "@/features/admin/labels";
 import type { AuditLog } from "@/features/admin/types";
 
+function toKstDateFromIso(date: string): string {
+  return `${date}T00:00:00+09:00`;
+}
+
+function toKstDateToIso(date: string): string {
+  return `${date}T23:59:59.999+09:00`;
+}
+
 function AuditLogDetailDialog({ log, onClose }: { log: AuditLog; onClose: () => void }) {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -81,11 +89,16 @@ function AuditLogDetailDialog({ log, onClose }: { log: AuditLog; onClose: () => 
 
 export function AuditLogViewer() {
   const [actionFilter, setActionFilter] = useState("");
+  const [dateFromInput, setDateFromInput] = useState("");
+  const [dateToInput, setDateToInput] = useState("");
   const [page, setPage] = useState(0);
   const [selectedLog, setSelectedLog] = useState<AuditLog | null>(null);
   const { sort, toggleSort } = useSortState();
 
-  const { data, isLoading } = useAuditLogs(actionFilter || undefined, undefined, undefined, sort, page, 20);
+  const dateFromIso = dateFromInput ? toKstDateFromIso(dateFromInput) : undefined;
+  const dateToIso = dateToInput ? toKstDateToIso(dateToInput) : undefined;
+
+  const { data, isLoading } = useAuditLogs(actionFilter || undefined, dateFromIso, dateToIso, sort, page, 20);
 
   function handleSortChange(field: string) {
     toggleSort(field);
@@ -94,7 +107,7 @@ export function AuditLogViewer() {
 
   return (
     <div className="mt-4 space-y-3">
-      <div className="flex gap-2 items-center">
+      <div className="flex gap-2 items-center flex-wrap">
         <select
           value={actionFilter}
           onChange={(e) => {
@@ -110,6 +123,45 @@ export function AuditLogViewer() {
             </option>
           ))}
         </select>
+        <label className="flex items-center gap-1 text-xs font-bold">
+          <span className="text-gray-600 dark:text-gray-400">시작</span>
+          <input
+            type="date"
+            value={dateFromInput}
+            max={dateToInput || undefined}
+            onChange={(e) => {
+              setDateFromInput(e.target.value);
+              setPage(0);
+            }}
+            className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-2 py-1.5"
+          />
+        </label>
+        <label className="flex items-center gap-1 text-xs font-bold">
+          <span className="text-gray-600 dark:text-gray-400">종료</span>
+          <input
+            type="date"
+            value={dateToInput}
+            min={dateFromInput || undefined}
+            onChange={(e) => {
+              setDateToInput(e.target.value);
+              setPage(0);
+            }}
+            className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-2 py-1.5"
+          />
+        </label>
+        {(dateFromInput || dateToInput) && (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => {
+              setDateFromInput("");
+              setDateToInput("");
+              setPage(0);
+            }}
+          >
+            날짜 초기화
+          </Button>
+        )}
       </div>
 
       {isLoading ? (

--- a/frontend/src/features/admin/components/AuditLogViewer.tsx
+++ b/frontend/src/features/admin/components/AuditLogViewer.tsx
@@ -114,7 +114,7 @@ export function AuditLogViewer() {
             setActionFilter(e.target.value);
             setPage(0);
           }}
-          className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5"
+          className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5 shadow-brutal-sm dark:[color-scheme:dark]"
         >
           <option value="">전체 액션</option>
           {Object.entries(AUDIT_ACTION_LABELS).map(([value, label]) => (
@@ -133,7 +133,7 @@ export function AuditLogViewer() {
               setDateFromInput(e.target.value);
               setPage(0);
             }}
-            className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-2 py-1.5"
+            className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-2 py-1.5 shadow-brutal-sm dark:[color-scheme:dark]"
           />
         </label>
         <label className="flex items-center gap-1 text-xs font-bold">
@@ -146,7 +146,7 @@ export function AuditLogViewer() {
               setDateToInput(e.target.value);
               setPage(0);
             }}
-            className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-2 py-1.5"
+            className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-2 py-1.5 shadow-brutal-sm dark:[color-scheme:dark]"
           />
         </label>
         {(dateFromInput || dateToInput) && (

--- a/frontend/src/features/admin/components/AuditLogViewer.tsx
+++ b/frontend/src/features/admin/components/AuditLogViewer.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/shared/ui/Button";
 import { useAuditLogs } from "@/features/admin/hooks/useAdminSystem";
 import { useSortState } from "@/features/admin/hooks/useSortState";
 import { SortableHeader } from "@/features/admin/components/SortableHeader";
+import { AUDIT_ACTION_LABELS, getAuditActionLabel, getAuditTargetTypeLabel } from "@/features/admin/labels";
 import type { AuditLog } from "@/features/admin/types";
 
 function AuditLogDetailDialog({ log, onClose }: { log: AuditLog; onClose: () => void }) {
@@ -44,15 +45,18 @@ function AuditLogDetailDialog({ log, onClose }: { log: AuditLog; onClose: () => 
           <div>
             <p className="text-xs font-bold text-gray-500 dark:text-gray-400">액션</p>
             <p>
-              <span className="inline-block px-1.5 py-0.5 bg-gray-200 dark:bg-gray-700 font-black text-xs">
-                {log.action}
+              <span
+                className="inline-block px-1.5 py-0.5 bg-gray-200 dark:bg-gray-700 font-black text-xs"
+                title={log.action}
+              >
+                {getAuditActionLabel(log.action)}
               </span>
             </p>
           </div>
           <div>
             <p className="text-xs font-bold text-gray-500 dark:text-gray-400">대상</p>
-            <p className="font-medium break-all">
-              {log.targetType}
+            <p className="font-medium break-all" title={log.targetType}>
+              {getAuditTargetTypeLabel(log.targetType)}
               {log.targetId ? `: ${log.targetId}` : ""}
             </p>
           </div>
@@ -100,23 +104,11 @@ export function AuditLogViewer() {
           className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5"
         >
           <option value="">전체 액션</option>
-          <option value="SENTENCE_CREATE">문장 생성</option>
-          <option value="SENTENCE_UPDATE">문장 수정</option>
-          <option value="SENTENCE_DELETE">문장 삭제</option>
-          <option value="CSV_UPLOAD">CSV 업로드</option>
-          <option value="SENTENCE_SCHEDULE">문장 예약</option>
-          <option value="EMERGENCY_REPLACE">긴급 교체</option>
-          <option value="ROLE_CHANGE">역할 변경</option>
-          <option value="USER_BAN">사용자 차단</option>
-          <option value="USER_UNBAN">차단 해제</option>
-          <option value="USER_FORCE_DELETE">강제 탈퇴</option>
-          <option value="USER_FORCE_NICKNAME">닉네임 변경</option>
-          <option value="USER_FORCE_PROFILE_DELETE">프로필 삭제</option>
-          <option value="ANNOUNCEMENT_CREATE">공지 생성</option>
-          <option value="ANNOUNCEMENT_UPDATE">공지 수정</option>
-          <option value="ANNOUNCEMENT_DELETE">공지 삭제</option>
-          <option value="RANKING_CACHE_RESET">캐시 리셋</option>
-          <option value="RATE_LIMIT_RESET">Rate Limit 리셋</option>
+          {Object.entries(AUDIT_ACTION_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
         </select>
       </div>
 
@@ -163,12 +155,15 @@ export function AuditLogViewer() {
                     </td>
                     <td className="px-3 py-2 font-bold">{log.adminNickname}</td>
                     <td className="px-3 py-2">
-                      <span className="inline-block px-1.5 py-0.5 bg-gray-200 dark:bg-gray-700 font-black text-[10px]">
-                        {log.action}
+                      <span
+                        className="inline-block px-1.5 py-0.5 bg-gray-200 dark:bg-gray-700 font-black text-[10px]"
+                        title={log.action}
+                      >
+                        {getAuditActionLabel(log.action)}
                       </span>
                     </td>
-                    <td className="px-3 py-2 text-gray-600 dark:text-gray-400">
-                      {log.targetType}
+                    <td className="px-3 py-2 text-gray-600 dark:text-gray-400" title={log.targetType}>
+                      {getAuditTargetTypeLabel(log.targetType)}
                       {log.targetId ? `: ${log.targetId.slice(0, 8)}...` : ""}
                     </td>
                     <td className="px-3 py-2 text-gray-500 dark:text-gray-400 truncate max-w-[200px]">

--- a/frontend/src/features/admin/components/CsvUploadDialog.tsx
+++ b/frontend/src/features/admin/components/CsvUploadDialog.tsx
@@ -56,7 +56,7 @@ export function CsvUploadDialog({ onClose }: CsvUploadDialogProps) {
             type="file"
             accept=".csv"
             onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-            className="block w-full text-sm font-bold file:mr-3 file:border-4 file:border-black file:dark:border-white file:bg-yellow-300 file:text-black file:font-bold file:px-3 file:py-1.5 file:text-sm file:cursor-pointer"
+            className="block w-full text-sm font-bold dark:[color-scheme:dark] file:mr-3 file:border-4 file:border-black file:dark:border-white file:shadow-brutal-sm file:bg-yellow-300 file:text-black file:font-bold file:px-3 file:py-1.5 file:text-sm file:cursor-pointer"
           />
 
           {file && <p className="text-sm font-bold">{file.name}</p>}

--- a/frontend/src/features/admin/components/SentenceDetailDialog.tsx
+++ b/frontend/src/features/admin/components/SentenceDetailDialog.tsx
@@ -168,7 +168,7 @@ export function SentenceDetailDialog({ sentence, onClose }: SentenceDetailDialog
                     type="date"
                     value={scheduleDate}
                     onChange={(e) => setScheduleDate(e.target.value)}
-                    className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold"
+                    className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold shadow-brutal-sm dark:[color-scheme:dark]"
                   />
                   <Button size="sm" onClick={handleSchedule} isLoading={scheduleMutation.isPending}>
                     예약

--- a/frontend/src/features/admin/components/SentenceTab.tsx
+++ b/frontend/src/features/admin/components/SentenceTab.tsx
@@ -78,7 +78,7 @@ export function SentenceTab() {
             setStatusFilter(e.target.value);
             setPage(0);
           }}
-          className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5"
+          className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5 shadow-brutal-sm dark:[color-scheme:dark]"
         >
           <option value="">전체</option>
           <option value="ACTIVE">ACTIVE</option>

--- a/frontend/src/features/admin/components/SystemTab.tsx
+++ b/frontend/src/features/admin/components/SystemTab.tsx
@@ -9,6 +9,7 @@ import {
 import { AnnouncementDialog } from "@/features/admin/components/AnnouncementDialog";
 import { AuditLogViewer } from "@/features/admin/components/AuditLogViewer";
 import { useDeleteAnnouncement } from "@/features/admin/hooks/useAdminSystem";
+import { getAnnouncementTypeLabel } from "@/features/admin/labels";
 import type { AnnouncementResponse } from "@/features/admin/types";
 import { useToastStore } from "@/shared/stores/useToastStore";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
@@ -23,12 +24,6 @@ function StatusIndicator({ healthy, label }: { healthy: boolean; label: string }
   );
 }
 
-const TYPE_LABELS: Record<string, string> = {
-  INFO: "안내",
-  MAINTENANCE: "점검",
-  WARNING: "경고",
-};
-
 function AnnouncementTypeBadge({ type }: { type: string }) {
   const colors: Record<string, string> = {
     INFO: "bg-blue-300 text-black",
@@ -39,7 +34,7 @@ function AnnouncementTypeBadge({ type }: { type: string }) {
     <span
       className={`inline-block px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white ${colors[type] ?? "bg-gray-300 text-black"}`}
     >
-      {TYPE_LABELS[type] ?? type}
+      {getAnnouncementTypeLabel(type)}
     </span>
   );
 }

--- a/frontend/src/features/admin/components/UserTab.tsx
+++ b/frontend/src/features/admin/components/UserTab.tsx
@@ -62,7 +62,7 @@ export function UserTab() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="닉네임 검색"
-          className="max-w-xs !py-1.5 !text-sm"
+          className="max-w-xs !py-1.5 !text-sm !shadow-brutal-sm"
         />
         <select
           value={bannedFilter === undefined ? "" : String(bannedFilter)}
@@ -71,7 +71,7 @@ export function UserTab() {
             setBannedFilter(val === "" ? undefined : val === "true");
             setPage(0);
           }}
-          className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5"
+          className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5 shadow-brutal-sm dark:[color-scheme:dark]"
         >
           <option value="">전체</option>
           <option value="true">차단됨</option>

--- a/frontend/src/features/admin/labels.ts
+++ b/frontend/src/features/admin/labels.ts
@@ -1,0 +1,45 @@
+export const AUDIT_ACTION_LABELS: Record<string, string> = {
+  SENTENCE_CREATE: "문장 생성",
+  SENTENCE_UPDATE: "문장 수정",
+  SENTENCE_DELETE: "문장 삭제",
+  SENTENCE_SCHEDULE: "문장 예약",
+  SENTENCE_UNSCHEDULE: "문장 예약 취소",
+  EMERGENCY_REPLACE: "문장 긴급 교체",
+  CSV_UPLOAD: "문장 CSV 업로드",
+  ROLE_CHANGE: "회원 역할 변경",
+  USER_BAN: "회원 차단",
+  USER_UNBAN: "회원 차단 해제",
+  USER_FORCE_DELETE: "회원 강제 탈퇴",
+  USER_FORCE_NICKNAME: "회원 닉네임 강제 변경",
+  USER_FORCE_PROFILE_DELETE: "회원 프로필 강제 삭제",
+  ANNOUNCEMENT_CREATE: "공지 생성",
+  ANNOUNCEMENT_UPDATE: "공지 수정",
+  ANNOUNCEMENT_DELETE: "공지 삭제",
+  RANKING_CACHE_RESET: "랭킹 캐시 초기화",
+  RATE_LIMIT_RESET: "Rate Limit 초기화",
+};
+
+export const AUDIT_TARGET_TYPE_LABELS: Record<string, string> = {
+  SENTENCE: "문장",
+  MEMBER: "회원",
+  ANNOUNCEMENT: "공지",
+  SYSTEM: "시스템",
+};
+
+export const ANNOUNCEMENT_TYPE_LABELS: Record<string, string> = {
+  INFO: "안내",
+  MAINTENANCE: "점검",
+  WARNING: "경고",
+};
+
+export function getAuditActionLabel(action: string): string {
+  return AUDIT_ACTION_LABELS[action] ?? action;
+}
+
+export function getAuditTargetTypeLabel(type: string): string {
+  return AUDIT_TARGET_TYPE_LABELS[type] ?? type;
+}
+
+export function getAnnouncementTypeLabel(type: string): string {
+  return ANNOUNCEMENT_TYPE_LABELS[type] ?? type;
+}


### PR DESCRIPTION
## 관련 이슈

Closes #167

## 변경 사항

### 라벨 SoT 통합 (refactor)
- `frontend/src/features/admin/labels.ts` 신설 - `AUDIT_ACTION_LABELS`(18개), `AUDIT_TARGET_TYPE_LABELS`(4개), `ANNOUNCEMENT_TYPE_LABELS`(3개) + 헬퍼 3개
- 라벨 정책 `[대상] 동작` 형식으로 통일 (예: 회원 강제 탈퇴, 랭킹 캐시 초기화)
- `AuditLogViewer`/`SystemTab`/`AnnouncementDialog`에서 inline 라벨 제거하고 헬퍼/매핑 경유
- 매핑 누락 시 enum 원본을 fallback으로 표시 (BE 신규 enum 추가 시 가시성 확보)
- 영문 enum 원본은 셀 `title` 속성에 보존 (운영 디버깅 보조)

### 감사 로그 dateFrom/dateTo 필터 (feat)
- `<input type="date">` 두 개를 액션 select 옆에 배치
- BE `Instant` 수신에 맞춰 KST 보정: dateFrom `T00:00:00+09:00`, dateTo `T23:59:59.999+09:00` (그 날 inclusive)
- 필터 변경 시 `setPage(0)` 리셋, `min`/`max`로 dateFrom > dateTo 가드, "날짜 초기화" 버튼 추가

### 어드민 sm 컨트롤 다크모드 시인성 + 그림자 일관성 (fix, 작업 중 발견)
- 다크모드에서 native picker indicator(캘린더/시계 아이콘, dropdown 화살표, file 텍스트)가 검정으로 묻히는 회귀를 `dark:[color-scheme:dark]`로 일괄 수정 (9개 위치)
- 어드민 sm 컨트롤(select/date/datetime-local/file)에 `shadow-brutal-sm` 추가, UserTab Input은 `!shadow-brutal-sm`로 override해 어드민 sm 컨트롤(Input·select·date·file·Button-sm) 그림자를 3px로 통일

## 알려진 한계
- 공지 유형 **색상**(blue-300/orange-300/red-400/red-500)은 여전히 3곳 분산(`SystemTab#AnnouncementTypeBadge`, `AnnouncementDialog#미리보기`, `AnnouncementBanner#TYPE_COLORS`). 라벨 SoT는 정리됐으나 색상 SoT 통합은 후속 이슈 대상
- WARNING 색상이 `red-400`(SystemTab/Dialog 미리보기) vs `red-500`(AnnouncementBanner)로 미세 불일치 - 후속 이슈로 분리

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다