### PR TITLE
refactor: 공지 유형 색상 SoT 통합 + Input size variant 도입

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -195,11 +195,16 @@ hue = (similarity / 100) × 120
 ### 입력창
 
 ```
-border-4 border-black rounded-none shadow-brutal bg-white dark:bg-gray-900
-px-4 py-3 font-medium text-lg
-focus:outline-none focus:ring-0 focus:border-indigo-500 dark:focus:border-indigo-400
-placeholder:text-gray-400
+공통: border-4 border-black rounded-none bg-white dark:bg-gray-900 font-medium
+      focus:outline-none focus:ring-0 focus:border-indigo-500 dark:focus:border-indigo-400
+      placeholder:text-gray-400
+md(기본): shadow-brutal px-4 py-3 text-lg
+sm: shadow-brutal-sm px-3 py-1.5 text-sm
 ```
+
+- `Input` 컴포넌트는 `size?: "sm" | "md"` prop을 받는다 (default `"md"`)
+- 어드민 폼 필드 등 컴팩트 컨트롤에는 `size="sm"` 사용 (옆 select/Button-sm과 그림자 3px로 일치)
+- 게임/마이페이지/로그인 등 기본 입력은 `size="md"` (별도 지정 불필요)
 
 ### 카드
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -299,5 +299,5 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **다이얼로그**: `border-4 shadow-brutal max-w-lg`. 헤더 `border-b-4 px-6 py-5`. 푸터 `border-t-4`. `role="dialog" aria-modal="true"` + Escape 닫기 필수
 - **텍스트 링크 액션**: 테이블 행 내 액션은 `text-indigo-600 dark:text-indigo-400 font-black text-xs hover:underline`
 - **Pagination**: `Button sm secondary` 이전/다음 + `tabular-nums` 페이지 표시
-- **공지 유형 라벨**: 안내(blue-300), 점검(orange-300), 경고(red-400). select에서도 한글 라벨 사용
+- **공지 유형 라벨**: 안내(blue-300), 점검(orange-300), 경고(red-500). select에서도 한글 라벨 사용. SoT는 `shared/config/announcement.ts`
 - **공지 배너**: `shared/ui/AnnouncementBanner.tsx`. 유형별 색상 배경 + `shadow-brutal-sm`. 닫기 시 localStorage `id_startsAt` 복합 키 저장

--- a/frontend/src/features/admin/components/AnnouncementDialog.tsx
+++ b/frontend/src/features/admin/components/AnnouncementDialog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Button } from "@/shared/ui/Button";
 import { Input } from "@/shared/ui/Input";
 import { useCreateAnnouncement, useUpdateAnnouncement } from "@/features/admin/hooks/useAdminSystem";
-import { ANNOUNCEMENT_TYPE_LABELS } from "@/features/admin/labels";
+import { ANNOUNCEMENT_TYPE_LABELS, getAnnouncementTypeColor } from "@/shared/config/announcement";
 import type { AnnouncementResponse } from "@/features/admin/types";
 import { useToastStore } from "@/shared/stores/useToastStore";
 import { ApiError } from "@/shared/api/client";
@@ -128,14 +128,7 @@ export function AnnouncementDialog({ announcement, onClose }: AnnouncementDialog
               </select>
             </div>
             <div
-              className={[
-                "border-4 border-black dark:border-white px-3 py-1 text-xs font-black",
-                type === "INFO"
-                  ? "bg-blue-300 text-black"
-                  : type === "MAINTENANCE"
-                    ? "bg-orange-300 text-black"
-                    : "bg-red-500 text-white",
-              ].join(" ")}
+              className={`border-4 border-black dark:border-white px-3 py-1 text-xs font-black ${getAnnouncementTypeColor(type)}`}
             >
               미리보기
             </div>

--- a/frontend/src/features/admin/components/SystemTab.tsx
+++ b/frontend/src/features/admin/components/SystemTab.tsx
@@ -9,7 +9,7 @@ import {
 import { AnnouncementDialog } from "@/features/admin/components/AnnouncementDialog";
 import { AuditLogViewer } from "@/features/admin/components/AuditLogViewer";
 import { useDeleteAnnouncement } from "@/features/admin/hooks/useAdminSystem";
-import { getAnnouncementTypeLabel } from "@/features/admin/labels";
+import { getAnnouncementTypeColor, getAnnouncementTypeLabel } from "@/shared/config/announcement";
 import type { AnnouncementResponse } from "@/features/admin/types";
 import { useToastStore } from "@/shared/stores/useToastStore";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
@@ -25,14 +25,9 @@ function StatusIndicator({ healthy, label }: { healthy: boolean; label: string }
 }
 
 function AnnouncementTypeBadge({ type }: { type: string }) {
-  const colors: Record<string, string> = {
-    INFO: "bg-blue-300 text-black",
-    MAINTENANCE: "bg-orange-300 text-black",
-    WARNING: "bg-red-400 text-white",
-  };
   return (
     <span
-      className={`inline-block px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white ${colors[type] ?? "bg-gray-300 text-black"}`}
+      className={`inline-block px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white ${getAnnouncementTypeColor(type)}`}
     >
       {getAnnouncementTypeLabel(type)}
     </span>

--- a/frontend/src/features/admin/components/UserTab.tsx
+++ b/frontend/src/features/admin/components/UserTab.tsx
@@ -59,10 +59,11 @@ export function UserTab() {
 
       <form onSubmit={handleSearch} className="flex gap-2 items-center">
         <Input
+          size="sm"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="닉네임 검색"
-          className="max-w-xs !py-1.5 !text-sm !shadow-brutal-sm"
+          className="max-w-xs"
         />
         <select
           value={bannedFilter === undefined ? "" : String(bannedFilter)}

--- a/frontend/src/features/admin/labels.ts
+++ b/frontend/src/features/admin/labels.ts
@@ -26,20 +26,10 @@ export const AUDIT_TARGET_TYPE_LABELS: Record<string, string> = {
   SYSTEM: "시스템",
 };
 
-export const ANNOUNCEMENT_TYPE_LABELS: Record<string, string> = {
-  INFO: "안내",
-  MAINTENANCE: "점검",
-  WARNING: "경고",
-};
-
 export function getAuditActionLabel(action: string): string {
   return AUDIT_ACTION_LABELS[action] ?? action;
 }
 
 export function getAuditTargetTypeLabel(type: string): string {
   return AUDIT_TARGET_TYPE_LABELS[type] ?? type;
-}
-
-export function getAnnouncementTypeLabel(type: string): string {
-  return ANNOUNCEMENT_TYPE_LABELS[type] ?? type;
 }

--- a/frontend/src/shared/config/announcement.ts
+++ b/frontend/src/shared/config/announcement.ts
@@ -1,0 +1,19 @@
+export const ANNOUNCEMENT_TYPE_LABELS: Record<string, string> = {
+  INFO: "안내",
+  MAINTENANCE: "점검",
+  WARNING: "경고",
+};
+
+export const ANNOUNCEMENT_TYPE_COLORS: Record<string, string> = {
+  INFO: "bg-blue-300 text-black",
+  MAINTENANCE: "bg-orange-300 text-black",
+  WARNING: "bg-red-500 text-white",
+};
+
+export function getAnnouncementTypeLabel(type: string): string {
+  return ANNOUNCEMENT_TYPE_LABELS[type] ?? type;
+}
+
+export function getAnnouncementTypeColor(type: string): string {
+  return ANNOUNCEMENT_TYPE_COLORS[type] ?? "bg-gray-300 text-black";
+}

--- a/frontend/src/shared/ui/AnnouncementBanner.tsx
+++ b/frontend/src/shared/ui/AnnouncementBanner.tsx
@@ -2,14 +2,9 @@ import { useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getActiveAnnouncements } from "@/shared/api/announcements";
 import type { ActiveAnnouncementResponse } from "@/shared/api/types";
+import { getAnnouncementTypeColor } from "@/shared/config/announcement";
 
 const STORAGE_KEY = "gakkaweo-dismissed-announcements";
-
-const TYPE_COLORS: Record<string, string> = {
-  INFO: "bg-blue-300 border-black dark:border-white text-black",
-  MAINTENANCE: "bg-orange-300 border-black dark:border-white text-black",
-  WARNING: "bg-red-500 border-black dark:border-white text-white",
-};
 
 function toDismissKey(a: ActiveAnnouncementResponse): string {
   return `${a.id}_${a.startsAt}`;
@@ -42,10 +37,12 @@ function BannerItem({
   announcement: ActiveAnnouncementResponse;
   onDismiss: (key: string) => void;
 }) {
-  const colorClass = TYPE_COLORS[announcement.type] ?? TYPE_COLORS.INFO;
+  const colorClass = getAnnouncementTypeColor(announcement.type);
 
   return (
-    <div className={`border-4 ${colorClass} shadow-brutal-sm px-5 py-3 flex items-start gap-3`}>
+    <div
+      className={`border-4 border-black dark:border-white ${colorClass} shadow-brutal-sm px-5 py-3 flex items-start gap-3`}
+    >
       <div className="flex-1 min-w-0">
         <p className="font-black text-sm">{announcement.title}</p>
         {announcement.content && (

--- a/frontend/src/shared/ui/Input.tsx
+++ b/frontend/src/shared/ui/Input.tsx
@@ -1,18 +1,27 @@
 import type { InputHTMLAttributes, Ref } from "react";
 
-interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+type Size = "sm" | "md";
+
+interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
   ref?: Ref<HTMLInputElement>;
+  size?: Size;
 }
 
-export function Input({ className = "", ref, ...rest }: InputProps) {
+const SIZE_CLASSES: Record<Size, string> = {
+  sm: "shadow-brutal-sm px-3 py-1.5 text-sm",
+  md: "shadow-brutal px-4 py-3 text-lg",
+};
+
+export function Input({ className = "", size = "md", ref, ...rest }: InputProps) {
   return (
     <input
       ref={ref}
       spellCheck={false}
       className={[
-        "border-4 border-black dark:border-white rounded-none shadow-brutal bg-white dark:bg-gray-900",
-        "text-black dark:text-white px-4 py-3 font-medium text-lg w-full",
+        "border-4 border-black dark:border-white rounded-none bg-white dark:bg-gray-900",
+        "text-black dark:text-white font-medium w-full",
         "focus:outline-none focus:ring-0 focus:border-indigo-500 dark:focus:border-indigo-400 placeholder:text-gray-400",
+        SIZE_CLASSES[size],
         className,
       ].join(" ")}
       {...rest}


### PR DESCRIPTION
## 관련 이슈

Closes #169

## 변경 사항

- `shared/config/announcement.ts` 신설: 공지 유형 라벨/색상/헬퍼를 단일 모듈로 응집
  - `ANNOUNCEMENT_TYPE_LABELS` / `ANNOUNCEMENT_TYPE_COLORS` / `getAnnouncementTypeLabel()` / `getAnnouncementTypeColor()`
  - 라벨도 어드민 종속이 아니라 시스템 전체 enum이므로 `features/admin/labels.ts`에서 이동
- 공지 유형 색상 inline 분산 3곳을 헬퍼 호출로 단일화
  - `SystemTab#AnnouncementTypeBadge`: WARNING **red-400 → red-500** 보정 (배너/미리보기 기준에 맞춤)
  - `AnnouncementDialog` 미리보기: 삼항 분기 제거
  - `AnnouncementBanner`: `TYPE_COLORS` 상수 제거, border 클래스만 컴포넌트에 잔존(관심사 분리)
- `Input` 컴포넌트에 `size?: \"sm\" | \"md\"` prop 추가 (default `\"md\"`)
  - sm: `shadow-brutal-sm` + `px-3 py-1.5 text-sm` / md: 기존과 동일
  - HTMLInputElement native `size` 속성과 충돌 방지 위해 `Omit` 적용
  - `UserTab` 닉네임 검색의 `!py-1.5 !text-sm !shadow-brutal-sm` important override 3개 제거
- `docs/design-system.md` 입력창 절에 sm/md variant 정의 + 사용 가이드 추가

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다 (\`pnpm format:check / lint / build\` 통과)
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다 (Input default \`md\`로 기존 사용처 무영향, 색상 변화는 어드민 배지 WARNING만 의도적)

## 참고자료

- 후속 PR: #168 (어드민 enum 한글 라벨 SoT 통합) 의 잔여 부채 정리
- 패턴 참고: \`shared/config/sound.ts\` (config 모듈), \`shared/ui/Button.tsx\` (size variant)