### PR TITLE
refactor: 어드민 DTO 팩토리 일관성 + 서비스 중복 로직 정리

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/AuditLogListResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/AuditLogListResponse.java
@@ -1,7 +1,9 @@
 package com.gakkaweo.backend.admin.dto;
 
+import com.gakkaweo.backend.domain.admin.entity.AuditLog;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 @Schema(description = "감사 로그 목록 응답")
 public record AuditLogListResponse(
@@ -9,4 +11,14 @@ public record AuditLogListResponse(
     @Schema(description = "현재 페이지", example = "0") int page,
     @Schema(description = "페이지 크기", example = "20") int size,
     @Schema(description = "전체 건수", example = "500") long totalElements,
-    @Schema(description = "전체 페이지 수", example = "25") int totalPages) {}
+    @Schema(description = "전체 페이지 수", example = "25") int totalPages) {
+
+  public static AuditLogListResponse from(Page<AuditLog> page) {
+    return new AuditLogListResponse(
+        page.getContent().stream().map(AuditLogResponse::from).toList(),
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages());
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/SentenceListResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/SentenceListResponse.java
@@ -1,12 +1,24 @@
 package com.gakkaweo.backend.admin.dto;
 
+import com.gakkaweo.backend.domain.game.entity.DailySentence;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 @Schema(description = "문장 목록 응답")
 public record SentenceListResponse(
-    @Schema(description = "문장 목록") List<SentenceResponse> sentences,
+    @Schema(description = "문장 목록") List<SentenceResponse> content,
     @Schema(description = "현재 페이지", example = "0") int page,
     @Schema(description = "페이지 크기", example = "20") int size,
     @Schema(description = "전체 건수", example = "200") long totalElements,
-    @Schema(description = "전체 페이지 수", example = "10") int totalPages) {}
+    @Schema(description = "전체 페이지 수", example = "10") int totalPages) {
+
+  public static SentenceListResponse from(Page<DailySentence> page) {
+    return new SentenceListResponse(
+        page.getContent().stream().map(SentenceResponse::from).toList(),
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages());
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/SentenceStatsResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/SentenceStatsResponse.java
@@ -9,4 +9,12 @@ public record SentenceStatsResponse(
     @Schema(description = "클리어 세션 수", example = "75") long clearedSessions,
     @Schema(description = "클리어율", example = "75.0") double clearRate,
     @Schema(description = "평균 유사도", example = "82.35") BigDecimal avgSimilarity,
-    @Schema(description = "평균 시도 횟수", example = "18.5") double avgAttemptCount) {}
+    @Schema(description = "평균 시도 횟수", example = "18.5") double avgAttemptCount) {
+
+  public static SentenceStatsResponse from(
+      long totalSessions, long clearedSessions, BigDecimal avgSimilarity, double avgAttemptCount) {
+    double clearRate = totalSessions > 0 ? (double) clearedSessions / totalSessions * 100 : 0;
+    return new SentenceStatsResponse(
+        totalSessions, clearedSessions, clearRate, avgSimilarity, avgAttemptCount);
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/dto/UserListResponse.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/dto/UserListResponse.java
@@ -2,11 +2,18 @@ package com.gakkaweo.backend.admin.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 @Schema(description = "사용자 목록 응답")
 public record UserListResponse(
-    @Schema(description = "사용자 목록") List<AdminUserResponse> users,
+    @Schema(description = "사용자 목록") List<AdminUserResponse> content,
     @Schema(description = "현재 페이지", example = "0") int page,
     @Schema(description = "페이지 크기", example = "20") int size,
     @Schema(description = "전체 건수", example = "150") long totalElements,
-    @Schema(description = "전체 페이지 수", example = "8") int totalPages) {}
+    @Schema(description = "전체 페이지 수", example = "8") int totalPages) {
+
+  public static UserListResponse from(List<AdminUserResponse> users, Page<?> page) {
+    return new UserListResponse(
+        users, page.getNumber(), page.getSize(), page.getTotalElements(), page.getTotalPages());
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -150,12 +150,11 @@ public class AdminSentenceService {
 
     long totalSessions = gameSessionRepository.countBySentence(entity);
     long clearedSessions = gameSessionRepository.countClearedBySentence(entity);
-    double clearRate = totalSessions > 0 ? (double) clearedSessions / totalSessions * 100 : 0;
     BigDecimal avgSimilarity = gameSessionRepository.avgSimilarityBySentence(entity);
     double avgAttemptCount = gameSessionRepository.avgAttemptCountBySentence(entity);
 
-    return new SentenceStatsResponse(
-        totalSessions, clearedSessions, clearRate, avgSimilarity, avgAttemptCount);
+    return SentenceStatsResponse.from(
+        totalSessions, clearedSessions, avgSimilarity, avgAttemptCount);
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSentenceService.java
@@ -80,12 +80,7 @@ public class AdminSentenceService {
     Page<DailySentence> pageResult =
         dailySentenceRepository.findAll(spec, PageRequest.of(page, size));
 
-    return new SentenceListResponse(
-        pageResult.getContent().stream().map(SentenceResponse::from).toList(),
-        pageResult.getNumber(),
-        pageResult.getSize(),
-        pageResult.getTotalElements(),
-        pageResult.getTotalPages());
+    return SentenceListResponse.from(pageResult);
   }
 
   @Transactional

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -173,7 +173,7 @@ public class AdminSystemService {
         && response.active()
         && isCurrentlyActiveByTime(response.startsAt(), response.endsAt())) {
       AnnouncementType effectiveType =
-          parsedType != null ? parsedType : AnnouncementType.valueOf(response.type());
+          parsedType != null ? parsedType : parseAnnouncementType(response.type());
       eventPublisher.publishEvent(
           new AnnouncementEvent(
               response.id(), response.title(), response.content(), effectiveType));

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -4,7 +4,6 @@ import com.gakkaweo.backend.admin.dto.AnnouncementCreateRequest;
 import com.gakkaweo.backend.admin.dto.AnnouncementResponse;
 import com.gakkaweo.backend.admin.dto.AnnouncementUpdateRequest;
 import com.gakkaweo.backend.admin.dto.AuditLogListResponse;
-import com.gakkaweo.backend.admin.dto.AuditLogResponse;
 import com.gakkaweo.backend.admin.dto.SystemStatusResponse;
 import com.gakkaweo.backend.admin.event.AnnouncementEvent;
 import com.gakkaweo.backend.admin.sort.AuditLogSortField;
@@ -264,12 +263,7 @@ public class AdminSystemService {
         auditLogFilters(action, dateFrom, dateTo).and(SortSpecBuilder.build(sortSpec, "id"));
     Page<AuditLog> pageResult = auditLogRepository.findAll(spec, PageRequest.of(page, size));
 
-    return new AuditLogListResponse(
-        pageResult.getContent().stream().map(AuditLogResponse::from).toList(),
-        pageResult.getNumber(),
-        pageResult.getSize(),
-        pageResult.getTotalElements(),
-        pageResult.getTotalPages());
+    return AuditLogListResponse.from(pageResult);
   }
 
   private Announcement findAnnouncement(Long id) {

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminSystemService.java
@@ -136,9 +136,8 @@ public class AdminSystemService {
 
   public AnnouncementResponse updateAnnouncement(
       Long id, AnnouncementUpdateRequest request, UUID adminPublicId, String ipAddress) {
-    if (request.type() != null) {
-      parseAnnouncementType(request.type());
-    }
+    AnnouncementType parsedType =
+        request.type() != null ? parseAnnouncementType(request.type()) : null;
 
     AnnouncementResponse response =
         transactionTemplate.execute(
@@ -151,8 +150,8 @@ public class AdminSystemService {
               if (request.content() != null) {
                 announcement.setContent(request.content());
               }
-              if (request.type() != null) {
-                announcement.setType(parseAnnouncementType(request.type()));
+              if (parsedType != null) {
+                announcement.setType(parsedType);
               }
               if (request.active() != null) {
                 announcement.setActive(request.active());
@@ -170,14 +169,14 @@ public class AdminSystemService {
               return AnnouncementResponse.from(announcement);
             });
 
-    if (response != null && response.active()) {
-      Instant now = clock.instant();
-      if (!response.startsAt().isAfter(now)
-          && (response.endsAt() == null || !response.endsAt().isBefore(now))) {
-        AnnouncementType type = parseAnnouncementType(response.type());
-        eventPublisher.publishEvent(
-            new AnnouncementEvent(response.id(), response.title(), response.content(), type));
-      }
+    if (response != null
+        && response.active()
+        && isCurrentlyActiveByTime(response.startsAt(), response.endsAt())) {
+      AnnouncementType effectiveType =
+          parsedType != null ? parsedType : AnnouncementType.valueOf(response.type());
+      eventPublisher.publishEvent(
+          new AnnouncementEvent(
+              response.id(), response.title(), response.content(), effectiveType));
     }
 
     return response;

--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminUserService.java
@@ -89,12 +89,9 @@ public class AdminUserService {
         memberFilters(nickname, banned).and(SortSpecBuilder.build(sortSpec, "id"));
     Page<Member> pageResult = memberRepository.findAll(spec, PageRequest.of(page, size));
 
-    return new UserListResponse(
-        pageResult.getContent().stream().map(this::toUserResponse).toList(),
-        pageResult.getNumber(),
-        pageResult.getSize(),
-        pageResult.getTotalElements(),
-        pageResult.getTotalPages());
+    List<AdminUserResponse> users =
+        pageResult.getContent().stream().map(this::toUserResponse).toList();
+    return UserListResponse.from(users, pageResult);
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSentenceIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSentenceIntegrationTest.java
@@ -205,7 +205,7 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
             SentenceListResponse.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody().sentences()).hasSize(2);
+    assertThat(response.getBody().content()).hasSize(2);
   }
 
   @Test
@@ -333,7 +333,7 @@ class AdminSentenceIntegrationTest extends IntegrationTestBase {
             SentenceListResponse.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody().sentences()).hasSize(2);
+    assertThat(response.getBody().content()).hasSize(2);
   }
 
   @Test

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminSortIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminSortIntegrationTest.java
@@ -51,7 +51,7 @@ class AdminSortIntegrationTest extends IntegrationTestBase {
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
       List<String> nicknames =
-          response.getBody().users().stream().map(AdminUserResponse::nickname).toList();
+          response.getBody().content().stream().map(AdminUserResponse::nickname).toList();
       assertThat(nicknames).isSortedAccordingTo(Comparator.naturalOrder());
     }
 
@@ -71,7 +71,7 @@ class AdminSortIntegrationTest extends IntegrationTestBase {
               UserListResponse.class);
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-      assertThat(response.getBody().users())
+      assertThat(response.getBody().content())
           .isNotEmpty()
           .allSatisfy(user -> assertThat(user.banned()).isTrue());
     }
@@ -90,7 +90,7 @@ class AdminSortIntegrationTest extends IntegrationTestBase {
               UserListResponse.class);
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-      assertThat(response.getBody().users()).isNotEmpty();
+      assertThat(response.getBody().content()).isNotEmpty();
     }
 
     @Test
@@ -147,7 +147,7 @@ class AdminSortIntegrationTest extends IntegrationTestBase {
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
       List<String> sentences =
-          response.getBody().sentences().stream().map(SentenceResponse::sentence).toList();
+          response.getBody().content().stream().map(SentenceResponse::sentence).toList();
       assertThat(sentences).isSortedAccordingTo(Comparator.naturalOrder());
     }
 
@@ -168,7 +168,7 @@ class AdminSortIntegrationTest extends IntegrationTestBase {
               SentenceListResponse.class);
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-      List<SentenceResponse> sentences = response.getBody().sentences();
+      List<SentenceResponse> sentences = response.getBody().content();
       assertThat(sentences).hasSize(4);
       assertThat(sentences.get(0).usedAt()).isEqualTo(LocalDate.of(2026, 4, 1));
       assertThat(sentences.get(1).usedAt()).isEqualTo(LocalDate.of(2026, 1, 1));
@@ -193,7 +193,7 @@ class AdminSortIntegrationTest extends IntegrationTestBase {
               SentenceListResponse.class);
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-      List<SentenceResponse> sentences = response.getBody().sentences();
+      List<SentenceResponse> sentences = response.getBody().content();
       assertThat(sentences).hasSize(4);
       assertThat(sentences.get(0).scheduledAt()).isEqualTo(LocalDate.of(2026, 6, 1));
       assertThat(sentences.get(1).scheduledAt()).isEqualTo(LocalDate.of(2026, 5, 1));

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminUserIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminUserIntegrationTest.java
@@ -220,7 +220,7 @@ class AdminUserIntegrationTest extends IntegrationTestBase {
             UserListResponse.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody().users()).isNotEmpty();
+    assertThat(response.getBody().content()).isNotEmpty();
   }
 
   @Test
@@ -276,7 +276,7 @@ class AdminUserIntegrationTest extends IntegrationTestBase {
             UserListResponse.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody().users())
+    assertThat(response.getBody().content())
         .extracting(AdminUserResponse::nickname)
         .contains(match.getNickname());
   }
@@ -297,7 +297,7 @@ class AdminUserIntegrationTest extends IntegrationTestBase {
             UserListResponse.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody().users()).allSatisfy(user -> assertThat(user.banned()).isTrue());
+    assertThat(response.getBody().content()).allSatisfy(user -> assertThat(user.banned()).isTrue());
   }
 
   @Test

--- a/frontend/src/features/admin/components/SentenceTab.tsx
+++ b/frontend/src/features/admin/components/SentenceTab.tsx
@@ -89,7 +89,7 @@ export function SentenceTab() {
 
       {isLoading ? (
         <p className="font-bold text-gray-400 animate-pulse py-8">로딩 중...</p>
-      ) : data && data.sentences.length > 0 ? (
+      ) : data && data.content.length > 0 ? (
         <>
           <div className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal overflow-hidden">
             <table className="w-full text-sm">
@@ -128,7 +128,7 @@ export function SentenceTab() {
                 </tr>
               </thead>
               <tbody>
-                {data.sentences.map((s) => (
+                {data.content.map((s) => (
                   <tr
                     key={s.publicId}
                     className="border-b-2 border-black/20 dark:border-white/20 hover:bg-yellow-50 dark:hover:bg-gray-800 transition-colors"

--- a/frontend/src/features/admin/components/UserTab.tsx
+++ b/frontend/src/features/admin/components/UserTab.tsx
@@ -85,7 +85,7 @@ export function UserTab() {
 
       {isLoading ? (
         <p className="font-bold text-gray-400 animate-pulse py-8">로딩 중...</p>
-      ) : data && data.users.length > 0 ? (
+      ) : data && data.content.length > 0 ? (
         <>
           <div className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal overflow-hidden">
             <table className="w-full text-sm">
@@ -125,7 +125,7 @@ export function UserTab() {
                 </tr>
               </thead>
               <tbody>
-                {data.users.map((u) => (
+                {data.content.map((u) => (
                   <tr
                     key={u.publicId}
                     className="border-b-2 border-black/20 dark:border-white/20 hover:bg-yellow-50 dark:hover:bg-gray-800 transition-colors"

--- a/frontend/src/features/admin/types.ts
+++ b/frontend/src/features/admin/types.ts
@@ -11,7 +11,7 @@ export interface SentenceResponse {
 }
 
 export interface SentenceListResponse {
-  sentences: SentenceResponse[];
+  content: SentenceResponse[];
   page: number;
   size: number;
   totalElements: number;
@@ -58,7 +58,7 @@ export interface AdminUserResponse {
 }
 
 export interface UserListResponse {
-  users: AdminUserResponse[];
+  content: AdminUserResponse[];
   page: number;
   size: number;
   totalElements: number;


### PR DESCRIPTION
## 관련 이슈

Closes #173

## 변경 사항

### ListResponse from(Page) 팩토리 도입 + 필드명 content 통일
- `SentenceListResponse`, `AuditLogListResponse`, `UserListResponse`에 `from(Page)` 정적 팩토리 추가
- 서비스 레이어의 Page 언패킹 보일러플레이트(5줄) → 1~2줄 압축
- 리스트 필드명 `sentences`/`users` → `content`로 Spring Page 컨벤션 통일
- BE 테스트 accessor + FE 타입/사용처 동기화 (12파일)

### updateAnnouncement 중복 로직 정리
- `parseAnnouncementType` 이중 호출 → TX 진입 전 `parsedType` 변수 재사용
- post-TX String→Enum 재파싱 → `parsedType`/`valueOf` 직접 사용
- 인라인 활성 시간 검사 → `isCurrentlyActiveByTime()` 헬퍼 재사용

### SentenceStatsResponse from() 팩토리 도입
- `clearRate` 계산을 DTO 내부로 캡슐화 (`DateStatsResponse` 패턴 통일)

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- API JSON 필드명 변경: `sentences` → `content`, `users` → `content` (어드민 내부 API, FE 동시 동기화)
- `AnnouncementResponse.content`(공지 본문)와 `XxxListResponse.content`(리스트)는 서로 다른 DTO 타입이므로 충돌 없음