### PR TITLE
refactor: Properties 일괄 record 전환

### DIFF
--- a/backend/.idea/codeStyles/Project.xml
+++ b/backend/.idea/codeStyles/Project.xml
@@ -1,0 +1,9 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="DO_NOT_FORMAT">
+      <list>
+        <fileSet type="globPattern" pattern="*/db/migration/*" />
+      </list>
+    </option>
+  </code_scheme>
+</component>

--- a/backend/src/main/java/com/gakkaweo/backend/auth/config/CookieProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/config/CookieProperties.java
@@ -1,14 +1,6 @@
 package com.gakkaweo.backend.auth.config;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "cookie")
-@Getter
-@RequiredArgsConstructor
-public class CookieProperties {
-
-  private final boolean secure;
-  private final String domain;
-}
+public record CookieProperties(boolean secure, String domain) {}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/config/JwtProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/config/JwtProperties.java
@@ -1,16 +1,8 @@
 package com.gakkaweo.backend.auth.config;
 
 import java.time.Duration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "jwt")
-@Getter
-@RequiredArgsConstructor
-public class JwtProperties {
-
-  private final String accessSecret;
-  private final Duration accessExpiration;
-  private final Duration refreshExpiration;
-}
+public record JwtProperties(
+    String accessSecret, Duration accessExpiration, Duration refreshExpiration) {}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/config/OAuth2Properties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/config/OAuth2Properties.java
@@ -1,13 +1,6 @@
 package com.gakkaweo.backend.auth.config;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.oauth2")
-@Getter
-@RequiredArgsConstructor
-public class OAuth2Properties {
-
-  private final String authorizedRedirectUri;
-}
+public record OAuth2Properties(String authorizedRedirectUri) {}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/config/ProfileImageProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/config/ProfileImageProperties.java
@@ -1,13 +1,6 @@
 package com.gakkaweo.backend.auth.config;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.upload")
-@Getter
-@RequiredArgsConstructor
-public class ProfileImageProperties {
-
-  private final String profileDir;
-}
+public record ProfileImageProperties(String profileDir) {}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/jwt/JwtProvider.java
@@ -20,9 +20,9 @@ public class JwtProvider {
   private final Clock clock;
 
   public JwtProvider(JwtProperties jwtProperties, Clock clock) {
-    byte[] keyBytes = Base64.getDecoder().decode(jwtProperties.getAccessSecret());
+    byte[] keyBytes = Base64.getDecoder().decode(jwtProperties.accessSecret());
     this.secretKey = Keys.hmacShaKeyFor(keyBytes);
-    this.accessExpirationMillis = jwtProperties.getAccessExpiration().toMillis();
+    this.accessExpirationMillis = jwtProperties.accessExpiration().toMillis();
     this.clock = clock;
   }
 

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/CookieAuthorizationRequestRepository.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/CookieAuthorizationRequestRepository.java
@@ -50,7 +50,7 @@ public class CookieAuthorizationRequestRepository
         ResponseCookie.from(COOKIE_NAME, serialized)
             .path("/")
             .httpOnly(true)
-            .secure(cookieProperties.isSecure())
+            .secure(cookieProperties.secure())
             .sameSite("Lax")
             .maxAge(COOKIE_EXPIRE_SECONDS)
             .build();
@@ -72,7 +72,7 @@ public class CookieAuthorizationRequestRepository
         ResponseCookie.from(COOKIE_NAME, "")
             .path("/")
             .httpOnly(true)
-            .secure(cookieProperties.isSecure())
+            .secure(cookieProperties.secure())
             .sameSite("Lax")
             .maxAge(0)
             .build();

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -30,6 +30,6 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
     String message = exception.getMessage() != null ? exception.getMessage() : "로그인에 실패했습니다";
     String errorMessage = URLEncoder.encode(message, StandardCharsets.UTF_8);
-    response.sendRedirect(oAuth2Properties.getAuthorizedRedirectUri() + "?error=" + errorMessage);
+    response.sendRedirect(oAuth2Properties.authorizedRedirectUri() + "?error=" + errorMessage);
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -45,6 +45,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     authorizationRequestRepository.deleteCookie(response);
 
-    response.sendRedirect(oAuth2Properties.getAuthorizedRedirectUri());
+    response.sendRedirect(oAuth2Properties.authorizedRedirectUri());
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/ProfileImageService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/ProfileImageService.java
@@ -28,7 +28,7 @@ public class ProfileImageService {
 
   @PostConstruct
   void init() {
-    uploadDir = Path.of(properties.getProfileDir());
+    uploadDir = Path.of(properties.profileDir());
     try {
       Files.createDirectories(uploadDir);
       log.info("프로필 이미지 업로드 디렉토리 준비 완료: {}", uploadDir.toAbsolutePath());

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
@@ -35,7 +35,7 @@ public class RefreshTokenService {
     String rawToken = UUID.randomUUID().toString();
     String tokenHash = hashToken(rawToken);
     UUID familyId = UUID.randomUUID();
-    Instant expiresAt = clock.instant().plus(jwtProperties.getRefreshExpiration());
+    Instant expiresAt = clock.instant().plus(jwtProperties.refreshExpiration());
 
     RefreshToken refreshToken = new RefreshToken(member, tokenHash, familyId, expiresAt);
     refreshTokenRepository.save(refreshToken);
@@ -69,7 +69,7 @@ public class RefreshTokenService {
 
     String newRawToken = UUID.randomUUID().toString();
     String newTokenHash = hashToken(newRawToken);
-    Instant expiresAt = clock.instant().plus(jwtProperties.getRefreshExpiration());
+    Instant expiresAt = clock.instant().plus(jwtProperties.refreshExpiration());
 
     RefreshToken newRefreshToken =
         new RefreshToken(existing.getMember(), newTokenHash, existing.getFamilyId(), expiresAt);

--- a/backend/src/main/java/com/gakkaweo/backend/auth/util/CookieUtils.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/util/CookieUtils.java
@@ -17,9 +17,9 @@ public class CookieUtils {
     return applyDomain(
             ResponseCookie.from("access_token", token)
                 .httpOnly(true)
-                .secure(cookieProperties.isSecure())
+                .secure(cookieProperties.secure())
                 .path("/")
-                .maxAge(jwtProperties.getAccessExpiration())
+                .maxAge(jwtProperties.accessExpiration())
                 .sameSite("Lax"))
         .build();
   }
@@ -28,9 +28,9 @@ public class CookieUtils {
     return applyDomain(
             ResponseCookie.from("refresh_token", token)
                 .httpOnly(true)
-                .secure(cookieProperties.isSecure())
+                .secure(cookieProperties.secure())
                 .path("/auth/refresh")
-                .maxAge(jwtProperties.getRefreshExpiration())
+                .maxAge(jwtProperties.refreshExpiration())
                 .sameSite("Lax"))
         .build();
   }
@@ -39,7 +39,7 @@ public class CookieUtils {
     return applyDomain(
             ResponseCookie.from("access_token", "")
                 .httpOnly(true)
-                .secure(cookieProperties.isSecure())
+                .secure(cookieProperties.secure())
                 .path("/")
                 .maxAge(0)
                 .sameSite("Lax"))
@@ -50,7 +50,7 @@ public class CookieUtils {
     return applyDomain(
             ResponseCookie.from("refresh_token", "")
                 .httpOnly(true)
-                .secure(cookieProperties.isSecure())
+                .secure(cookieProperties.secure())
                 .path("/auth/refresh")
                 .maxAge(0)
                 .sameSite("Lax"))
@@ -61,9 +61,9 @@ public class CookieUtils {
     return applyDomain(
             ResponseCookie.from("has_session", "1")
                 .httpOnly(false)
-                .secure(cookieProperties.isSecure())
+                .secure(cookieProperties.secure())
                 .path("/")
-                .maxAge(jwtProperties.getRefreshExpiration())
+                .maxAge(jwtProperties.refreshExpiration())
                 .sameSite("Lax"))
         .build();
   }
@@ -72,7 +72,7 @@ public class CookieUtils {
     return applyDomain(
             ResponseCookie.from("has_session", "")
                 .httpOnly(false)
-                .secure(cookieProperties.isSecure())
+                .secure(cookieProperties.secure())
                 .path("/")
                 .maxAge(0)
                 .sameSite("Lax"))
@@ -81,7 +81,7 @@ public class CookieUtils {
 
   private ResponseCookie.ResponseCookieBuilder applyDomain(
       ResponseCookie.ResponseCookieBuilder builder) {
-    String domain = cookieProperties.getDomain();
+    String domain = cookieProperties.domain();
     if (domain != null && !domain.isBlank()) {
       builder.domain(domain);
     }

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -93,7 +93,7 @@ public class SecurityConfig {
                     .requestMatchers("/v3/api-docs/full")
                     .access(
                         (authentication, context) ->
-                            new AuthorizationDecision(openApiProperties.isDocsMode()))
+                            new AuthorizationDecision(openApiProperties.docsMode()))
                     .requestMatchers(HttpMethod.GET, "/daily/today")
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/daily/guess")
@@ -139,7 +139,7 @@ public class SecurityConfig {
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
-    configuration.setAllowedOrigins(List.of(oAuth2Properties.getAuthorizedRedirectUri()));
+    configuration.setAllowedOrigins(List.of(oAuth2Properties.authorizedRedirectUri()));
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setAllowCredentials(true);

--- a/backend/src/main/java/com/gakkaweo/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/WebConfig.java
@@ -16,7 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
     registry
         .addResourceHandler("/uploads/profiles/**")
-        .addResourceLocations("file:" + profileImageProperties.getProfileDir() + "/")
+        .addResourceLocations("file:" + profileImageProperties.profileDir() + "/")
         .setCachePeriod(31536000);
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/config/openapi/OpenApiProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/openapi/OpenApiProperties.java
@@ -1,13 +1,6 @@
 package com.gakkaweo.backend.config.openapi;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.openapi")
-@Getter
-@RequiredArgsConstructor
-public class OpenApiProperties {
-
-  private final boolean docsMode;
-}
+public record OpenApiProperties(boolean docsMode) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/config/GameProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/config/GameProperties.java
@@ -1,17 +1,11 @@
 package com.gakkaweo.backend.game.config;
 
 import java.math.BigDecimal;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.game")
-@Getter
-@RequiredArgsConstructor
-public class GameProperties {
-
-  private final BigDecimal similarityThreshold;
-  private final BigDecimal hintTriggerThreshold;
-  private final BigDecimal hintMaxSimilarity;
-  private final int hintMaxCount;
-}
+public record GameProperties(
+    BigDecimal similarityThreshold,
+    BigDecimal hintTriggerThreshold,
+    BigDecimal hintMaxSimilarity,
+    int hintMaxCount) {}

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -97,7 +97,7 @@ public class DailyGameService {
         similarityService.calculateSimilarity(
             sentence.getId(), request.guessText(), sentence.getSentence(), remainingTtl());
 
-    boolean isCorrect = similarity.compareTo(gameProperties.getSimilarityThreshold()) >= 0;
+    boolean isCorrect = similarity.compareTo(gameProperties.similarityThreshold()) >= 0;
 
     BigDecimal previousBest = session.getBestSimilarity();
     Instant now = clock.instant();
@@ -143,7 +143,7 @@ public class DailyGameService {
         similarityService.calculateSimilarity(
             sentence.getId(), request.guessText(), sentence.getSentence(), remainingTtl());
 
-    boolean isCorrect = similarity.compareTo(gameProperties.getSimilarityThreshold()) >= 0;
+    boolean isCorrect = similarity.compareTo(gameProperties.similarityThreshold()) >= 0;
 
     return new GuessResponse(similarity, null, isCorrect, null, clock.instant());
   }
@@ -184,16 +184,15 @@ public class DailyGameService {
             .findByMemberAndSentence(member, sentence)
             .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
 
-    if (session.getBestSimilarity().compareTo(gameProperties.getHintTriggerThreshold()) < 0) {
+    if (session.getBestSimilarity().compareTo(gameProperties.hintTriggerThreshold()) < 0) {
       throw new BusinessException(ErrorCode.HINT_NOT_AVAILABLE);
     }
 
-    BigDecimal maxSimilarity =
-        session.getBestSimilarity().min(gameProperties.getHintMaxSimilarity());
+    BigDecimal maxSimilarity = session.getBestSimilarity().min(gameProperties.hintMaxSimilarity());
 
     List<HintProjection> projections =
         guessHistoryRepository.findHints(
-            sentence.getId(), member.getId(), maxSimilarity, gameProperties.getHintMaxCount());
+            sentence.getId(), member.getId(), maxSimilarity, gameProperties.hintMaxCount());
 
     List<HintResponse.HintEntry> entries =
         projections.stream()

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/config/AiServiceConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/config/AiServiceConfig.java
@@ -10,12 +10,12 @@ public class AiServiceConfig {
 
   @Bean
   RestClient aiServiceRestClient(AiServiceProperties properties) {
-    int timeoutMillis = (int) properties.getTimeout().toMillis();
+    int timeoutMillis = (int) properties.timeout().toMillis();
 
     SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
     factory.setConnectTimeout(timeoutMillis);
     factory.setReadTimeout(timeoutMillis);
 
-    return RestClient.builder().baseUrl(properties.getUrl()).requestFactory(factory).build();
+    return RestClient.builder().baseUrl(properties.url()).requestFactory(factory).build();
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/config/AiServiceProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/config/AiServiceProperties.java
@@ -1,15 +1,7 @@
 package com.gakkaweo.backend.infra.ai.config;
 
 import java.time.Duration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.ai-service")
-@Getter
-@RequiredArgsConstructor
-public class AiServiceProperties {
-
-  private final String url;
-  private final Duration timeout;
-}
+public record AiServiceProperties(String url, Duration timeout) {}

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/client/DiscordWebhookClient.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/client/DiscordWebhookClient.java
@@ -36,7 +36,7 @@ public class DiscordWebhookClient {
   }
 
   private void dispatch(DiscordWebhookPayload payload) {
-    String webhookUrl = properties.getWebhookUrl();
+    String webhookUrl = properties.webhookUrl();
     if (!StringUtils.hasText(webhookUrl)) {
       log.debug("Discord 웹훅 URL 미설정, 전송 건너뜀");
       return;
@@ -58,7 +58,7 @@ public class DiscordWebhookClient {
   private String buildContent(NotificationLevel level) {
     return switch (level) {
       case HIGH -> {
-        String roleId = properties.getMentionRoleId();
+        String roleId = properties.mentionRoleId();
         yield StringUtils.hasText(roleId) ? "<@&" + roleId + ">" : "";
       }
       case INFO -> "";
@@ -68,7 +68,7 @@ public class DiscordWebhookClient {
   private AllowedMentions buildAllowedMentions(NotificationLevel level) {
     return switch (level) {
       case HIGH -> {
-        String roleId = properties.getMentionRoleId();
+        String roleId = properties.mentionRoleId();
         yield StringUtils.hasText(roleId)
             ? AllowedMentions.roles(List.of(roleId))
             : AllowedMentions.none();

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/config/DiscordWebhookConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/config/DiscordWebhookConfig.java
@@ -12,7 +12,7 @@ public class DiscordWebhookConfig {
 
   @Bean
   RestClient discordWebhookRestClient(DiscordWebhookProperties properties) {
-    int timeoutMillis = Math.toIntExact(properties.getTimeout().toMillis());
+    int timeoutMillis = Math.toIntExact(properties.timeout().toMillis());
 
     SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
     factory.setConnectTimeout(timeoutMillis);

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/config/DiscordWebhookProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/config/DiscordWebhookProperties.java
@@ -1,16 +1,7 @@
 package com.gakkaweo.backend.infra.notification.config;
 
 import java.time.Duration;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.notification.discord")
-@Getter
-@RequiredArgsConstructor
-public class DiscordWebhookProperties {
-
-  private final String webhookUrl;
-  private final Duration timeout;
-  private final String mentionRoleId;
-}
+public record DiscordWebhookProperties(String webhookUrl, Duration timeout, String mentionRoleId) {}

--- a/backend/src/main/java/com/gakkaweo/backend/infra/redis/config/RedisCleanupProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/redis/config/RedisCleanupProperties.java
@@ -1,24 +1,13 @@
 package com.gakkaweo.backend.infra.redis.config;
 
 import jakarta.validation.constraints.Min;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties(prefix = "app.redis.cleanup")
 @Validated
-@Getter
-@RequiredArgsConstructor
-public class RedisCleanupProperties {
-
-  private final boolean enabled;
-
-  @Min(1)
-  private final int scanBatchSize;
-
-  @Min(2)
-  private final int purgeOlderThanDays;
-
-  private final boolean notifyOnZero;
-}
+public record RedisCleanupProperties(
+    boolean enabled,
+    @Min(1) int scanBatchSize,
+    @Min(2) int purgeOlderThanDays,
+    boolean notifyOnZero) {}

--- a/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupScheduler.java
@@ -37,7 +37,7 @@ public class RedisCleanupScheduler {
 
   @Scheduled(cron = "0 30 4,10,16,22 * * *", zone = "Asia/Seoul")
   public void executeCleanup() {
-    if (!properties.isEnabled()) {
+    if (!properties.enabled()) {
       log.debug("Redis 정리 스케줄러 비활성화");
       return;
     }
@@ -60,7 +60,7 @@ public class RedisCleanupScheduler {
       log.error("Redis orphan 스캔 실패: {}", e.getMessage(), e);
     }
 
-    LocalDate cutoff = LocalDate.now(clock).minusDays(properties.getPurgeOlderThanDays());
+    LocalDate cutoff = LocalDate.now(clock).minusDays(properties.purgeOlderThanDays());
     try {
       purgeRetry.executeRunnable(
           () -> {
@@ -137,7 +137,7 @@ public class RedisCleanupScheduler {
 
   private Cursor<String> openCursor(String pattern) {
     ScanOptions options =
-        ScanOptions.scanOptions().match(pattern).count(properties.getScanBatchSize()).build();
+        ScanOptions.scanOptions().match(pattern).count(properties.scanBatchSize()).build();
     return redisTemplate.scan(options);
   }
 
@@ -151,7 +151,7 @@ public class RedisCleanupScheduler {
   }
 
   private void notifyDiscord(RedisCleanupReport report) {
-    if (!report.hasAnyAction() && !report.hasFailure() && !properties.isNotifyOnZero()) {
+    if (!report.hasAnyAction() && !report.hasFailure() && !properties.notifyOnZero()) {
       return;
     }
     try {
@@ -184,7 +184,7 @@ public class RedisCleanupScheduler {
             new DiscordEmbed.Field("Orphan 스캔", report.orphanScanFailed() ? "실패" : "성공", true),
             new DiscordEmbed.Field("Ranking 정리", report.rankingPurgeFailed() ? "실패" : "성공", true),
             new DiscordEmbed.Field(
-                "삭제 임계 일수", String.valueOf(properties.getPurgeOlderThanDays()), true));
+                "삭제 임계 일수", String.valueOf(properties.purgeOlderThanDays()), true));
 
     return new DiscordEmbed(title, description, color, fields);
   }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/seeding/InitialDataSeeder.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/seeding/InitialDataSeeder.java
@@ -103,7 +103,7 @@ public class InitialDataSeeder {
   }
 
   private void seedAdmin() {
-    String password = seedProperties.getAdminPassword();
+    String password = seedProperties.adminPassword();
     if (!StringUtils.hasText(password)) {
       log.info("SEED_ADMIN_PASSWORD 미설정, admin 시딩 skip");
       return;

--- a/backend/src/main/java/com/gakkaweo/backend/infra/seeding/SeedProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/seeding/SeedProperties.java
@@ -1,13 +1,6 @@
 package com.gakkaweo.backend.infra.seeding;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.seed")
-@Getter
-@RequiredArgsConstructor
-public class SeedProperties {
-
-  private final String adminPassword;
-}
+public record SeedProperties(String adminPassword) {}

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/SseConnectionManager.java
@@ -55,7 +55,7 @@ public class SseConnectionManager {
   }
 
   public synchronized SseEmitter register() {
-    if (emitters.size() >= sseProperties.getMaxConnections()) {
+    if (emitters.size() >= sseProperties.maxConnections()) {
       throw new BusinessException(ErrorCode.SSE_MAX_CONNECTIONS);
     }
 

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/sse/config/SseProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/sse/config/SseProperties.java
@@ -1,17 +1,9 @@
 package com.gakkaweo.backend.ranking.sse.config;
 
 import jakarta.validation.constraints.Min;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties(prefix = "app.sse")
 @Validated
-@Getter
-@RequiredArgsConstructor
-public class SseProperties {
-
-  @Min(1)
-  private final int maxConnections;
-}
+public record SseProperties(@Min(1) int maxConnections) {}

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/config/RateLimitProperties.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/config/RateLimitProperties.java
@@ -1,18 +1,12 @@
 package com.gakkaweo.backend.ratelimit.config;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.rate-limit")
-@Getter
-@RequiredArgsConstructor
-public class RateLimitProperties {
-
-  private final int guessPerMinute;
-  private final int readPerMinute;
-  private final int ssePerMinute;
-  private final int authPerMinute;
-  private final int adminPerMinute;
-  private final int bucketExpiryMinutes;
-}
+public record RateLimitProperties(
+    int guessPerMinute,
+    int readPerMinute,
+    int ssePerMinute,
+    int authPerMinute,
+    int adminPerMinute,
+    int bucketExpiryMinutes) {}

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/BucketStore.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/BucketStore.java
@@ -43,7 +43,7 @@ public class BucketStore {
 
   @Scheduled(fixedDelayString = "${app.rate-limit.cleanup-interval-ms:300000}")
   public void cleanup() {
-    Instant expiry = Instant.now().minusSeconds(properties.getBucketExpiryMinutes() * 60L);
+    Instant expiry = Instant.now().minusSeconds(properties.bucketExpiryMinutes() * 60L);
     int before = buckets.size();
     buckets.entrySet().removeIf(entry -> entry.getValue().lastAccessed().isBefore(expiry));
     int removed = before - buckets.size();
@@ -65,11 +65,11 @@ public class BucketStore {
 
   private int getCapacity(EndpointGroup group) {
     return switch (group) {
-      case GUESS -> properties.getGuessPerMinute();
-      case READ -> properties.getReadPerMinute();
-      case SSE -> properties.getSsePerMinute();
-      case AUTH -> properties.getAuthPerMinute();
-      case ADMIN -> properties.getAdminPerMinute();
+      case GUESS -> properties.guessPerMinute();
+      case READ -> properties.readPerMinute();
+      case SSE -> properties.ssePerMinute();
+      case AUTH -> properties.authPerMinute();
+      case ADMIN -> properties.adminPerMinute();
       case NONE -> throw new IllegalArgumentException("NONE 그룹은 버킷을 생성하지 않습니다");
     };
   }


### PR DESCRIPTION
## 관련 이슈

Closes #171

## 변경 사항

- `@ConfigurationProperties` 클래스 12개를 Java record로 일괄 전환 (NotificationProperties와 정합)
- 호출부 17개 파일의 accessor 메서드명 변경 (`getXxx()`/`isXxx()` -> `xxx()`)
- Lombok `@Getter`, `@RequiredArgsConstructor` 및 import 제거
- `@Validated` + `@Min` 검증 어노테이션 유지 (RedisCleanupProperties, SseProperties)
- IntelliJ 프로젝트 코드 스타일에 Flyway 마이그레이션 포맷 제외 패턴 추가
- 동작 변경 0, application.yaml 변경 0

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다