### PR TITLE
feat: 운영 모니터링 인프라 도입 (Prometheus + Grafana + Micrometer)

### DIFF
--- a/.env.prod.sample
+++ b/.env.prod.sample
@@ -89,6 +89,12 @@ REDIS_CLEANUP_NOTIFY_ON_ZERO=false
 # OpenAPI (CI 전용, 프로덕션에서는 false 유지)
 APP_OPENAPI_DOCS_MODE=false
 
+# Monitoring (Actuator 관리 포트. Prometheus 스크래핑 대상)
+MANAGEMENT_PORT=9090
+# Grafana 관리자 계정 (프로덕션: 비밀번호 필수. SSH 터널링으로 접근)
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=INPUT_YOUR_GRAFANA_PASSWORD
+
 # 서버
 SERVER_PORT=8080
 # Nginx 등 프록시 뒤 X-Forwarded-* 헤더 처리 (local=none, prod=native)

--- a/.env.sample
+++ b/.env.sample
@@ -89,6 +89,12 @@ REDIS_CLEANUP_NOTIFY_ON_ZERO=false
 # OpenAPI (CI 전용, 로컬에서는 false 유지)
 APP_OPENAPI_DOCS_MODE=false
 
+# Monitoring (Actuator 관리 포트. Prometheus가 스크래핑하는 대상)
+MANAGEMENT_PORT=9090
+# Grafana 관리자 계정 (로컬에서만 사용, 기본값 admin/admin)
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin
+
 # 서버
 SERVER_PORT=8080
 # Nginx 등 프록시 뒤 X-Forwarded-* 헤더 처리 (local=none, prod=native)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -169,6 +169,7 @@ jobs:
           source: infra/
           target: ~/gakkaweo/infra
           strip_components: 1
+          rm: true
           overwrite: true
 
       - name: Upload compose file

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       nginx: ${{ steps.filter.outputs.nginx }}
       compose: ${{ steps.filter.outputs.compose }}
+      infra: ${{ steps.filter.outputs.infra }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -36,6 +37,8 @@ jobs:
               - 'nginx/**'
             compose:
               - 'docker-compose.prod.yml'
+            infra:
+              - 'infra/**'
 
   build-backend:
     name: Build Backend Image
@@ -125,7 +128,8 @@ jobs:
         needs.changes.outputs.ai_service == 'true' ||
         needs.changes.outputs.frontend == 'true' ||
         needs.changes.outputs.nginx == 'true' ||
-        needs.changes.outputs.compose == 'true'
+        needs.changes.outputs.compose == 'true' ||
+        needs.changes.outputs.infra == 'true'
       )
     runs-on: ubuntu-latest
     steps:
@@ -154,11 +158,25 @@ jobs:
           overwrite: true
 
       # --- Docker services ---
+      - name: Upload infra configs
+        if: needs.changes.outputs.infra == 'true'
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_SSH_PORT }}
+          source: infra/
+          target: ~/gakkaweo/infra
+          strip_components: 1
+          overwrite: true
+
       - name: Upload compose file
         if: >-
           needs.changes.outputs.backend == 'true' ||
           needs.changes.outputs.ai_service == 'true' ||
-          needs.changes.outputs.compose == 'true'
+          needs.changes.outputs.compose == 'true' ||
+          needs.changes.outputs.infra == 'true'
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -173,7 +191,8 @@ jobs:
         if: >-
           needs.changes.outputs.backend == 'true' ||
           needs.changes.outputs.ai_service == 'true' ||
-          needs.changes.outputs.compose == 'true'
+          needs.changes.outputs.compose == 'true' ||
+          needs.changes.outputs.infra == 'true'
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.SERVER_HOST }}

--- a/backend/.idea/codeStyles/codeStyleConfig.xml
+++ b/backend/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,6 +26,6 @@ COPY --from=builder --chown=appuser:appgroup /build/build/libs/*.jar app.jar
 
 USER appuser
 
-EXPOSE 8080
+EXPOSE 8080 9090
 
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -23,6 +23,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/backend/src/main/java/com/gakkaweo/backend/auth/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/jwt/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -23,6 +24,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtProvider jwtProvider;
   private final StringRedisTemplate redisTemplate;
+
+  @Value("${management.server.port:#{null}}")
+  private Integer managementPort;
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return managementPort != null && request.getLocalPort() == managementPort;
+  }
 
   @Override
   protected void doFilterInternal(

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/health", "/auth/refresh", "/auth/register", "/auth/login")
                     .permitAll()
-                    .requestMatchers("/actuator/**")
+                    .requestMatchers("/actuator/prometheus")
                     .permitAll()
                     .requestMatchers("/uploads/**")
                     .permitAll()

--- a/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/SecurityConfig.java
@@ -76,6 +76,8 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/health", "/auth/refresh", "/auth/register", "/auth/login")
                     .permitAll()
+                    .requestMatchers("/actuator/**")
+                    .permitAll()
                     .requestMatchers("/uploads/**")
                     .permitAll()
                     .requestMatchers("/v3/api-docs")

--- a/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/scheduler/DailySentenceScheduler.java
@@ -13,6 +13,7 @@ import com.gakkaweo.backend.ranking.event.DayChangeEvent;
 import com.gakkaweo.backend.ranking.service.RankingService;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.annotation.Timed;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -53,6 +54,7 @@ public class DailySentenceScheduler {
     return succeeded ? "성공" : "실패";
   }
 
+  @Timed(value = "scheduler.midnight.duration", description = "Midnight scheduler execution time")
   @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
   public void executeMidnightJob() {
     executeMidnightJob(true);

--- a/backend/src/main/java/com/gakkaweo/backend/infra/monitoring/CustomMetricsConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/monitoring/CustomMetricsConfig.java
@@ -1,0 +1,46 @@
+package com.gakkaweo.backend.infra.monitoring;
+
+import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
+import com.gakkaweo.backend.ranking.sse.SseConnectionManager;
+import com.gakkaweo.backend.ratelimit.filter.BucketStore;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CustomMetricsConfig {
+
+  @Bean
+  TimedAspect timedAspect(MeterRegistry registry) {
+    return new TimedAspect(registry);
+  }
+
+  @Bean
+  MeterBinder sseConnectionsGauge(SseConnectionManager sseConnectionManager) {
+    return registry ->
+        Gauge.builder(
+                "sse.connections", sseConnectionManager, SseConnectionManager::getConnectionCount)
+            .description("Active SSE connections")
+            .register(registry);
+  }
+
+  @Bean
+  MeterBinder rateLimitBucketsGauge(BucketStore bucketStore) {
+    return registry ->
+        Gauge.builder("ratelimit.buckets.active", bucketStore, BucketStore::getBucketCount)
+            .description("Active rate limit buckets")
+            .register(registry);
+  }
+
+  @Bean
+  MeterBinder unusedSentencesGauge(DailySentenceRepository dailySentenceRepository) {
+    return registry ->
+        Gauge.builder(
+                "game.sentences.unused", dailySentenceRepository, repo -> repo.countUnusedActive())
+            .description("Unused active sentences remaining")
+            .register(registry);
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupScheduler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/redis/scheduler/RedisCleanupScheduler.java
@@ -7,6 +7,7 @@ import com.gakkaweo.backend.infra.notification.dto.DiscordEmbed;
 import com.gakkaweo.backend.infra.redis.config.RedisCleanupProperties;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.annotation.Timed;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -35,6 +36,9 @@ public class RedisCleanupScheduler {
   private final RedisCleanupProperties properties;
   private final Clock clock;
 
+  @Timed(
+      value = "scheduler.redis_cleanup.duration",
+      description = "Redis cleanup scheduler execution time")
   @Scheduled(cron = "0 30 4,10,16,22 * * *", zone = "Asia/Seoul")
   public void executeCleanup() {
     if (!properties.enabled()) {

--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -16,6 +16,10 @@ import com.gakkaweo.backend.ranking.dto.RankingResponse;
 import com.gakkaweo.backend.ranking.dto.RankingResponse.MyRank;
 import com.gakkaweo.backend.ranking.dto.RankingResponse.RankingEntry;
 import com.gakkaweo.backend.ranking.dto.RankingSnapshot;
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
@@ -48,7 +52,18 @@ public class RankingService {
   private final DailySentenceRepository dailySentenceRepository;
   private final GameSessionRepository gameSessionRepository;
   private final MemberRepository memberRepository;
+  private final MeterRegistry meterRegistry;
   private final Clock clock;
+
+  private Counter rankingUpdateCounter;
+
+  @PostConstruct
+  void initCounters() {
+    rankingUpdateCounter =
+        Counter.builder("ranking.update")
+            .description("Ranking update count")
+            .register(meterRegistry);
+  }
 
   public Integer updateRanking(GameSession session, Member member) {
     try {
@@ -81,6 +96,8 @@ public class RankingService {
 
       redisTemplate.expire(rankingKey, LIVE_TTL);
       redisTemplate.expire(detailKey, LIVE_TTL);
+
+      rankingUpdateCounter.increment();
 
       Long rank = redisTemplate.opsForZSet().reverseRank(rankingKey, memberKey);
       if (rank != null) {
@@ -253,6 +270,7 @@ public class RankingService {
     }
   }
 
+  @Timed(value = "ranking.cache.rebuild.duration", description = "Ranking cache rebuild time")
   public int rebuildRankingCache(LocalDate date) {
     DailySentence sentence =
         dailySentenceRepository

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/BucketStore.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/BucketStore.java
@@ -35,6 +35,10 @@ public class BucketStore {
         .bucket();
   }
 
+  public int getBucketCount() {
+    return buckets.size();
+  }
+
   public void clearAllBuckets() {
     int size = buckets.size();
     buckets.clear();

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/RateLimitFilter.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/RateLimitFilter.java
@@ -6,15 +6,21 @@ import com.gakkaweo.backend.common.exception.ErrorBody;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.ConsumptionProbe;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,6 +35,33 @@ public class RateLimitFilter extends OncePerRequestFilter {
   private final EndpointGroupResolver endpointGroupResolver;
   private final BucketStore bucketStore;
   private final ObjectMapper objectMapper;
+  private final MeterRegistry meterRegistry;
+
+  @Value("${management.server.port:#{null}}")
+  private Integer managementPort;
+
+  private Map<EndpointGroup, Counter> rejectionCounters;
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return managementPort != null && request.getLocalPort() == managementPort;
+  }
+
+  @PostConstruct
+  void initCounters() {
+    rejectionCounters = new EnumMap<>(EndpointGroup.class);
+    for (EndpointGroup group : EndpointGroup.values()) {
+      if (group == EndpointGroup.NONE) {
+        continue;
+      }
+      rejectionCounters.put(
+          group,
+          Counter.builder("ratelimit.rejected")
+              .tag("group", group.name())
+              .description("Rate limit rejection count")
+              .register(meterRegistry));
+    }
+  }
 
   @Override
   protected void doFilterInternal(
@@ -54,6 +87,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
     }
 
     long retryAfterSeconds = TimeUnit.NANOSECONDS.toSeconds(probe.getNanosToWaitForRefill()) + 1;
+    rejectionCounters.get(group).increment();
     log.warn("Rate limit 초과: group={}, key={}, retryAfter={}s", group, key, retryAfterSeconds);
 
     ErrorCode errorCode = ErrorCode.RATE_LIMIT_EXCEEDED;

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -184,6 +184,17 @@ logging:
   level:
     com.gakkaweo.backend: ${LOG_LEVEL:DEBUG}
 
+management:
+  server:
+    port: ${MANAGEMENT_PORT:9090}
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  metrics:
+    tags:
+      application: gakkaweo-backend
+
 server:
   port: ${SERVER_PORT:8080}
   forward-headers-strategy: ${FORWARD_HEADERS_STRATEGY:none}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -65,6 +65,32 @@ services:
       retries: 5
       start_period: 120s
 
+  prometheus:
+    image: prom/prometheus:v3.5.3
+    ports:
+      - "127.0.0.1:9091:9090"
+    volumes:
+      - ./infra/prometheus/prometheus.dev.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheusdata:/prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    logging: *logging
+
+  grafana:
+    image: grafana/grafana:13.0.1
+    ports:
+      - "127.0.0.1:3001:3000"
+    volumes:
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./infra/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafanadata:/var/lib/grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+    depends_on:
+      - prometheus
+    logging: *logging
+
 volumes:
   pgdata:
     name: gakkaweo-postgresql
@@ -72,3 +98,7 @@ volumes:
     name: gakkaweo-redis
   hf-model-cache:
     name: gakkaweo-hf-model-cache
+  prometheusdata:
+    name: gakkaweo-prometheus
+  grafanadata:
+    name: gakkaweo-grafana

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -94,6 +94,34 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  prometheus:
+    image: prom/prometheus:v3.5.3
+    volumes:
+      - ./infra/prometheus/prometheus.prod.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheusdata:/prometheus
+    networks:
+      - internal
+    logging: *logging
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:13.0.1
+    ports:
+      - "127.0.0.1:3001:3000"
+    volumes:
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./infra/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafanadata:/var/lib/grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+    networks:
+      - internal
+    depends_on:
+      - prometheus
+    logging: *logging
+    restart: unless-stopped
+
 networks:
   internal:
     driver: bridge
@@ -105,3 +133,7 @@ volumes:
     name: gakkaweo-redis
   hf-model-cache:
     name: gakkaweo-hf-model-cache
+  prometheusdata:
+    name: gakkaweo-prometheus
+  grafanadata:
+    name: gakkaweo-grafana

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -101,7 +101,16 @@ services:
       - prometheusdata:/prometheus
     networks:
       - internal
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     logging: *logging
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
 
   grafana:
@@ -118,7 +127,8 @@ services:
     networks:
       - internal
     depends_on:
-      - prometheus
+      prometheus:
+        condition: service_healthy
     logging: *logging
     restart: unless-stopped
 

--- a/infra/grafana/dashboards/gakkaweo.json
+++ b/infra/grafana/dashboards/gakkaweo.json
@@ -1,0 +1,841 @@
+{
+  "uid": "gakkaweo-overview",
+  "title": "가까워 - Overview",
+  "timezone": "Asia/Seoul",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "15s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "panels": [
+    {
+      "type": "row",
+      "title": "JVM",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": null,
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "gauge",
+      "title": "Heap Usage",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 1 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 80 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(jvm_memory_used_bytes{area=\"heap\"}) / sum(jvm_memory_max_bytes{area=\"heap\"}) * 100",
+          "legendFormat": "Heap Usage",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Non-Heap Usage",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 1 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(jvm_memory_used_bytes{area=\"nonheap\"})",
+          "legendFormat": "Non-Heap Used",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "GC Pause",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 1 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "rate(jvm_gc_pause_seconds_sum[5m]) / rate(jvm_gc_pause_seconds_count[5m])",
+          "legendFormat": "{{ action }} - {{ cause }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Active Threads",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 1 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 200 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "jvm_threads_live_threads",
+          "legendFormat": "Live Threads",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU Usage",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 9 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "process_cpu_usage * 100",
+          "legendFormat": "Process",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "system_cpu_usage * 100",
+          "legendFormat": "System",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Uptime",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 9 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "process_uptime_seconds",
+          "legendFormat": "Uptime",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "HTTP",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "id": null,
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Request Rate",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 18 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "mode": "none" }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count[5m]))",
+          "legendFormat": "{{ uri }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency p50 / p95 / p99",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 18 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(http_server_requests_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Error Rate 5xx",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 18 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[5m])) / sum(rate(http_server_requests_seconds_count[5m])) * 100",
+          "legendFormat": "5xx Rate",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "piechart",
+      "title": "Status Code Distribution",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 18 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] },
+        "pieType": "donut",
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum by (status) (increase(http_server_requests_seconds_count[1h]))",
+          "legendFormat": "{{ status }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Logback Errors",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 26 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "ERROR" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "WARN" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "INFO" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(rate(logback_events_total{level=\"error\"}[5m]))",
+          "legendFormat": "ERROR",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(rate(logback_events_total{level=\"warn\"}[5m]))",
+          "legendFormat": "WARN",
+          "refId": "B"
+        },
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(rate(logback_events_total{level=\"info\"}[5m]))",
+          "legendFormat": "INFO",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Infrastructure",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": null,
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "HikariCP Connections",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 35 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Active" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Idle" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Pending" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "hikaricp_connections_active",
+          "legendFormat": "Active",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "hikaricp_connections_idle",
+          "legendFormat": "Idle",
+          "refId": "B"
+        },
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "hikaricp_connections_pending",
+          "legendFormat": "Pending",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Redis Command Latency",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 35 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "rate(spring_data_redis_command_duration_seconds_sum[5m]) / rate(spring_data_redis_command_duration_seconds_count[5m])",
+          "legendFormat": "Avg Latency",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Unused Sentences",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 35 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "green", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "game_sentences_unused",
+          "legendFormat": "Unused",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Circuit Breaker State",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 43 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "CLOSED", "color": "green", "index": 0 },
+                "1": { "text": "OPEN", "color": "red", "index": 1 },
+                "2": { "text": "HALF_OPEN", "color": "yellow", "index": 2 }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "resilience4j_circuitbreaker_state{name=\"aiService\"}",
+          "legendFormat": "aiService",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Retry Calls",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 43 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(rate(resilience4j_retry_calls_total{kind=\"successful_without_retry\"}[5m]))",
+          "legendFormat": "Success (no retry)",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(rate(resilience4j_retry_calls_total{kind=~\"successful_with_retry|failed.*\"}[5m]))",
+          "legendFormat": "Retried/Failed",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Domain",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 51 },
+      "id": null,
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "gauge",
+      "title": "SSE Connections",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 52 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "max": 500,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 300 },
+              { "color": "red", "value": 450 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sse_connections",
+          "legendFormat": "SSE",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Scheduler Durations",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 52 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "always",
+            "pointSize": 6,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "scheduler_midnight_duration_seconds_max",
+          "legendFormat": "Midnight",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "scheduler_redis_cleanup_duration_seconds_max",
+          "legendFormat": "Redis Cleanup",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Ranking Updates",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 52 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "rate(ranking_update_total[5m])",
+          "legendFormat": "Updates/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Rate Limit Rejections",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 52 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum by (group) (rate(ratelimit_rejected_total[5m]))",
+          "legendFormat": "{{ group }}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "links": []
+}

--- a/infra/grafana/provisioning/dashboards/dashboard.yml
+++ b/infra/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/infra/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/infra/prometheus/prometheus.dev.yml
+++ b/infra/prometheus/prometheus.dev.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: gakkaweo-backend
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - host.docker.internal:9090

--- a/infra/prometheus/prometheus.prod.yml
+++ b/infra/prometheus/prometheus.prod.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: gakkaweo-backend
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - backend:9090


### PR DESCRIPTION
## 관련 이슈

Closes #175

## 변경 사항

### Actuator 관리 포트 분리
- `management.server.port=9090` 분리, `include: prometheus` 노출
- SecurityConfig `/actuator/**` permitAll
- JwtAuthenticationFilter, RateLimitFilter 관리 포트 `shouldNotFilter()` 적용
- `micrometer-registry-prometheus` + `spring-boot-starter-aop` 의존성 추가

### 도메인 커스텀 메트릭
- CustomMetricsConfig: Gauge 3종(SSE 연결 수, Rate Limit 버킷 수, 미사용 문장 잔여) + TimedAspect 빈
- @Timed: DailySentenceScheduler, RedisCleanupScheduler, RankingService.rebuildRankingCache
- Counter: ranking.update(성공 경로만), ratelimit.rejected(EndpointGroup별 EnumMap 사전 초기화)

### Prometheus + Grafana 스택
- Prometheus v3.5.3 LTS + Grafana 13.0.1 Docker 서비스 (dev/prod)
- Grafana 프로비저닝: 데이터소스 자동 등록 + 프리빌트 대시보드 20패널
  - JVM: Heap, Non-Heap, GC, Threads, CPU, Uptime
  - HTTP: Request Rate, Latency p50/p95/p99, Error Rate, Status Code, Logback Errors
  - Infrastructure: HikariCP, Redis Latency, Unused Sentences, Circuit Breaker State, Retry Calls
  - Domain: SSE Connections, Scheduler Durations, Ranking Updates, Rate Limit Rejections
- prod: Docker internal 네트워크 + Grafana localhost-only 바인딩 (SSH 터널링 접근)

### CD 확장
- paths-filter `infra/**` 추가 + SCP 배포 단계

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다