### PR TITLE
refactor: 기술부채 일괄 정리 (TX 경계/RoleHierarchy/Counter 통일/SHA-256/env)

### DIFF
--- a/.env.prod.sample
+++ b/.env.prod.sample
@@ -46,6 +46,12 @@ AI_SERVICE_TIMEOUT=3s
 # 게임
 # 클리어 인정 유사도 임계값(0~100, 이 값 이상이면 정답 처리)
 SIMILARITY_THRESHOLD=95.0
+# 힌트 활성화 유사도 임계값(이 값 이상 달성 시 힌트 패널 잠금 해제)
+HINT_TRIGGER_THRESHOLD=60.0
+# 힌트 최대 유사도 상한(요청자 bestSimilarity와 이 값 중 작은 쪽 기준 필터링)
+HINT_MAX_SIMILARITY=90.0
+# 힌트 최대 표시 개수
+HINT_MAX_COUNT=5
 # 프로필 이미지 저장 경로. prod는 docker 볼륨 마운트 지점
 UPLOAD_PROFILE_DIR=/data/uploads/profiles
 
@@ -54,7 +60,7 @@ SSE_MAX_CONNECTIONS=500
 
 # Rate Limiting (분당 요청 수. 그룹별 적용 경로: GUESS=/daily/guess, READ=GET 엔드포인트, SSE=/ranking/stream, AUTH=/auth/**, ADMIN=/admin/**)
 RATE_LIMIT_GUESS=40
-RATE_LIMIT_READ=90
+RATE_LIMIT_READ=120
 RATE_LIMIT_SSE=10
 RATE_LIMIT_AUTH=10
 RATE_LIMIT_ADMIN=120

--- a/.env.sample
+++ b/.env.sample
@@ -46,6 +46,12 @@ AI_SERVICE_TIMEOUT=3s
 # 게임
 # 클리어 인정 유사도 임계값(0~100, 이 값 이상이면 정답 처리)
 SIMILARITY_THRESHOLD=95.0
+# 힌트 활성화 유사도 임계값(이 값 이상 달성 시 힌트 패널 잠금 해제)
+HINT_TRIGGER_THRESHOLD=60.0
+# 힌트 최대 유사도 상한(요청자 bestSimilarity와 이 값 중 작은 쪽 기준 필터링)
+HINT_MAX_SIMILARITY=90.0
+# 힌트 최대 표시 개수
+HINT_MAX_COUNT=5
 # 프로필 이미지 저장 경로. prod는 docker 볼륨 마운트 지점
 UPLOAD_PROFILE_DIR=./uploads/profiles
 
@@ -54,7 +60,7 @@ SSE_MAX_CONNECTIONS=500
 
 # Rate Limiting (분당 요청 수. 그룹별 적용 경로: GUESS=/daily/guess, READ=GET 엔드포인트, SSE=/ranking/stream, AUTH=/auth/**, ADMIN=/admin/**)
 RATE_LIMIT_GUESS=40
-RATE_LIMIT_READ=90
+RATE_LIMIT_READ=120
 RATE_LIMIT_SSE=10
 RATE_LIMIT_AUTH=10
 RATE_LIMIT_ADMIN=120

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/LocalAuthService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/LocalAuthService.java
@@ -13,7 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @Slf4j
@@ -25,6 +25,7 @@ public class LocalAuthService {
   private final NicknameGenerator nicknameGenerator;
   private final PasswordEncoder passwordEncoder;
   private final AuthMetrics authMetrics;
+  private final TransactionTemplate transactionTemplate;
 
   public Member register(String username, String password) {
     if (username.length() < 4 || password.length() < 8) {
@@ -36,26 +37,25 @@ public class LocalAuthService {
     }
 
     String passwordHash = passwordEncoder.encode(password);
-    return createLocalAccount(username, passwordHash);
-  }
 
-  @Transactional
-  protected Member createLocalAccount(String username, String passwordHash) {
-    String nickname = nicknameGenerator.generate();
-    Member member = memberRepository.save(new Member(nickname));
-
-    try {
-      localAccountRepository.save(new LocalAccount(member, username, passwordHash));
-    } catch (DataIntegrityViolationException e) {
-      throw new BusinessException(ErrorCode.DUPLICATE_USERNAME);
-    }
+    Member member =
+        transactionTemplate.execute(
+            status -> {
+              String nickname = nicknameGenerator.generate();
+              Member saved = memberRepository.save(new Member(nickname));
+              try {
+                localAccountRepository.save(new LocalAccount(saved, username, passwordHash));
+              } catch (DataIntegrityViolationException e) {
+                throw new BusinessException(ErrorCode.DUPLICATE_USERNAME);
+              }
+              return saved;
+            });
 
     log.info("로컬 계정 가입: publicId={}, username={}", member.getPublicId(), username);
     authMetrics.recordRegister("local");
     return member;
   }
 
-  @Transactional(readOnly = true)
   public Member authenticate(String username, String password) {
     LocalAccount localAccount =
         localAccountRepository

--- a/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/auth/service/RefreshTokenService.java
@@ -3,15 +3,12 @@ package com.gakkaweo.backend.auth.service;
 import com.gakkaweo.backend.auth.config.JwtProperties;
 import com.gakkaweo.backend.common.exception.BusinessException;
 import com.gakkaweo.backend.common.exception.ErrorCode;
+import com.gakkaweo.backend.common.util.HashUtils;
 import com.gakkaweo.backend.domain.auth.entity.RefreshToken;
 import com.gakkaweo.backend.domain.auth.repository.RefreshTokenRepository;
 import com.gakkaweo.backend.domain.member.entity.Member;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -87,13 +84,7 @@ public class RefreshTokenService {
   }
 
   public String hashToken(String rawToken) {
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      byte[] hash = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
-      return HexFormat.of().formatHex(hash);
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다", e);
-    }
+    return HashUtils.sha256Hex(rawToken);
   }
 
   private void revokeFamilyInternal(UUID familyId) {

--- a/backend/src/main/java/com/gakkaweo/backend/common/util/HashUtils.java
+++ b/backend/src/main/java/com/gakkaweo/backend/common/util/HashUtils.java
@@ -1,0 +1,21 @@
+package com.gakkaweo.backend.common.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public final class HashUtils {
+
+  private HashUtils() {}
+
+  public static String sha256Hex(String input) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(hash);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다", e);
+    }
+  }
+}

--- a/backend/src/main/java/com/gakkaweo/backend/config/openapi/SwaggerConfigController.java
+++ b/backend/src/main/java/com/gakkaweo/backend/config/openapi/SwaggerConfigController.java
@@ -7,6 +7,7 @@ import org.springdoc.core.models.GroupedOpenApi;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,6 +21,7 @@ public class SwaggerConfigController {
 
   private final List<GroupedOpenApi> groupedOpenApis;
   private final SwaggerUiConfigProperties swaggerUiConfigProperties;
+  private final RoleHierarchy roleHierarchy;
 
   @GetMapping("/v3/api-docs/swagger-config")
   public ResponseEntity<SwaggerConfig> swaggerConfig() {
@@ -60,7 +62,7 @@ public class SwaggerConfigController {
     if (authentication == null || !authentication.isAuthenticated()) {
       return false;
     }
-    return authentication.getAuthorities().stream()
+    return roleHierarchy.getReachableGrantedAuthorities(authentication.getAuthorities()).stream()
         .map(GrantedAuthority::getAuthority)
         .anyMatch("ROLE_ADMIN"::equals);
   }

--- a/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/game/service/DailyGameService.java
@@ -25,7 +25,9 @@ import com.gakkaweo.backend.game.util.HintMaskGenerator;
 import com.gakkaweo.backend.infra.ai.service.SimilarityClient;
 import com.gakkaweo.backend.ranking.event.RankingUpdateEvent;
 import com.gakkaweo.backend.ranking.service.RankingService;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
@@ -40,6 +42,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @Slf4j
@@ -57,9 +60,32 @@ public class DailyGameService {
   private final ApplicationEventPublisher eventPublisher;
   private final Clock clock;
   private final MeterRegistry meterRegistry;
+  private final TransactionTemplate transactionTemplate;
+
+  private Counter guessCorrectCounter;
+  private Counter guessIncorrectCounter;
+  private Counter clearCounter;
 
   private static boolean isPerfect(BigDecimal similarity) {
     return similarity.compareTo(GameConstants.PERFECT_SIMILARITY) >= 0;
+  }
+
+  @PostConstruct
+  void initCounters() {
+    guessCorrectCounter =
+        Counter.builder("game.guesses.total")
+            .tag("result", "correct")
+            .description("Total guess submissions")
+            .register(meterRegistry);
+    guessIncorrectCounter =
+        Counter.builder("game.guesses.total")
+            .tag("result", "incorrect")
+            .description("Total guess submissions")
+            .register(meterRegistry);
+    clearCounter =
+        Counter.builder("game.clears.total")
+            .description("Total game clears")
+            .register(meterRegistry);
   }
 
   @Transactional(readOnly = true)
@@ -86,7 +112,6 @@ public class DailyGameService {
         yesterdaySentence != null ? yesterday : null);
   }
 
-  @Transactional
   public GuessResponse guessAuthenticated(GuessRequest request, UUID memberPublicId) {
     DailySentence sentence = findTodaySentenceByPublicId(request.sentenceId());
     Member member = findMember(memberPublicId);
@@ -100,33 +125,46 @@ public class DailyGameService {
             sentence.getId(), request.guessText(), sentence.getSentence(), remainingTtl());
 
     boolean isCorrect = similarity.compareTo(gameProperties.similarityThreshold()) >= 0;
-    meterRegistry
-        .counter("game.guesses.total", "result", isCorrect ? "correct" : "incorrect")
-        .increment();
-
-    BigDecimal previousBest = session.getBestSimilarity();
     Instant now = clock.instant();
 
-    if (session.isInProgress()) {
-      session.incrementAttempt();
-      if (isCorrect) {
-        session.markCleared(now);
-        meterRegistry.counter("game.clears.total").increment();
-      }
-    } else if (session.isCleared() && isPerfect(similarity)) {
-      session.updateClearedAt(now);
+    record TxResult(GameSession updatedSession, BigDecimal previousBest, boolean cleared) {}
+
+    TxResult txResult =
+        transactionTemplate.execute(
+            status -> {
+              GameSession s = gameSessionRepository.findById(session.getId()).orElseThrow();
+              BigDecimal prevBest = s.getBestSimilarity();
+              boolean justCleared = false;
+
+              if (s.isInProgress()) {
+                s.incrementAttempt();
+                if (isCorrect) {
+                  s.markCleared(now);
+                  justCleared = true;
+                }
+              } else if (s.isCleared() && isPerfect(similarity)) {
+                s.updateClearedAt(now);
+              }
+              s.updateBestSimilarity(similarity);
+
+              int guessSequence = (int) guessHistoryRepository.countBySession(s) + 1;
+              guessHistoryRepository.save(
+                  new GuessHistory(s, request.guessText(), similarity, guessSequence));
+
+              gameSessionRepository.save(s);
+
+              return new TxResult(s, prevBest, justCleared);
+            });
+
+    GameSession updated = txResult.updatedSession();
+
+    (isCorrect ? guessCorrectCounter : guessIncorrectCounter).increment();
+    if (txResult.cleared()) {
+      clearCounter.increment();
     }
-    session.updateBestSimilarity(similarity);
 
-    int guessSequence = (int) guessHistoryRepository.countBySession(session) + 1;
-
-    guessHistoryRepository.save(
-        new GuessHistory(session, request.guessText(), similarity, guessSequence));
-
-    gameSessionRepository.save(session);
-
-    if (similarity.compareTo(previousBest) > 0) {
-      rankingService.updateRanking(session, member);
+    if (similarity.compareTo(txResult.previousBest()) > 0) {
+      rankingService.updateRanking(updated, member);
       eventPublisher.publishEvent(new RankingUpdateEvent());
     }
 
@@ -138,10 +176,9 @@ public class DailyGameService {
         isCorrect);
 
     return new GuessResponse(
-        similarity, session.getAttemptCount(), isCorrect, session.getStatus().name(), now);
+        similarity, updated.getAttemptCount(), isCorrect, updated.getStatus().name(), now);
   }
 
-  @Transactional(readOnly = true)
   public GuessResponse guessAnonymous(GuessRequest request) {
     DailySentence sentence = findTodaySentenceByPublicId(request.sentenceId());
 
@@ -150,9 +187,7 @@ public class DailyGameService {
             sentence.getId(), request.guessText(), sentence.getSentence(), remainingTtl());
 
     boolean isCorrect = similarity.compareTo(gameProperties.similarityThreshold()) >= 0;
-    meterRegistry
-        .counter("game.guesses.total", "result", isCorrect ? "correct" : "incorrect")
-        .increment();
+    (isCorrect ? guessCorrectCounter : guessIncorrectCounter).increment();
 
     return new GuessResponse(similarity, null, isCorrect, null, clock.instant());
   }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/config/AiServiceConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/config/AiServiceConfig.java
@@ -10,7 +10,7 @@ public class AiServiceConfig {
 
   @Bean
   RestClient aiServiceRestClient(AiServiceProperties properties) {
-    int timeoutMillis = (int) properties.timeout().toMillis();
+    int timeoutMillis = Math.toIntExact(properties.timeout().toMillis());
 
     SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
     factory.setConnectTimeout(timeoutMillis);

--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/TextNormalizer.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/TextNormalizer.java
@@ -1,10 +1,7 @@
 package com.gakkaweo.backend.infra.ai.service;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import com.gakkaweo.backend.common.util.HashUtils;
 import java.text.Normalizer;
-import java.util.HexFormat;
 import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
@@ -22,12 +19,6 @@ public class TextNormalizer {
   }
 
   public String hashForCache(String normalizedText) {
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      byte[] hash = digest.digest(normalizedText.getBytes(StandardCharsets.UTF_8));
-      return HexFormat.of().formatHex(hash);
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다", e);
-    }
+    return HashUtils.sha256Hex(normalizedText);
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/monitoring/CustomMetricsConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/monitoring/CustomMetricsConfig.java
@@ -4,7 +4,6 @@ import com.gakkaweo.backend.domain.game.repository.DailySentenceRepository;
 import com.gakkaweo.backend.ranking.sse.SseConnectionManager;
 import com.gakkaweo.backend.ratelimit.filter.BucketStore;
 import io.micrometer.core.aop.TimedAspect;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
@@ -43,28 +42,5 @@ public class CustomMetricsConfig {
                 "game.sentences.unused", dailySentenceRepository, repo -> repo.countUnusedActive())
             .description("Unused active sentences remaining")
             .register(registry);
-  }
-
-  @Bean
-  MeterBinder businessCounters() {
-    return registry -> {
-      Counter.builder("game.guesses.total")
-          .tag("result", "correct")
-          .description("Total guess submissions")
-          .register(registry);
-      Counter.builder("game.guesses.total")
-          .tag("result", "incorrect")
-          .description("Total guess submissions")
-          .register(registry);
-      Counter.builder("game.clears.total").description("Total game clears").register(registry);
-      Counter.builder("discord.webhook.total")
-          .tag("result", "success")
-          .description("Total Discord webhook dispatches")
-          .register(registry);
-      Counter.builder("discord.webhook.total")
-          .tag("result", "failure")
-          .description("Total Discord webhook dispatches")
-          .register(registry);
-    };
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/client/DiscordWebhookClient.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/client/DiscordWebhookClient.java
@@ -5,7 +5,9 @@ import com.gakkaweo.backend.infra.notification.config.DiscordWebhookProperties;
 import com.gakkaweo.backend.infra.notification.dto.AllowedMentions;
 import com.gakkaweo.backend.infra.notification.dto.DiscordEmbed;
 import com.gakkaweo.backend.infra.notification.dto.DiscordWebhookPayload;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +29,23 @@ public class DiscordWebhookClient {
   private final RestClient discordWebhookRestClient;
   private final DiscordWebhookProperties properties;
   private final MeterRegistry meterRegistry;
+
+  private Counter webhookSuccessCounter;
+  private Counter webhookFailureCounter;
+
+  @PostConstruct
+  void initCounters() {
+    webhookSuccessCounter =
+        Counter.builder("discord.webhook.total")
+            .tag("result", "success")
+            .description("Total Discord webhook dispatches")
+            .register(meterRegistry);
+    webhookFailureCounter =
+        Counter.builder("discord.webhook.total")
+            .tag("result", "failure")
+            .description("Total Discord webhook dispatches")
+            .register(meterRegistry);
+  }
 
   @Async("discordWebhookExecutor")
   public void send(NotificationLevel level, DiscordEmbed embed) {
@@ -52,9 +71,9 @@ public class DiscordWebhookClient {
           .body(payload)
           .retrieve()
           .toBodilessEntity();
-      meterRegistry.counter("discord.webhook.total", "result", "success").increment();
+      webhookSuccessCounter.increment();
     } catch (RestClientException e) {
-      meterRegistry.counter("discord.webhook.total", "result", "failure").increment();
+      webhookFailureCounter.increment();
       log.warn("Discord 웹훅 전송 실패: {}", e.getMessage(), e);
     }
   }

--- a/backend/src/main/java/com/gakkaweo/backend/infra/notification/client/DiscordWebhookClient.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/notification/client/DiscordWebhookClient.java
@@ -7,9 +7,7 @@ import com.gakkaweo.backend.infra.notification.dto.DiscordEmbed;
 import com.gakkaweo.backend.infra.notification.dto.DiscordWebhookPayload;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import jakarta.annotation.PostConstruct;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.Async;
@@ -20,7 +18,6 @@ import org.springframework.web.client.RestClientException;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class DiscordWebhookClient {
 
   private static final int COLOR_HIGH = 0xE67E22;
@@ -28,19 +25,21 @@ public class DiscordWebhookClient {
 
   private final RestClient discordWebhookRestClient;
   private final DiscordWebhookProperties properties;
-  private final MeterRegistry meterRegistry;
+  private final Counter webhookSuccessCounter;
+  private final Counter webhookFailureCounter;
 
-  private Counter webhookSuccessCounter;
-  private Counter webhookFailureCounter;
-
-  @PostConstruct
-  void initCounters() {
-    webhookSuccessCounter =
+  public DiscordWebhookClient(
+      RestClient discordWebhookRestClient,
+      DiscordWebhookProperties properties,
+      MeterRegistry meterRegistry) {
+    this.discordWebhookRestClient = discordWebhookRestClient;
+    this.properties = properties;
+    this.webhookSuccessCounter =
         Counter.builder("discord.webhook.total")
             .tag("result", "success")
             .description("Total Discord webhook dispatches")
             .register(meterRegistry);
-    webhookFailureCounter =
+    this.webhookFailureCounter =
         Counter.builder("discord.webhook.total")
             .tag("result", "failure")
             .description("Total Discord webhook dispatches")

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/BucketStore.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/BucketStore.java
@@ -3,6 +3,7 @@ package com.gakkaweo.backend.ratelimit.filter;
 import com.gakkaweo.backend.ratelimit.config.RateLimitProperties;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class BucketStore {
 
   private final RateLimitProperties properties;
+  private final Clock clock;
   private final Map<String, BucketEntry> buckets = new ConcurrentHashMap<>();
 
   public Bucket resolveBucket(EndpointGroup group, String key) {
@@ -27,10 +29,10 @@ public class BucketStore {
             bucketKey,
             (k, existing) -> {
               if (existing != null) {
-                return new BucketEntry(existing.bucket(), Instant.now());
+                return new BucketEntry(existing.bucket(), clock.instant());
               }
               Bucket bucket = createBucket(group);
-              return new BucketEntry(bucket, Instant.now());
+              return new BucketEntry(bucket, clock.instant());
             })
         .bucket();
   }
@@ -47,7 +49,7 @@ public class BucketStore {
 
   @Scheduled(fixedDelayString = "${app.rate-limit.cleanup-interval-ms:300000}")
   public void cleanup() {
-    Instant expiry = Instant.now().minusSeconds(properties.bucketExpiryMinutes() * 60L);
+    Instant expiry = clock.instant().minusSeconds(properties.bucketExpiryMinutes() * 60L);
     int before = buckets.size();
     buckets.entrySet().removeIf(entry -> entry.getValue().lastAccessed().isBefore(expiry));
     int removed = before - buckets.size();

--- a/frontend/src/features/game/components/GuessInput.tsx
+++ b/frontend/src/features/game/components/GuessInput.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
 import { Button } from "@/shared/ui/Button";
 import { Input } from "@/shared/ui/Input";
 
@@ -30,7 +31,7 @@ export function GuessInput({ onSubmit, isLoading, disabled = false }: GuessInput
     focusInput();
   }
 
-  function handleKeyDown(e: React.KeyboardEvent) {
+  function handleKeyDown(e: KeyboardEvent) {
     if (e.key !== "Enter") {
       return;
     }

--- a/frontend/src/features/ranking/components/RankingPanel.tsx
+++ b/frontend/src/features/ranking/components/RankingPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import type { TransitionEvent } from "react";
 import type { RankingResponse } from "@/shared/api/types";
 import { Card } from "@/shared/ui/Card";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
@@ -69,7 +70,7 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
     return () => clearInterval(id);
   }, [shouldAnimate, isPaused, isHovered, itemHeight]);
 
-  const handleTransitionEnd = (e: React.TransitionEvent<HTMLDivElement>) => {
+  const handleTransitionEnd = (e: TransitionEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) {
       return;
     }


### PR DESCRIPTION
## 관련 이슈

Closes #179

## 변경 사항

### fix: TX 경계 정상화
- LocalAuthService: self-invocation으로 @Transactional 무효화되던 문제 해소. TransactionTemplate으로 DB 쓰기만 TX 적용, authenticate()의 불필요한 readOnly TX 제거
- DailyGameService: AI HTTP 호출/Redis/이벤트가 @Transactional 안에서 DB 커넥션을 점유하던 문제 해소. 4-Phase 구조로 분리 (DB 읽기 -> HTTP -> TX 쓰기 -> 메트릭/Redis/이벤트)

### fix: SwaggerConfigController RoleHierarchy 적용
- SUPERADMIN이 admin Swagger 그룹에 접근하지 못하던 버그 수정 (#163과 동일 패턴)

### refactor: Counter 패턴 통일 (사용처 co-location)
- DailyGameService/DiscordWebhookClient에 @PostConstruct + Counter 필드 등록
- CustomMetricsConfig의 businessCounters() MeterBinder 빈 삭제

### refactor: BucketStore Clock 주입
- Instant.now() 3곳을 clock.instant()로 교체 (프로젝트 Clock 규칙 준수)

### refactor: SHA-256 유틸 추출 + int cast 통일
- HashUtils.sha256Hex() 유틸 추출 (RefreshTokenService/TextNormalizer 중복 해소)
- AiServiceConfig의 (int) cast를 Math.toIntExact()로 통일

### chore: env 샘플 보완
- HINT_* 변수 3개 추가, RATE_LIMIT_READ를 yaml default(120)와 동기화

### style: React.* 네임스페이스 named import 전환
- RankingPanel.tsx, GuessInput.tsx에서 React.* 사용을 named import로 전환

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다