### PR TITLE
docs: 설계 문서 최신 코드베이스 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ AI 임베딩 유사도 판별 기반 데일리 웹 게임입니다. 세멘틀(Se
 | **Backend**      | Spring Boot 3.5, Java 21, Spring Security, Spring Data JPA, Flyway, Bucket4j, Resilience4j                    |
 | **AI Service**   | FastAPI, Python 3.14, sentence-transformers ([jhgan/ko-sbert-sts](https://huggingface.co/jhgan/ko-sbert-sts)) |
 | **Database**     | PostgreSQL 16, Redis 7                                                                                        |
-| **Infra**        | Docker Compose, Nginx (reverse proxy), Cloudflare (Full Strict SSL)                                           |
+| **Infra**        | Docker Compose, Nginx (reverse proxy), Cloudflare (Full Strict SSL), Prometheus, Grafana                      |
 | **Deployment**   | Self-hosted Ubuntu server (Docker-based), GitHub Container Registry, SSH/SCP deployment scripts               |
 | **CI/CD**        | GitHub Actions                                                                                                |
 | **Code Quality** | ESLint + Prettier (FE), Spotless + Google Java Format (BE), Ruff (AI), Husky + lint-staged                    |
@@ -125,6 +125,7 @@ gakkaweo/
 │       │   ├── game/            #   GameSession, DailySentence, GuessHistory
 │       │   └── member/          #   Member, SocialAccount, LocalAccount
 │       ├── game/                # 게임 로직
+│       ├── infra/               # 외부 의존성 - AI 클라이언트, 알림, 모니터링
 │       ├── ranking/             # 랭킹 (Redis Sorted Set)
 │       └── ratelimit/           # Rate Limiting (Bucket4j)
 │
@@ -140,10 +141,13 @@ gakkaweo/
 │
 ├── docs-site/                   # Swagger UI 정적 사이트 (GitHub Pages)
 │
+├── infra/                       # Prometheus, Grafana 설정
+│
 ├── docs/                        # 프로젝트 문서
 │   ├── design-system.md         # UI/UX 디자인 시스템
 │   ├── branch-strategy.md       # 브랜치 전략
 │   ├── commit-convention.md     # 커밋 컨벤션
+│   ├── performance/             # DB 성능 분석
 │   └── decisions/               # 기술 의사결정
 │       ├── infra.md             #   인프라
 │       ├── backend.md           #   백엔드
@@ -221,12 +225,12 @@ pnpm dev
 
 ## 문서
 
-| 문서                                     | 설명                                           |
-| ---------------------------------------- | ---------------------------------------------- |
+| 문서                                                       | 설명                                          |
+| ---------------------------------------------------------- | --------------------------------------------- |
 | [API 문서 (Swagger)](https://api.r4b2.xyz/swagger-ui.html) | 런타임 API 문서 (public, admin은 로그인 필요) |
-| [디자인 시스템](docs/design-system.md)   | Neo-Brutalism UI 규칙, 컴포넌트 스타일 가이드  |
-| [브랜치 전략](docs/branch-strategy.md)   | main/dev 기반 브랜치 워크플로우                |
-| [커밋 컨벤션](docs/commit-convention.md) | Conventional Commits 규칙                      |
+| [디자인 시스템](docs/design-system.md)                     | Neo-Brutalism UI 규칙, 컴포넌트 스타일 가이드 |
+| [브랜치 전략](docs/branch-strategy.md)                     | main/dev 기반 브랜치 워크플로우               |
+| [커밋 컨벤션](docs/commit-convention.md)                   | Conventional Commits 규칙                     |
 
 ### 기술 의사결정
 
@@ -245,4 +249,4 @@ pnpm dev
 
 ---
 
-_마지막 업데이트: 2026-04-28_
+_마지막 업데이트: 2026-05-12_

--- a/docs/decisions/backend.md
+++ b/docs/decisions/backend.md
@@ -106,22 +106,22 @@ Family 기반 Refresh Token Rotation을 구현했다.
 
 ### 가드 3층
 
-| 층 | 위치 | 거부 코드 |
-| --- | --- | --- |
-| Path matcher | `SecurityConfig` (`/admin/**` = ADMIN, 위험 액션 = SUPERADMIN) | `ACCESS_DENIED` |
-| 대상 보호 | `AdminUserService.requireSufficientRoleOver` | `INSUFFICIENT_ROLE` |
-| 부여 정책 | `AdminUserService.requireRoleAssignmentAllowed` | `INSUFFICIENT_ROLE` |
+| 층           | 위치                                                           | 거부 코드           |
+| ------------ | -------------------------------------------------------------- | ------------------- |
+| Path matcher | `SecurityConfig` (`/admin/**` = ADMIN, 위험 액션 = SUPERADMIN) | `ACCESS_DENIED`     |
+| 대상 보호    | `AdminUserService.requireSufficientRoleOver`                   | `INSUFFICIENT_ROLE` |
+| 부여 정책    | `AdminUserService.requireRoleAssignmentAllowed`                | `INSUFFICIENT_ROLE` |
 
 > 거부 사유가 다르므로 응답 코드를 분리해 클라이언트가 구분할 수 있게 했다.
 
 ### 액션별 매트릭스
 
-| 액션 | Path | 대상 보호 | 부여 정책 |
-| --- | --- | --- | --- |
-| 역할 변경 | `ADMIN` | ✓ | ✓ (SUPERADMIN-only) |
-| 차단/해제, 닉네임 강제, 프로필 강제 삭제 | `ADMIN` | ✓ | — |
-| 강제 탈퇴 | `SUPERADMIN` | ✓ | — |
-| 긴급 교체, 랭킹 캐시 리셋, Rate Limit 초기화 | `SUPERADMIN` | — | — |
+| 액션                                         | Path         | 대상 보호 | 부여 정책           |
+| -------------------------------------------- | ------------ | --------- | ------------------- |
+| 역할 변경                                    | `ADMIN`      | ✓         | ✓ (SUPERADMIN-only) |
+| 차단/해제, 닉네임 강제, 프로필 강제 삭제     | `ADMIN`      | ✓         | —                   |
+| 강제 탈퇴                                    | `SUPERADMIN` | ✓         | —                   |
+| 긴급 교체, 랭킹 캐시 리셋, Rate Limit 초기화 | `SUPERADMIN` | —         | —                   |
 
 `ADMIN`은 가역적이고 단일 사용자에 한정된 액션, `SUPERADMIN`은 비가역(강제 탈퇴, 긴급 교체, 캐시 리셋), 시스템 광역(Rate Limit), 권한 부여 메타-액션(역할 변경)을 수행한다.
 
@@ -200,11 +200,11 @@ HALF_OPEN → 일정 시간 후 재시도
 
 운영시 중요 이벤트를 Discord 웹훅을 통해 알리게끔 설계했다.
 
-| 출처                         | 레벨   | 호출 방식                               | 멘션      |
-| ---------------------------- | ------ | --------------------------------------- | --------- |
-| 자정 스케줄러 결과           | `INFO` | `DailySentenceScheduler.notifyDiscord`  | 없음      |
-| 어드민 감사 로그             | `HIGH` | `AuditLogNotificationListener` (이벤트) | Role 멘션 |
-| `GlobalExceptionHandler` 500 | `HIGH` | `ServerErrorNotifier.notify`            | Role 멘션 |
+| 출처                         | 레벨          | 호출 방식                               | 멘션       |
+| ---------------------------- | ------------- | --------------------------------------- | ---------- |
+| 자정 스케줄러 결과           | `INFO`        | `DailySentenceScheduler.notifyDiscord`  | 없음       |
+| 어드민 감사 로그             | severity 기반 | `AuditLogNotificationListener` (이벤트) | CRITICAL만 |
+| `GlobalExceptionHandler` 500 | `HIGH`        | `ServerErrorNotifier.notify`            | Role 멘션  |
 
 ### 레벨 체계
 
@@ -218,6 +218,17 @@ HALF_OPEN → 일정 시간 후 재시도
 `mentionRoleId` 미설정 시 HIGH도 멘션 없이 전송을 하게 해두었다.
 
 `CRITICAL` (`@everyone`) 레벨은 설계 초기에 검토했으나 **현재 @everyone 멘션을 날릴만한 적절한 이벤트가 없어서 YAGNI원칙에 의거하여 보류.** 실사용 시나리오 (DB 연결 불가, Circuit breaker OPEN 등) 확정 시 enum 값 추가 + switch 분기 작업으로 도입 가능하다.
+
+### AuditSeverity
+
+감사 로그의 알림 레벨은 `AuditAction`마다 고정된 `AuditSeverity`로 결정한다. 기존에는 감사 로그 알림이 모두 `HIGH`(멘션 포함)였지만, 문장 등록이나 닉네임 강제 변경 같은 일상 운영 액션까지 멘션이 오면 알림 피로가 심해지기 때문에 2단계로 분리했다.
+
+| Severity   | NotificationLevel | 멘션      | 해당 액션                                                                     |
+| ---------- | ----------------- | --------- | ----------------------------------------------------------------------------- |
+| `CRITICAL` | `HIGH`            | Role 멘션 | 긴급 교체, 역할 변경, 차단/해제, 강제 탈퇴, 랭킹 캐시 리셋, Rate Limit 초기화 |
+| `ROUTINE`  | `INFO`            | 없음      | 문장 CRUD, CSV 업로드, 닉네임 강제, 프로필 강제 삭제, 공지 CRUD               |
+
+`AuditAction` enum이 severity를 필드로 갖고, `AuditLogNotificationListener`에서 severity에 따라 `NotificationLevel`을 결정한다.
 
 ### 감사 로그 알림: 이벤트 기반 (AFTER_COMMIT)
 
@@ -270,9 +281,37 @@ HTTP I/O가 호출 스레드를 블로킹하지 않도록 분리했다.
 
 > 실제로 이전의 개발 경험중에서 UTC와 KST 혼용으로 여러 버그를 경험한 적이 많다.
 
+### JPA Auditing
+
+엔티티 시간 필드(`createdAt`, `updatedAt`)를 Spring Data JPA Auditing으로 자동 관리한다. `@PrePersist`에서 `Instant.now()`를 직접 호출하면 테스트에서 시간을 제어할 수 없으므로, `Clock` 빈을 주입하는 구조를 택했다.
+
+```java
+@Configuration
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
+public class AuditConfig {
+  private final Clock clock;
+
+  @Bean
+  public DateTimeProvider auditingDateTimeProvider() {
+    return () -> Optional.of(clock.instant());
+  }
+}
+```
+
+테스트에서는 `TestClock`을 주입해 시간을 고정하거나 원하는 시점으로 이동시킬 수 있다.
+
+2단계 상속 구조로 엔티티별 필요에 맞게 선택한다.
+
+| 기반 클래스                                    | 필드                         | 사용 엔티티                          |
+| ---------------------------------------------- | ---------------------------- | ------------------------------------ |
+| `BaseTimeEntity`                               | `createdAt` (불변)           | DailySentence, GameSession 외 대부분 |
+| `BaseAuditableEntity` (extends BaseTimeEntity) | + `updatedAt` (수정 시 갱신) | Member, GameSession                  |
+
+`SocialAccount`는 예외로 `connectedAt`이라는 비즈니스 의미의 시간 필드를 갖는다. Auditing이 아닌 `@Column` + `@PrePersist`에서 직접 설정하는 방식을 쓴다.
+
 ### Flyway 마이그레이션
 
-V1~V13까지 적용. 기존 마이그레이션은 절대 수정하지 않고, 새 마이그레이션을 추가한다.
+V1~V17까지 적용. 기존 마이그레이션은 절대 수정하지 않고, 새 마이그레이션을 추가한다.
 
 > 마이그레이션 파일은 `V{timestamp}__{description}.sql` 형식으로 작성한다. 예: `V20260407_01__add_user_email.sql`
 
@@ -325,4 +364,4 @@ Spring Security role 기반으로 admin 그룹 접근을 제어한다.
 
 ---
 
-_마지막 업데이트: 2026-04-22_
+_마지막 업데이트: 2026-05-12_

--- a/docs/decisions/backend.md
+++ b/docs/decisions/backend.md
@@ -288,6 +288,7 @@ HTTP I/O가 호출 스레드를 블로킹하지 않도록 분리했다.
 ```java
 @Configuration
 @EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
+@RequiredArgsConstructor
 public class AuditConfig {
   private final Clock clock;
 

--- a/docs/decisions/infra.md
+++ b/docs/decisions/infra.md
@@ -128,6 +128,77 @@ AI Service (/health)    ──┘
 
 Backend는 3개 서비스가 모두 healthy일 때만 시작된다. AI Service는 모델 로딩에 시간이 걸리므로 `start_period: 120s`를 설정했다.
 
+## 모니터링 (Prometheus + Grafana)
+
+홈서버 한 대에서 모든 서비스를 돌리다 보니, CPU/메모리/디스크 상태와 애플리케이션 내부 지표를 한 눈에 보고 싶었다. Spring Boot Actuator + Micrometer가 이미 메트릭 수집 인프라를 제공하므로, 여기에 Prometheus와 Grafana를 얹는 방식으로 구성했다.
+
+### Actuator 포트 분리
+
+Actuator 엔드포인트를 애플리케이션 포트(8080)가 아닌 별도 포트(9090)로 분리했다.
+
+```yaml
+management:
+  server:
+    port: ${MANAGEMENT_PORT:9090}
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+```
+
+이렇게 하면 Nginx가 프록시하는 8080 포트에는 Actuator가 노출되지 않는다. 프로덕션에서는 Docker 네트워크 내부(internal)에서만 Prometheus가 9090에 접근하고, 외부에서는 접근할 수 없다.
+
+### 커스텀 메트릭
+
+Micrometer 기본 JVM/HTTP 메트릭 외에 도메인 메트릭을 추가했다.
+
+| 이름                               | 타입    | 태그                     | 설명                                  |
+| ---------------------------------- | ------- | ------------------------ | ------------------------------------- |
+| `game.guesses.total`               | Counter | `result`=success/failure | 추측 시도 (정답/오답)                 |
+| `game.clears.total`                | Counter | -                        | 클리어 횟수                           |
+| `game.sentences.unused`            | Gauge   | -                        | 미사용 문장 잔량 (5분 주기 갱신)      |
+| `ranking.update`                   | Counter | -                        | 랭킹 업데이트 횟수                    |
+| `auth.login.total`                 | Counter | `provider`, `result`     | 로그인 시도 (프로바이더별, 성공/실패) |
+| `auth.register.total`              | Counter | `provider`               | 회원가입                              |
+| `auth.withdraw.total`              | Counter | -                        | 탈퇴                                  |
+| `discord.webhook.total`            | Counter | `result`=success/failure | Discord 웹훅 전송                     |
+| `ratelimit.rejected`               | Counter | `group`                  | Rate Limit 거부 횟수                  |
+| `ratelimit.buckets.active`         | Gauge   | -                        | 활성 버킷 수                          |
+| `sse.connections`                  | Gauge   | -                        | 활성 SSE 연결 수                      |
+| `scheduler.midnight.duration`      | Timer   | -                        | 자정 스케줄러 실행 시간               |
+| `ranking.cache.rebuild.duration`   | Timer   | -                        | 랭킹 캐시 리빌드 시간                 |
+| `scheduler.redis_cleanup.duration` | Timer   | -                        | Redis 정리 스케줄러 실행 시간         |
+
+Gauge는 `CustomMetricsConfig`에서 `MeterBinder`로 등록하고, Counter는 각 서비스에서 생성자 주입 시 빌더로 등록한다. `@Timed`는 `TimedAspect` 빈으로 활성화했다. 인증 메트릭은 `AuthMetrics` 클래스로 분리해서 프로바이더별 카운터를 일괄 초기화하는 패턴을 사용했다.
+
+### Grafana 프로비저닝
+
+Grafana 대시보드와 데이터소스를 코드로 관리한다. 컨테이너가 새로 생성되어도 수동 설정 없이 동일한 대시보드가 자동으로 로드된다.
+
+```
+infra/
+├── grafana/
+│   ├── dashboards/
+│   │   └── gakkaweo.json         # 대시보드 정의
+│   └── provisioning/
+│       ├── dashboards/
+│       │   └── dashboard.yml     # 대시보드 프로비저닝
+│       └── datasources/
+│           └── prometheus.yml    # 데이터소스 프로비저닝
+└── prometheus/
+    ├── prometheus.dev.yml        # 로컬 환경
+    └── prometheus.prod.yml       # 프로덕션 환경
+```
+
+### 프로덕션 접근 제어
+
+Prometheus와 Grafana 모두 외부에 직접 노출하지 않는다.
+
+- Prometheus: Docker internal 네트워크에만 연결, 포트 바인딩 없음
+- Grafana: `127.0.0.1:3001:3000`으로 localhost만 바인딩
+
+대시보드를 볼 때는 SSH 터널(`ssh -L 3001:localhost:3001`)로 접근한다. Cloudflare 프록시를 통하지 않으므로 인증 우회나 외부 노출 걱정이 없다.
+
 ## CI/CD (GitHub Actions)
 
 ### CI — PR to dev
@@ -174,4 +245,4 @@ backend/.env       # 루트 .env의 심볼릭 링크
 
 ---
 
-_마지막 업데이트: 2026-04-07_
+_마지막 업데이트: 2026-05-12_


### PR DESCRIPTION
## 관련 이슈

Closes #184

## 변경 사항

- README.md: 기술 스택에 Prometheus/Grafana 추가, 프로젝트 구조 트리에 infra/, performance/ 반영
- docs/decisions/infra.md: 모니터링 섹션 신설 (Actuator 포트 분리, 커스텀 메트릭 14종, Grafana 프로비저닝, 프로덕션 접근 제어)
- docs/decisions/backend.md: JPA Auditing 2단계 상속/Clock 주입, AuditSeverity 알림 분리, Flyway V1~V17 갱신

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다