### PR TITLE
feat: 도메인 비즈니스 메트릭 강화 (추측/클리어/로그인/가입/탈퇴/Discord + 대시보드)

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/auth/metrics/AuthMetrics.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/metrics/AuthMetrics.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.auth.metrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 public class AuthMetrics {
 
   private static final String[] PROVIDERS = {"local", "kakao", "google", "naver"};
+  private static final Set<String> ALLOWED_PROVIDERS = Set.of(PROVIDERS);
 
   private final MeterRegistry meterRegistry;
 
@@ -32,20 +34,38 @@ public class AuthMetrics {
           .description("Total registrations")
           .register(meterRegistry);
     }
+    Counter.builder("auth.login.total")
+        .tag("provider", "unknown")
+        .tag("result", "success")
+        .description("Total login attempts")
+        .register(meterRegistry);
+    Counter.builder("auth.login.total")
+        .tag("provider", "unknown")
+        .tag("result", "failure")
+        .description("Total login attempts")
+        .register(meterRegistry);
+    Counter.builder("auth.register.total")
+        .tag("provider", "unknown")
+        .description("Total registrations")
+        .register(meterRegistry);
     Counter.builder("auth.withdraw.total")
         .description("Total account withdrawals")
         .register(meterRegistry);
   }
 
   public void recordLogin(String provider, boolean success) {
+    String safe = sanitize(provider);
     meterRegistry
-        .counter(
-            "auth.login.total", "provider", provider, "result", success ? "success" : "failure")
+        .counter("auth.login.total", "provider", safe, "result", success ? "success" : "failure")
         .increment();
   }
 
   public void recordRegister(String provider) {
-    meterRegistry.counter("auth.register.total", "provider", provider).increment();
+    meterRegistry.counter("auth.register.total", "provider", sanitize(provider)).increment();
+  }
+
+  private static String sanitize(String provider) {
+    return ALLOWED_PROVIDERS.contains(provider) ? provider : "unknown";
   }
 
   public void recordWithdraw() {

--- a/backend/src/main/java/com/gakkaweo/backend/auth/metrics/AuthMetrics.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/metrics/AuthMetrics.java
@@ -1,0 +1,54 @@
+package com.gakkaweo.backend.auth.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthMetrics {
+
+  private static final String[] PROVIDERS = {"local", "kakao", "google", "naver"};
+
+  private final MeterRegistry meterRegistry;
+
+  @PostConstruct
+  void initCounters() {
+    for (String provider : PROVIDERS) {
+      Counter.builder("auth.login.total")
+          .tag("provider", provider)
+          .tag("result", "success")
+          .description("Total login attempts")
+          .register(meterRegistry);
+      Counter.builder("auth.login.total")
+          .tag("provider", provider)
+          .tag("result", "failure")
+          .description("Total login attempts")
+          .register(meterRegistry);
+      Counter.builder("auth.register.total")
+          .tag("provider", provider)
+          .description("Total registrations")
+          .register(meterRegistry);
+    }
+    Counter.builder("auth.withdraw.total")
+        .description("Total account withdrawals")
+        .register(meterRegistry);
+  }
+
+  public void recordLogin(String provider, boolean success) {
+    meterRegistry
+        .counter(
+            "auth.login.total", "provider", provider, "result", success ? "success" : "failure")
+        .increment();
+  }
+
+  public void recordRegister(String provider) {
+    meterRegistry.counter("auth.register.total", "provider", provider).increment();
+  }
+
+  public void recordWithdraw() {
+    meterRegistry.counter("auth.withdraw.total").increment();
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -44,6 +44,9 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
       return "unknown";
     }
     String segment = uri.substring(idx + prefix.length());
+    if (segment.isEmpty()) {
+      return "unknown";
+    }
     int slash = segment.indexOf('/');
     return slash > 0 ? segment.substring(0, slash) : segment;
   }

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,6 +1,7 @@
 package com.gakkaweo.backend.auth.oauth2.handler;
 
 import com.gakkaweo.backend.auth.config.OAuth2Properties;
+import com.gakkaweo.backend.auth.metrics.AuthMetrics;
 import com.gakkaweo.backend.auth.oauth2.CookieAuthorizationRequestRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,16 +21,30 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
   private final OAuth2Properties oAuth2Properties;
   private final CookieAuthorizationRequestRepository authorizationRequestRepository;
+  private final AuthMetrics authMetrics;
 
   @Override
   public void onAuthenticationFailure(
       HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
       throws IOException {
+    String provider = extractProvider(request.getRequestURI());
+    authMetrics.recordLogin(provider, false);
     log.warn("OAuth2 로그인 실패: {}", exception.getMessage());
     authorizationRequestRepository.deleteCookie(response);
 
     String message = exception.getMessage() != null ? exception.getMessage() : "로그인에 실패했습니다";
     String errorMessage = URLEncoder.encode(message, StandardCharsets.UTF_8);
     response.sendRedirect(oAuth2Properties.authorizedRedirectUri() + "?error=" + errorMessage);
+  }
+
+  private String extractProvider(String uri) {
+    String prefix = "/login/oauth2/code/";
+    int idx = uri.indexOf(prefix);
+    if (idx < 0) {
+      return "unknown";
+    }
+    String segment = uri.substring(idx + prefix.length());
+    int slash = segment.indexOf('/');
+    return slash > 0 ? segment.substring(0, slash) : segment;
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -2,6 +2,7 @@ package com.gakkaweo.backend.auth.oauth2.handler;
 
 import com.gakkaweo.backend.auth.config.OAuth2Properties;
 import com.gakkaweo.backend.auth.dto.TokenPair;
+import com.gakkaweo.backend.auth.metrics.AuthMetrics;
 import com.gakkaweo.backend.auth.oauth2.CookieAuthorizationRequestRepository;
 import com.gakkaweo.backend.auth.oauth2.CustomOAuth2User;
 import com.gakkaweo.backend.auth.service.AuthService;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -25,12 +27,18 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
   private final CookieUtils cookieUtils;
   private final OAuth2Properties oAuth2Properties;
   private final CookieAuthorizationRequestRepository authorizationRequestRepository;
+  private final AuthMetrics authMetrics;
 
   @Override
   public void onAuthenticationSuccess(
       HttpServletRequest request, HttpServletResponse response, Authentication authentication)
       throws IOException {
     CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+    String provider =
+        authentication instanceof OAuth2AuthenticationToken oauthToken
+            ? oauthToken.getAuthorizedClientRegistrationId()
+            : "unknown";
+    authMetrics.recordLogin(provider, true);
     log.info("OAuth2 로그인 성공: memberId={}", oAuth2User.getMember().getPublicId());
     TokenPair tokenPair = authService.issueTokens(oAuth2User.getMember());
 

--- a/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/OAuthMemberService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/oauth2/service/OAuthMemberService.java
@@ -1,5 +1,6 @@
 package com.gakkaweo.backend.auth.oauth2.service;
 
+import com.gakkaweo.backend.auth.metrics.AuthMetrics;
 import com.gakkaweo.backend.auth.oauth2.dto.OAuthAttributes;
 import com.gakkaweo.backend.domain.member.entity.Member;
 import com.gakkaweo.backend.domain.member.entity.SocialAccount;
@@ -20,6 +21,7 @@ public class OAuthMemberService {
   private final SocialAccountRepository socialAccountRepository;
   private final MemberRepository memberRepository;
   private final NicknameGenerator nicknameGenerator;
+  private final AuthMetrics authMetrics;
 
   @Transactional
   public Member findOrCreateMember(OAuthAttributes attributes) {
@@ -43,6 +45,7 @@ public class OAuthMemberService {
     String nickname = nicknameGenerator.generate();
     Member member = memberRepository.save(new Member(nickname));
     log.info("신규 회원 가입: provider={}, memberId={}", attributes.provider(), member.getPublicId());
+    authMetrics.recordRegister(attributes.provider().name().toLowerCase());
 
     SocialAccount socialAccount =
         new SocialAccount(member, attributes.provider(), attributes.providerId());

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/AccountService.java
@@ -1,5 +1,6 @@
 package com.gakkaweo.backend.auth.service;
 
+import com.gakkaweo.backend.auth.metrics.AuthMetrics;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.domain.admin.repository.SentenceUploadRepository;
@@ -32,6 +33,7 @@ public class AccountService {
   private final AuthService authService;
   private final RankingService rankingService;
   private final ApplicationEventPublisher eventPublisher;
+  private final AuthMetrics authMetrics;
 
   @Transactional
   public void deleteAccount(UUID publicId) {
@@ -48,6 +50,7 @@ public class AccountService {
     refreshTokenRepository.deleteByMemberId(member.getId());
     memberRepository.delete(member);
 
+    authMetrics.recordWithdraw();
     log.info(
         "회원 탈퇴 완료: publicId={}, anonymizedSessions={}, anonymizedUploads={}",
         publicId,

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/LocalAuthService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/LocalAuthService.java
@@ -1,5 +1,6 @@
 package com.gakkaweo.backend.auth.service;
 
+import com.gakkaweo.backend.auth.metrics.AuthMetrics;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
 import com.gakkaweo.backend.domain.member.entity.LocalAccount;
@@ -23,6 +24,7 @@ public class LocalAuthService {
   private final MemberRepository memberRepository;
   private final NicknameGenerator nicknameGenerator;
   private final PasswordEncoder passwordEncoder;
+  private final AuthMetrics authMetrics;
 
   public Member register(String username, String password) {
     if (username.length() < 4 || password.length() < 8) {
@@ -49,6 +51,7 @@ public class LocalAuthService {
     }
 
     log.info("로컬 계정 가입: publicId={}, username={}", member.getPublicId(), username);
+    authMetrics.recordRegister("local");
     return member;
   }
 
@@ -57,17 +60,24 @@ public class LocalAuthService {
     LocalAccount localAccount =
         localAccountRepository
             .findByUsernameIgnoreCase(username)
-            .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
+            .orElseThrow(
+                () -> {
+                  authMetrics.recordLogin("local", false);
+                  return new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+                });
 
     if (!passwordEncoder.matches(password, localAccount.getPasswordHash())) {
+      authMetrics.recordLogin("local", false);
       throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
     }
 
     Member member = localAccount.getMember();
     if (Boolean.TRUE.equals(member.getBanned())) {
+      authMetrics.recordLogin("local", false);
       throw new BusinessException(ErrorCode.MEMBER_BANNED);
     }
 
+    authMetrics.recordLogin("local", true);
     return member;
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -25,6 +25,7 @@ import com.gakkaweo.backend.game.util.HintMaskGenerator;
 import com.gakkaweo.backend.infra.ai.service.SimilarityClient;
 import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
 import com.gakkaweo.backend.ranking.service.RankingService;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
@@ -55,6 +56,7 @@ public class DailyGameService {
   private final GameProperties gameProperties;
   private final ApplicationEventPublisher eventPublisher;
   private final Clock clock;
+  private final MeterRegistry meterRegistry;
 
   private static boolean isPerfect(BigDecimal similarity) {
     return similarity.compareTo(GameConstants.PERFECT_SIMILARITY) >= 0;
@@ -98,6 +100,9 @@ public class DailyGameService {
             sentence.getId(), request.guessText(), sentence.getSentence(), remainingTtl());
 
     boolean isCorrect = similarity.compareTo(gameProperties.similarityThreshold()) >= 0;
+    meterRegistry
+        .counter("game.guesses.total", "result", isCorrect ? "correct" : "incorrect")
+        .increment();
 
     BigDecimal previousBest = session.getBestSimilarity();
     Instant now = clock.instant();
@@ -106,6 +111,7 @@ public class DailyGameService {
       session.incrementAttempt();
       if (isCorrect) {
         session.markCleared(now);
+        meterRegistry.counter("game.clears.total").increment();
       }
     } else if (session.isCleared() && isPerfect(similarity)) {
       session.updateClearedAt(now);
@@ -144,6 +150,9 @@ public class DailyGameService {
             sentence.getId(), request.guessText(), sentence.getSentence(), remainingTtl());
 
     boolean isCorrect = similarity.compareTo(gameProperties.similarityThreshold()) >= 0;
+    meterRegistry
+        .counter("game.guesses.total", "result", isCorrect ? "correct" : "incorrect")
+        .increment();
 
     return new GuessResponse(similarity, null, isCorrect, null, clock.instant());
   }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/monitoring/CustomMetricsConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/monitoring/CustomMetricsConfig.java
@@ -4,6 +4,7 @@ import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
 import com.gakkaweo.backend.ranking.sse.SseConnectionManager;
 import com.gakkaweo.backend.ratelimit.filter.BucketStore;
 import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
@@ -42,5 +43,28 @@ public class CustomMetricsConfig {
                 "game.sentences.unused", dailySentenceRepository, repo -> repo.countUnusedActive())
             .description("Unused active sentences remaining")
             .register(registry);
+  }
+
+  @Bean
+  MeterBinder businessCounters() {
+    return registry -> {
+      Counter.builder("game.guesses.total")
+          .tag("result", "correct")
+          .description("Total guess submissions")
+          .register(registry);
+      Counter.builder("game.guesses.total")
+          .tag("result", "incorrect")
+          .description("Total guess submissions")
+          .register(registry);
+      Counter.builder("game.clears.total").description("Total game clears").register(registry);
+      Counter.builder("discord.webhook.total")
+          .tag("result", "success")
+          .description("Total Discord webhook dispatches")
+          .register(registry);
+      Counter.builder("discord.webhook.total")
+          .tag("result", "failure")
+          .description("Total Discord webhook dispatches")
+          .register(registry);
+    };
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/client/DiscordWebhookClient.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/client/DiscordWebhookClient.java
@@ -5,6 +5,7 @@ import com.gakkaweo.backend.infra.notification.config.DiscordWebhookProperties;
 import com.gakkaweo.backend.infra.notification.dto.AllowedMentions;
 import com.gakkaweo.backend.infra.notification.dto.DiscordEmbed;
 import com.gakkaweo.backend.infra.notification.dto.DiscordWebhookPayload;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,7 @@ public class DiscordWebhookClient {
 
   private final RestClient discordWebhookRestClient;
   private final DiscordWebhookProperties properties;
+  private final MeterRegistry meterRegistry;
 
   @Async("discordWebhookExecutor")
   public void send(NotificationLevel level, DiscordEmbed embed) {
@@ -50,7 +52,9 @@ public class DiscordWebhookClient {
           .body(payload)
           .retrieve()
           .toBodilessEntity();
+      meterRegistry.counter("discord.webhook.total", "result", "success").increment();
     } catch (RestClientException e) {
+      meterRegistry.counter("discord.webhook.total", "result", "failure").increment();
       log.warn("Discord 웹훅 전송 실패: {}", e.getMessage(), e);
     }
   }

--- a/backend/src/test/java/com/gakkaweo/backend/auth/OAuth2LoginHandlerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/auth/OAuth2LoginHandlerTest.java
@@ -9,6 +9,7 @@ import com.gakkaweo.backend.auth.config.CookieProperties;
 import com.gakkaweo.backend.auth.config.JwtProperties;
 import com.gakkaweo.backend.auth.config.OAuth2Properties;
 import com.gakkaweo.backend.auth.dto.TokenPair;
+import com.gakkaweo.backend.auth.metrics.AuthMetrics;
 import com.gakkaweo.backend.auth.oauth2.CookieAuthorizationRequestRepository;
 import com.gakkaweo.backend.auth.oauth2.CustomOAuth2User;
 import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginFailureHandler;
@@ -16,6 +17,7 @@ import com.gakkaweo.backend.auth.oauth2.handler.OAuth2LoginSuccessHandler;
 import com.gakkaweo.backend.auth.service.AuthService;
 import com.gakkaweo.backend.auth.util.CookieUtils;
 import com.gakkaweo.backend.domain.member.entity.Member;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.net.HttpCookie;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -45,6 +47,7 @@ class OAuth2LoginHandlerTest {
   private CookieUtils cookieUtils;
   private OAuth2Properties oAuth2Properties;
   private CookieAuthorizationRequestRepository authorizationRequestRepository;
+  private AuthMetrics authMetrics;
 
   private static List<HttpCookie> allSetCookies(MockHttpServletResponse response) {
     return response.getHeaders(HttpHeaders.SET_COOKIE).stream()
@@ -69,6 +72,7 @@ class OAuth2LoginHandlerTest {
     oAuth2Properties = new OAuth2Properties(REDIRECT_URI);
     authorizationRequestRepository =
         new CookieAuthorizationRequestRepository(cookieProperties, new ObjectMapper());
+    authMetrics = new AuthMetrics(new SimpleMeterRegistry());
   }
 
   private static class NullMessageAuthenticationException extends AuthenticationException {
@@ -86,7 +90,11 @@ class OAuth2LoginHandlerTest {
     void 성공_쿠키_리다이렉트() throws Exception {
       OAuth2LoginSuccessHandler handler =
           new OAuth2LoginSuccessHandler(
-              authService, cookieUtils, oAuth2Properties, authorizationRequestRepository);
+              authService,
+              cookieUtils,
+              oAuth2Properties,
+              authorizationRequestRepository,
+              authMetrics);
       Member member = new Member("tester");
       when(authService.issueTokens(any(Member.class)))
           .thenReturn(new TokenPair("access-value", "refresh-value"));
@@ -117,7 +125,8 @@ class OAuth2LoginHandlerTest {
     @DisplayName("예외 메시지 있음 - URLEncoded error 파라미터 포함 리다이렉트")
     void 메시지_있음() throws Exception {
       OAuth2LoginFailureHandler handler =
-          new OAuth2LoginFailureHandler(oAuth2Properties, authorizationRequestRepository);
+          new OAuth2LoginFailureHandler(
+              oAuth2Properties, authorizationRequestRepository, authMetrics);
       AuthenticationException exception =
           new OAuth2AuthenticationException(new OAuth2Error("member_banned", "차단된 계정입니다", null));
 
@@ -132,7 +141,8 @@ class OAuth2LoginHandlerTest {
     @DisplayName("예외 메시지 null - 기본 메시지로 리다이렉트")
     void 메시지_null() throws Exception {
       OAuth2LoginFailureHandler handler =
-          new OAuth2LoginFailureHandler(oAuth2Properties, authorizationRequestRepository);
+          new OAuth2LoginFailureHandler(
+              oAuth2Properties, authorizationRequestRepository, authMetrics);
       AuthenticationException exception = new NullMessageAuthenticationException();
 
       MockHttpServletResponse response = new MockHttpServletResponse();
@@ -146,7 +156,8 @@ class OAuth2LoginHandlerTest {
     @DisplayName("실패 - oauth2 인증 요청 삭제 쿠키 발급")
     void 인증요청_삭제쿠키() throws Exception {
       OAuth2LoginFailureHandler handler =
-          new OAuth2LoginFailureHandler(oAuth2Properties, authorizationRequestRepository);
+          new OAuth2LoginFailureHandler(
+              oAuth2Properties, authorizationRequestRepository, authMetrics);
       AuthenticationException exception =
           new OAuth2AuthenticationException(new OAuth2Error("invalid_request", "bad", null));
 

--- a/backend/src/test/java/com/gakkaweo/backend/infra/notification/DiscordWebhookClientTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/infra/notification/DiscordWebhookClientTest.java
@@ -14,6 +14,7 @@ import com.gakkaweo.backend.infra.notification.config.DiscordWebhookProperties;
 import com.gakkaweo.backend.infra.notification.dto.DiscordEmbed;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -42,7 +43,7 @@ class DiscordWebhookClientTest {
     RestClient restClient = RestClient.builder().requestFactory(factory).build();
     DiscordWebhookProperties properties =
         new DiscordWebhookProperties(webhookUrl, Duration.ofSeconds(3), mentionRoleId);
-    return new DiscordWebhookClient(restClient, properties);
+    return new DiscordWebhookClient(restClient, properties, new SimpleMeterRegistry());
   }
 
   @Test

--- a/infra/grafana/dashboards/gakkaweo.json
+++ b/infra/grafana/dashboards/gakkaweo.json
@@ -913,7 +913,7 @@
       "targets": [
         {
           "datasource": { "uid": "prometheus", "type": "prometheus" },
-          "expr": "increase(game_clears_total[1h])",
+          "expr": "sum(increase(game_clears_total[1h]))",
           "legendFormat": "Clears",
           "refId": "A"
         }
@@ -1065,7 +1065,7 @@
       "targets": [
         {
           "datasource": { "uid": "prometheus", "type": "prometheus" },
-          "expr": "increase(auth_withdraw_total[1h])",
+          "expr": "sum(increase(auth_withdraw_total[1h]))",
           "legendFormat": "Withdrawals",
           "refId": "A"
         }

--- a/infra/grafana/dashboards/gakkaweo.json
+++ b/infra/grafana/dashboards/gakkaweo.json
@@ -834,6 +834,663 @@
         }
       ]
     }
+    ,
+    {
+      "type": "row",
+      "title": "Application",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 60 },
+      "id": null,
+      "collapsed": false,
+      "panels": []
+    },
+
+    {
+      "type": "stat",
+      "title": "추측 (1h)",
+      "description": "최근 1시간 총 추측 횟수 (correct + incorrect)",
+      "gridPos": { "h": 4, "w": 3, "x": 0, "y": 61 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "semi-dark-blue", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(increase(game_guesses_total[1h]))",
+          "legendFormat": "Guesses",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "클리어 (1h)",
+      "description": "최근 1시간 게임 클리어 횟수",
+      "gridPos": { "h": 4, "w": 3, "x": 3, "y": 61 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "dark-blue", "value": null },
+              { "color": "semi-dark-green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "increase(game_clears_total[1h])",
+          "legendFormat": "Clears",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "가입 (1h)",
+      "description": "최근 1시간 신규 회원가입 횟수 (모든 프로바이더 합산)",
+      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 61 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "semi-dark-purple", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(increase(auth_register_total[1h]))",
+          "legendFormat": "Registers",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "로그인 (1h)",
+      "description": "최근 1시간 성공 로그인 횟수 (모든 프로바이더 합산)",
+      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 61 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "semi-dark-purple", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(increase(auth_login_total{result=\"success\"}[1h]))",
+          "legendFormat": "Logins",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "로그인 실패 (1h)",
+      "description": "최근 1시간 로그인 실패 횟수. 급증 시 brute-force 의심",
+      "gridPos": { "h": 4, "w": 3, "x": 12, "y": 61 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "semi-dark-green", "value": null },
+              { "color": "semi-dark-orange", "value": 10 },
+              { "color": "dark-red", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(increase(auth_login_total{result=\"failure\"}[1h]))",
+          "legendFormat": "Failures",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "탈퇴 (1h)",
+      "description": "최근 1시간 회원 탈퇴 횟수",
+      "gridPos": { "h": 4, "w": 3, "x": 15, "y": 61 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "semi-dark-green", "value": null },
+              { "color": "semi-dark-orange", "value": 3 },
+              { "color": "dark-red", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "increase(auth_withdraw_total[1h])",
+          "legendFormat": "Withdrawals",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Discord 성공률",
+      "description": "Discord 웹훅 전송 성공률. webhookUrl 미설정(skip)은 미포함",
+      "gridPos": { "h": 4, "w": 3, "x": 18, "y": 61 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "min": 0,
+          "max": 100,
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "dark-red", "value": null },
+              { "color": "semi-dark-orange", "value": 90 },
+              { "color": "semi-dark-green", "value": 99 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum(increase(discord_webhook_total{result=\"success\"}[1h])) / sum(increase(discord_webhook_total[1h])) * 100",
+          "legendFormat": "Success %",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Rate Limit Buckets",
+      "description": "현재 활성 Rate Limit 버킷 수 (IP당 1개)",
+      "gridPos": { "h": 4, "w": 3, "x": 21, "y": 61 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "semi-dark-green", "value": null },
+              { "color": "semi-dark-orange", "value": 500 },
+              { "color": "dark-red", "value": 1000 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "ratelimit_buckets_active",
+          "legendFormat": "Active Buckets",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "type": "timeseries",
+      "title": "Game Guesses Rate",
+      "description": "추측 제출 속도 (correct/incorrect). 인증+비인증 합산",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 65 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 25,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "mode": "normal", "group": "A" },
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "correct" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "semi-dark-green", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "incorrect" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "semi-dark-orange", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum", "mean", "max"]
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum by (result) (rate(game_guesses_total[5m]))",
+          "legendFormat": "{{ result }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Login by Provider",
+      "description": "프로바이더별 성공 로그인 속도",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 65 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "mode": "normal", "group": "A" },
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "kakao" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#FEE500", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "naver" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#03C75A", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "google" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#4285F4", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "local" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "semi-dark-blue", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum", "mean"]
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum by (provider) (rate(auth_login_total{result=\"success\"}[5m]))",
+          "legendFormat": "{{ provider }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Discord Webhook Dispatches",
+      "description": "Discord 웹훅 전송 결과. failure 급증 시 Discord API 장애 또는 payload 오류 의심",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 65 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": true,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "success" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "semi-dark-green", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "failure" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "dark-red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum", "mean"]
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum by (result) (rate(discord_webhook_total[5m]))",
+          "legendFormat": "{{ result }}",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "type": "timeseries",
+      "title": "Login Failures by Provider",
+      "description": "프로바이더별 로그인 실패 속도. 특정 프로바이더 급증 시 OAuth 설정 이상 또는 brute-force 공격 의심",
+      "gridPos": { "h": 8, "w": 14, "x": 0, "y": 73 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": true,
+            "stacking": { "mode": "normal", "group": "A" },
+            "lineInterpolation": "smooth",
+            "thresholdsStyle": { "mode": "dashed" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "dark-red", "value": 0.1 }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "local" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "semi-dark-red", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "kakao" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "dark-orange", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "naver" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "dark-yellow", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "google" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "dark-purple", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum", "mean", "max"]
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum by (provider) (rate(auth_login_total{result=\"failure\"}[5m]))",
+          "legendFormat": "{{ provider }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "piechart",
+      "title": "Login Provider 비율",
+      "description": "프로바이더별 성공 로그인 비율 (1h 기준)",
+      "gridPos": { "h": 8, "w": 5, "x": 14, "y": 73 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "kakao" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#FEE500", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "naver" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#03C75A", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "google" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "#4285F4", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "local" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "semi-dark-blue", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] },
+        "pieType": "donut",
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "sum by (provider) (increase(auth_login_total{result=\"success\"}[1h]))",
+          "legendFormat": "{{ provider }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "gauge",
+      "title": "Rate Limit Buckets",
+      "description": "현재 활성 Rate Limit 버킷 수 (IP당 1개). 임계치 초과 시 메모리 압박 가능",
+      "gridPos": { "h": 8, "w": 5, "x": 19, "y": 73 },
+      "id": null,
+      "datasource": { "uid": "prometheus", "type": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "max": 1000,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "semi-dark-green", "value": null },
+              { "color": "semi-dark-orange", "value": 500 },
+              { "color": "dark-red", "value": 800 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus", "type": "prometheus" },
+          "expr": "ratelimit_buckets_active",
+          "legendFormat": "Active Buckets",
+          "refId": "A"
+        }
+      ]
+    }
   ],
   "templating": { "list": [] },
   "annotations": { "list": [] },


### PR DESCRIPTION
## 관련 이슈

Closes #177

## 변경 사항

- `game.guesses.total`(correct/incorrect), `game.clears.total` Counter를 DailyGameService에 추가
- `discord.webhook.total`(success/failure) Counter를 DiscordWebhookClient에 추가
- `auth.login.total`(provider x result), `auth.register.total`(provider), `auth.withdraw.total` Counter를 AuthMetrics 컴포넌트로 신설
- LocalAuthService, OAuth2 핸들러, OAuthMemberService, AccountService에서 AuthMetrics 호출
- CustomMetricsConfig에 game/discord Counter 사전 등록(MeterBinder)으로 기동 시 0값 노출
- Grafana Application 행 + 3단 14패널 구성 (stats strip 8개 / 상세 차트 3개 / 보안-운영 3개)
- 프로바이더별 브랜드 색상(카카오/네이버/구글), threshold 경고선, donut 비율 차트
- 미등록이던 `ratelimit_buckets_active` gauge 패널 배치
- 기존 테스트에 MeterRegistry/AuthMetrics 전달 대응 (352 테스트 전체 통과)

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다