### PR TITLE
chore: 잔존 기술부채 소규모 정리

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/admin/event/AuditLogNotificationListener.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/event/AuditLogNotificationListener.java
@@ -1,5 +1,6 @@
 package com.gakkaweo.backend.admin.event;
 
+import com.gakkaweo.backend.domain.admin.entity.AuditSeverity;
 import com.gakkaweo.backend.infra.notification.NotificationLevel;
 import com.gakkaweo.backend.infra.notification.client.DiscordWebhookClient;
 import com.gakkaweo.backend.infra.notification.config.NotificationProperties;
@@ -26,7 +27,7 @@ public class AuditLogNotificationListener {
       return;
     }
 
-    discordWebhookClient.send(NotificationLevel.HIGH, buildEmbed(event));
+    discordWebhookClient.send(levelFor(event.action().severity()), buildEmbed(event));
   }
 
   private DiscordEmbed buildEmbed(AuditLogEvent event) {
@@ -48,6 +49,13 @@ public class AuditLogNotificationListener {
       return targetType;
     }
     return targetType + ":" + targetId;
+  }
+
+  private static NotificationLevel levelFor(AuditSeverity severity) {
+    return switch (severity) {
+      case CRITICAL -> NotificationLevel.HIGH;
+      case ROUTINE -> NotificationLevel.INFO;
+    };
   }
 
   private String safe(String value) {

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditAction.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditAction.java
@@ -1,35 +1,41 @@
 package com.gakkaweo.backend.domain.admin.entity;
 
 public enum AuditAction {
-  SENTENCE_CREATE(AuditTargetType.SENTENCE),
-  SENTENCE_UPDATE(AuditTargetType.SENTENCE),
-  SENTENCE_DELETE(AuditTargetType.SENTENCE),
-  SENTENCE_SCHEDULE(AuditTargetType.SENTENCE),
-  SENTENCE_UNSCHEDULE(AuditTargetType.SENTENCE),
-  EMERGENCY_REPLACE(AuditTargetType.SENTENCE),
-  CSV_UPLOAD(AuditTargetType.SENTENCE),
+  SENTENCE_CREATE(AuditTargetType.SENTENCE, AuditSeverity.ROUTINE),
+  SENTENCE_UPDATE(AuditTargetType.SENTENCE, AuditSeverity.ROUTINE),
+  SENTENCE_DELETE(AuditTargetType.SENTENCE, AuditSeverity.ROUTINE),
+  SENTENCE_SCHEDULE(AuditTargetType.SENTENCE, AuditSeverity.ROUTINE),
+  SENTENCE_UNSCHEDULE(AuditTargetType.SENTENCE, AuditSeverity.ROUTINE),
+  EMERGENCY_REPLACE(AuditTargetType.SENTENCE, AuditSeverity.CRITICAL),
+  CSV_UPLOAD(AuditTargetType.SENTENCE, AuditSeverity.ROUTINE),
 
-  ROLE_CHANGE(AuditTargetType.MEMBER),
-  USER_BAN(AuditTargetType.MEMBER),
-  USER_UNBAN(AuditTargetType.MEMBER),
-  USER_FORCE_DELETE(AuditTargetType.MEMBER),
-  USER_FORCE_NICKNAME(AuditTargetType.MEMBER),
-  USER_FORCE_PROFILE_DELETE(AuditTargetType.MEMBER),
+  ROLE_CHANGE(AuditTargetType.MEMBER, AuditSeverity.CRITICAL),
+  USER_BAN(AuditTargetType.MEMBER, AuditSeverity.CRITICAL),
+  USER_UNBAN(AuditTargetType.MEMBER, AuditSeverity.CRITICAL),
+  USER_FORCE_DELETE(AuditTargetType.MEMBER, AuditSeverity.CRITICAL),
+  USER_FORCE_NICKNAME(AuditTargetType.MEMBER, AuditSeverity.ROUTINE),
+  USER_FORCE_PROFILE_DELETE(AuditTargetType.MEMBER, AuditSeverity.ROUTINE),
 
-  ANNOUNCEMENT_CREATE(AuditTargetType.ANNOUNCEMENT),
-  ANNOUNCEMENT_UPDATE(AuditTargetType.ANNOUNCEMENT),
-  ANNOUNCEMENT_DELETE(AuditTargetType.ANNOUNCEMENT),
+  ANNOUNCEMENT_CREATE(AuditTargetType.ANNOUNCEMENT, AuditSeverity.ROUTINE),
+  ANNOUNCEMENT_UPDATE(AuditTargetType.ANNOUNCEMENT, AuditSeverity.ROUTINE),
+  ANNOUNCEMENT_DELETE(AuditTargetType.ANNOUNCEMENT, AuditSeverity.ROUTINE),
 
-  RANKING_CACHE_RESET(AuditTargetType.SYSTEM),
-  RATE_LIMIT_RESET(AuditTargetType.SYSTEM);
+  RANKING_CACHE_RESET(AuditTargetType.SYSTEM, AuditSeverity.CRITICAL),
+  RATE_LIMIT_RESET(AuditTargetType.SYSTEM, AuditSeverity.CRITICAL);
 
   private final AuditTargetType targetType;
+  private final AuditSeverity severity;
 
-  AuditAction(AuditTargetType targetType) {
+  AuditAction(AuditTargetType targetType, AuditSeverity severity) {
     this.targetType = targetType;
+    this.severity = severity;
   }
 
   public AuditTargetType targetType() {
     return targetType;
+  }
+
+  public AuditSeverity severity() {
+    return severity;
   }
 }

--- a/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditSeverity.java
+++ b/backend/src/main/java/com/gakkaweo/backend/domain/admin/entity/AuditSeverity.java
@@ -1,0 +1,6 @@
+package com.gakkaweo.backend.domain.admin.entity;
+
+public enum AuditSeverity {
+  CRITICAL,
+  ROUTINE,
+}

--- a/backend/src/main/java/com/gakkaweo/backend/infra/monitoring/CustomMetricsConfig.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/monitoring/CustomMetricsConfig.java
@@ -7,11 +7,23 @@ import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
 
 @Configuration
+@RequiredArgsConstructor
 public class CustomMetricsConfig {
+
+  private final DailySentenceRepository dailySentenceRepository;
+  private final AtomicLong unusedSentenceCount = new AtomicLong();
+
+  @Scheduled(fixedRate = 300_000)
+  void refreshUnusedSentenceCount() {
+    unusedSentenceCount.set(dailySentenceRepository.countUnusedActive());
+  }
 
   @Bean
   TimedAspect timedAspect(MeterRegistry registry) {
@@ -36,10 +48,9 @@ public class CustomMetricsConfig {
   }
 
   @Bean
-  MeterBinder unusedSentencesGauge(DailySentenceRepository dailySentenceRepository) {
+  MeterBinder unusedSentencesGauge() {
     return registry ->
-        Gauge.builder(
-                "game.sentences.unused", dailySentenceRepository, repo -> repo.countUnusedActive())
+        Gauge.builder("game.sentences.unused", unusedSentenceCount, AtomicLong::doubleValue)
             .description("Unused active sentences remaining")
             .register(registry);
   }

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AuditLogNotificationListenerTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AuditLogNotificationListenerTest.java
@@ -35,7 +35,7 @@ class AuditLogNotificationListenerTest {
   }
 
   @Test
-  @DisplayName("enabled=true - 모든 감사 액션을 HIGH level로 Discord 전송 + timestamp 포함")
+  @DisplayName("enabled=true - 보안/파괴적 액션은 HIGH level로 Discord 전송 + timestamp 포함")
   void 활성화_전송() {
     DiscordWebhookClient client = mock(DiscordWebhookClient.class);
     AuditLogNotificationListener listener = new AuditLogNotificationListener(client, props(true));
@@ -64,14 +64,14 @@ class AuditLogNotificationListenerTest {
   }
 
   @Test
-  @DisplayName("enabled=true - 사용자 강제 액션 외의 관리자 액션도 그대로 전송")
-  void 문장등록도_전송() {
+  @DisplayName("enabled=true - 루틴 관리 액션은 INFO level로 전송")
+  void 루틴_액션_INFO() {
     DiscordWebhookClient client = mock(DiscordWebhookClient.class);
     AuditLogNotificationListener listener = new AuditLogNotificationListener(client, props(true));
 
     listener.onAuditLog(event(AuditAction.SENTENCE_CREATE, "문장 등록"));
 
-    verify(client).send(eq(NotificationLevel.HIGH), any(DiscordEmbed.class));
+    verify(client).send(eq(NotificationLevel.INFO), any(DiscordEmbed.class));
   }
 
   @Test

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,8 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       TZ: UTC
     command: postgres -c timezone=UTC
+    ports:
+      - "127.0.0.1:${DB_PORT}:5432"
     networks:
       - internal
     logging: *logging
@@ -37,6 +39,8 @@ services:
       --maxmemory 256mb
       --maxmemory-policy volatile-lru
       --requirepass ${REDIS_PASSWORD}
+    ports:
+      - "127.0.0.1:${REDIS_PORT}:6379"
     networks:
       - internal
     logging: *logging


### PR DESCRIPTION
## 관련 이슈

Closes #181

## 변경 사항

### 1. AuditLog Discord 알림 우선순위 분기 (refactor)
- `AuditSeverity`(CRITICAL/ROUTINE) 도메인 enum 신설
- `AuditAction`에 `severity` 필드 추가하여 위험도 판단을 도메인에 귀속
- `AuditLogNotificationListener`는 severity -> NotificationLevel 2분기 변환만 수행
- 보안/파괴적 액션(USER_BAN 등 7개) = CRITICAL -> HIGH(멘션), 루틴 액션(SENTENCE_CREATE 등 11개) = ROUTINE -> INFO(멘션 없음)

### 2. prod compose DB/Redis localhost 바인딩 (chore)
- `docker-compose.prod.yml`에 PostgreSQL/Redis `127.0.0.1` 포트 바인딩 추가
- SSH 터널링으로 DB/Redis 직접 접속 지원 (backend 서비스와 동일 패턴)

### 3. unused sentences Gauge 스케줄러 캐싱 (perf)
- `game.sentences.unused` Gauge가 Prometheus 스크래핑(15초)마다 COUNT 쿼리 실행하던 것을 AtomicLong + @Scheduled(5분) 캐싱으로 전환
- 메트릭 변경 빈도(일 1회)에 비해 충분히 빈번한 갱신 주기

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다