### PR TITLE
refactor: FE 품질 소규모 번들 (환경변수 중앙화 + Dialog 통합 + ErrorBoundary)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -13,7 +13,7 @@
 7. [레이아웃](#7-layout-레이아웃)
 8. [페이지 구성](#8-페이지-구성)
 9. [로그인 프로바이더 색상](#9-로그인-프로바이더-색상)
-10. [컴포넌트 규칙](#10-컴포넌트-규칙) — 버튼, 입력창, 카드, 푸터, 랭킹, 모달, 프로필, 추측 피드백, 힌트, 어드민
+10. [컴포넌트 규칙](#10-컴포넌트-규칙) — 버튼, 입력창, 카드, 다이얼로그, 푸터, 랭킹, 모달, 프로필, 추측 피드백, 힌트, 어드민
 
 ---
 
@@ -213,6 +213,36 @@ border-4 border-black dark:border-white rounded-none shadow-brutal
 dark:shadow-brutal-dark bg-white dark:bg-gray-900 p-6
 ```
 
+### 다이얼로그
+
+공용 컴포넌트 `shared/ui/Dialog.tsx`. 모든 다이얼로그/모달은 이 컴포넌트를 사용한다.
+
+```
+백드롭: fixed inset-0 z-50 bg-black/40
+패널: border-4 border-black dark:border-white bg-white dark:bg-gray-900
+      shadow-brutal max-h-[85vh] flex flex-col
+헤더: border-b-4 px-6 py-5 (제목 + 닫기 X 버튼)
+콘텐츠: px-6 py-5 overflow-y-auto flex-1
+푸터: border-t-4 px-6 py-4 flex gap-3 (footer prop이 있을 때만)
+```
+
+**Props**:
+
+| prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `isOpen` | `boolean` | `true` | `false`이면 null 반환. 부모에서 조건부 렌더링 시 생략 가능 |
+| `onClose` | `() => void` | 필수 | Escape/click-outside/X 버튼에 연결 |
+| `title` | `string` | 필수 | 헤더에 표시. `aria-labelledby` 자동 연결 (`useId()`) |
+| `children` | `ReactNode` | 필수 | 콘텐츠 영역 |
+| `footer` | `ReactNode` | - | 없으면 푸터 미렌더. 버튼 조합 전달 |
+| `maxWidth` | `string` | `"max-w-sm"` | 패널 최대 너비 (`max-w-md`, `max-w-lg` 등) |
+| `disableClose` | `boolean` | `false` | 로딩 중 Escape/click-outside/X 차단 |
+| `className` | `string` | `""` | 패널에 추가 클래스 |
+
+**기능**: Escape 키, click-outside, body scroll lock (모듈 레벨 카운터로 중첩 지원), `role="dialog" aria-modal="true" aria-labelledby`
+
+**닫기(X) 버튼**: `border-4 shadow-brutal-sm` sm 상호작용. `disableClose` 시 `opacity-50 cursor-not-allowed`
+
 ### 푸터
 
 ```
@@ -236,6 +266,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 
 ### 플레이 방법 모달
 
+- 공용 `Dialog` 컴포넌트 사용 (`maxWidth="max-w-lg"`, footer 없음)
 - 최초 방문 시 자동 표시 (localStorage `help_modal_shown`). 닫으면 재표시 안 함
 - "플레이 방법" 버튼으로 언제든 재열람 (`border-2 bg-yellow-300 text-xs font-black`)
 - 섹션 간 `border-t-2 border-gray-200 dark:border-gray-800` 구분선
@@ -246,6 +277,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 
 ### 설정 모달
 
+- 공용 `Dialog` 컴포넌트 사용 (footer 없음). 닫을 때 재생 중 사운드 정지
 - **테마**: 라이트/다크/시스템 3버튼 토글. 활성 = `bg-black text-white`
 - **사운드 볼륨**: `input[type=range]` 슬라이더 (`accent-yellow-400`). localStorage `sound_volume` (기본 0.7, 범위 0~1). 상수: `shared/config/sound.ts`. 0이면 🔇, 그 외 🔊
 - **볼륨 아이콘 mute 토글**: 🔊/🔇 아이콘은 `border-2 shadow-brutal-sm-hover w-7 h-7` 버튼. 클릭 시 mute 토글, 이전 볼륨은 localStorage `sound_last_volume`에 보존(0 초과 값만 저장). 접근성: `aria-label` 동적 전환 + `aria-pressed`
@@ -296,7 +328,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **위젯 카드**: `border-4 shadow-brutal-sm`. 라벨 `text-xs uppercase tracking-wide`. 수치 `text-3xl font-black tabular-nums`
 - **상태 배지**: `px-2 py-0.5 text-xs font-black border-2 border-black dark:border-white`. ACTIVE=green-400, USED=blue-300, DISABLED=gray-300, SUPERADMIN=purple-400, ADMIN=red-400, USER=blue-300, 차단=gray-800
 - **SUPERADMIN 전용 액션 가시성**: 강제 탈퇴, 긴급 교체, 랭킹 캐시 리셋, Rate Limit 초기화, 역할 변경은 `useAuthStore().user?.role === "SUPERADMIN"` 검사로 disabled 분기. 비-SUPERADMIN ADMIN에게는 안내 문구(`text-amber-600 dark:text-amber-400`) 노출
-- **다이얼로그**: `border-4 shadow-brutal max-w-lg`. 헤더 `border-b-4 px-6 py-5`. 푸터 `border-t-4`. `role="dialog" aria-modal="true"` + Escape 닫기 필수
+- **다이얼로그**: 공용 `Dialog` 컴포넌트 사용. `maxWidth`는 `max-w-md`~`max-w-lg`. `disableClose`로 로딩 중 보호
 - **텍스트 링크 액션**: 테이블 행 내 액션은 `text-indigo-600 dark:text-indigo-400 font-black text-xs hover:underline`
 - **Pagination**: `Button sm secondary` 이전/다음 + `tabular-nums` 페이지 표시
 - **공지 유형 라벨**: 안내(blue-300), 점검(orange-300), 경고(red-500). select에서도 한글 라벨 사용. SoT는 `shared/config/announcement.ts`

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
+import { ErrorBoundary } from "@/app/ErrorBoundary";
 import { router } from "@/app/router";
 import { queryClient } from "@/shared/api/queryClient";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
@@ -32,8 +33,10 @@ export function App() {
   }, [addToast]);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/app/ErrorBoundary.tsx
+++ b/frontend/src/app/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, type ReactNode } from "react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
 import { ErrorFallback } from "@/shared/ui/ErrorFallback";
 
 interface Props {
@@ -17,7 +17,7 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+  componentDidCatch(error: unknown, info: ErrorInfo) {
     console.error("ErrorBoundary caught:", error, info.componentStack);
   }
 

--- a/frontend/src/app/ErrorBoundary.tsx
+++ b/frontend/src/app/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import { Component, type ReactNode } from "react";
+import { ErrorFallback } from "@/shared/ui/ErrorFallback";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: unknown;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: unknown): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    console.error("ErrorBoundary caught:", error, info.componentStack);
+  }
+
+  resetError = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorFallback error={this.state.error} resetError={this.resetError} />;
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/app/layout/SettingsModal.tsx
+++ b/frontend/src/app/layout/SettingsModal.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { Dialog } from "@/shared/ui/Dialog";
 import { useThemeStore } from "@/shared/stores/useThemeStore";
 import {
   SOUND_VOLUME_KEY,
@@ -31,7 +32,6 @@ const SOUND_TESTS: { label: string; type: SoundType; color: string }[] = [
 
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const { theme, setTheme } = useThemeStore();
-  const modalRef = useRef<HTMLDivElement>(null);
   const [volume, setVolume] = useState(getSoundVolume);
 
   function handleVolumeChange(v: number) {
@@ -63,152 +63,90 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
   useEffect(() => {
     if (!isOpen) {
-      return;
-    }
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isOpen, onClose]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handleClickOutside = (e: MouseEvent) => {
-      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isOpen, onClose]);
-
-  useEffect(() => {
-    if (!isOpen) {
       stopCurrentSound();
     }
   }, [isOpen]);
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="settings-modal-title"
-    >
-      <div
-        ref={modalRef}
-        className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-sm"
-      >
-        <div className="flex items-center justify-between border-b-4 border-black dark:border-white px-6 py-4">
-          <h2 id="settings-modal-title" className="text-xl font-black">
-            설정
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-black dark:text-white px-3 py-1 font-black text-lg transition-all duration-100 shadow-brutal-sm hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]"
-            aria-label="설정 닫기"
-          >
-            ✕
-          </button>
-        </div>
-
-        <div className="px-6 py-5 space-y-5">
-          <div>
-            <h3 className="text-sm font-extrabold uppercase tracking-wider mb-3 text-gray-600 dark:text-gray-400">
-              테마
-            </h3>
-            <div className="flex gap-2">
-              {THEME_OPTIONS.map(({ value, label, icon }) => (
-                <button
-                  type="button"
-                  key={value}
-                  onClick={() => setTheme(value)}
-                  className={[
-                    "flex-1 border-4 border-black dark:border-white px-3 py-2.5 font-bold text-sm transition-all duration-100",
-                    theme === value
-                      ? "bg-black text-white dark:bg-white dark:text-black shadow-none translate-x-0 translate-y-0"
-                      : "bg-white dark:bg-gray-900 text-black dark:text-white shadow-brutal-sm hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]",
-                  ].join(" ")}
-                >
-                  <span className="block text-lg" aria-hidden="true">
-                    {icon}
-                  </span>
-                  <span className="block mt-1">{label}</span>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <h3 className="text-sm font-extrabold uppercase tracking-wider mb-3 text-gray-600 dark:text-gray-400">
-              사운드
-            </h3>
-            <div className="flex items-center gap-3">
+    <Dialog isOpen={isOpen} onClose={onClose} title="설정">
+      <div className="space-y-5">
+        <div>
+          <h3 className="text-sm font-extrabold uppercase tracking-wider mb-3 text-gray-600 dark:text-gray-400">
+            테마
+          </h3>
+          <div className="flex gap-2">
+            {THEME_OPTIONS.map(({ value, label, icon }) => (
               <button
                 type="button"
-                onClick={handleMuteToggle}
-                aria-label={volume === 0 ? "음소거 해제" : "음소거"}
-                aria-pressed={volume === 0}
-                className="border-2 border-black dark:border-white bg-white dark:bg-gray-900 w-7 h-7 shrink-0 flex items-center justify-center text-sm transition-all duration-100 shadow-brutal-sm-hover hover:shadow-none hover:translate-x-[1px] hover:translate-y-[1px] active:shadow-none active:translate-x-[1px] active:translate-y-[1px]"
+                key={value}
+                onClick={() => setTheme(value)}
+                className={[
+                  "flex-1 border-4 border-black dark:border-white px-3 py-2.5 font-bold text-sm transition-all duration-100",
+                  theme === value
+                    ? "bg-black text-white dark:bg-white dark:text-black shadow-none translate-x-0 translate-y-0"
+                    : "bg-white dark:bg-gray-900 text-black dark:text-white shadow-brutal-sm hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]",
+                ].join(" ")}
               >
-                {volume === 0 ? "🔇" : "🔊"}
+                <span className="block text-lg" aria-hidden="true">
+                  {icon}
+                </span>
+                <span className="block mt-1">{label}</span>
               </button>
-              <input
-                type="range"
-                aria-label="사운드 볼륨"
-                min="0"
-                max="1"
-                step="0.1"
-                value={volume}
-                onChange={(e) => handleVolumeChange(parseFloat(e.target.value))}
-                className="flex-1 accent-yellow-400"
-              />
-              <span className="text-sm font-bold tabular-nums w-10 text-right">{Math.round(volume * 100)}%</span>
-            </div>
+            ))}
           </div>
+        </div>
 
-          <div>
-            <h3 className="text-sm font-extrabold uppercase tracking-wider mb-3 text-gray-600 dark:text-gray-400">
-              사운드 테스트
-            </h3>
-            <div className="flex gap-2">
-              {SOUND_TESTS.map(({ label, type, color }) => (
-                <button
-                  type="button"
-                  key={type}
-                  onClick={() => playTestSound(type)}
-                  disabled={volume === 0}
-                  className={[
-                    `border-2 border-black dark:border-white px-3 py-1.5 text-xs font-black transition-all duration-100 ${color} text-black`,
-                    "shadow-brutal-sm hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]",
-                    "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:shadow-brutal-sm disabled:hover:translate-x-0 disabled:hover:translate-y-0 disabled:active:shadow-brutal-sm disabled:active:translate-x-0 disabled:active:translate-y-0",
-                  ].join(" ")}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
+        <div>
+          <h3 className="text-sm font-extrabold uppercase tracking-wider mb-3 text-gray-600 dark:text-gray-400">
+            사운드
+          </h3>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleMuteToggle}
+              aria-label={volume === 0 ? "음소거 해제" : "음소거"}
+              aria-pressed={volume === 0}
+              className="border-2 border-black dark:border-white bg-white dark:bg-gray-900 w-7 h-7 shrink-0 flex items-center justify-center text-sm transition-all duration-100 shadow-brutal-sm-hover hover:shadow-none hover:translate-x-[1px] hover:translate-y-[1px] active:shadow-none active:translate-x-[1px] active:translate-y-[1px]"
+            >
+              {volume === 0 ? "🔇" : "🔊"}
+            </button>
+            <input
+              type="range"
+              aria-label="사운드 볼륨"
+              min="0"
+              max="1"
+              step="0.1"
+              value={volume}
+              onChange={(e) => handleVolumeChange(parseFloat(e.target.value))}
+              className="flex-1 accent-yellow-400"
+            />
+            <span className="text-sm font-bold tabular-nums w-10 text-right">{Math.round(volume * 100)}%</span>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-sm font-extrabold uppercase tracking-wider mb-3 text-gray-600 dark:text-gray-400">
+            사운드 테스트
+          </h3>
+          <div className="flex gap-2">
+            {SOUND_TESTS.map(({ label, type, color }) => (
+              <button
+                type="button"
+                key={type}
+                onClick={() => playTestSound(type)}
+                disabled={volume === 0}
+                className={[
+                  `border-2 border-black dark:border-white px-3 py-1.5 text-xs font-black transition-all duration-100 ${color} text-black`,
+                  "shadow-brutal-sm hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]",
+                  "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:shadow-brutal-sm disabled:hover:translate-x-0 disabled:hover:translate-y-0 disabled:active:shadow-brutal-sm disabled:active:translate-x-0 disabled:active:translate-y-0",
+                ].join(" ")}
+              >
+                {label}
+              </button>
+            ))}
           </div>
         </div>
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, Navigate } from "react-router-dom";
 import { Layout } from "@/app/layout/Layout";
 import { RequireAuth, RequireAdminAuth, RedirectIfAuth } from "@/app/guards";
+import { RouteErrorFallback } from "@/shared/ui/ErrorFallback";
 import { HomePage } from "@/pages/HomePage";
 import { LoginPage } from "@/features/auth/LoginPage";
 import { MyPage } from "@/features/auth/MyPage";
@@ -16,6 +17,7 @@ import { TermsOfServicePage } from "@/pages/TermsOfServicePage";
 export const router = createBrowserRouter([
   {
     element: <Layout />,
+    errorElement: <RouteErrorFallback />,
     children: [
       { index: true, element: <HomePage /> },
       {

--- a/frontend/src/features/admin/components/AnnouncementDialog.tsx
+++ b/frontend/src/features/admin/components/AnnouncementDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/shared/ui/Button";
+import { Dialog } from "@/shared/ui/Dialog";
 import { Input } from "@/shared/ui/Input";
 import { useCreateAnnouncement, useUpdateAnnouncement } from "@/features/admin/hooks/useAdminSystem";
 import { ANNOUNCEMENT_TYPE_LABELS, getAnnouncementTypeColor } from "@/shared/config/announcement";
@@ -33,18 +34,6 @@ export function AnnouncementDialog({ announcement, onClose }: AnnouncementDialog
   const { addToast } = useToastStore();
 
   const isSaving = createMutation.isPending || updateMutation.isPending;
-
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape" && !isSaving) {
-        onClose();
-      }
-    }
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isSaving, onClose]);
 
   function handleSave() {
     if (!title.trim() || !startsAt) {
@@ -89,97 +78,97 @@ export function AnnouncementDialog({ announcement, onClose }: AnnouncementDialog
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
-      <div className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-md">
-        <div className="px-6 py-5 border-b-4 border-black dark:border-white">
-          <h2 className="text-xl font-black">{isEdit ? "공지 수정" : "공지 등록"}</h2>
-        </div>
-
-        <div className="px-6 py-5 space-y-4">
-          <div>
-            <label className="block text-sm font-bold mb-1">제목</label>
-            <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="공지 제목" />
-          </div>
-
-          <div>
-            <label className="block text-sm font-bold mb-1">내용 (선택)</label>
-            <textarea
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              placeholder="공지 내용"
-              rows={3}
-              className="w-full border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-black dark:text-white px-4 py-3 font-medium text-sm focus:outline-none focus:border-indigo-500 dark:focus:border-indigo-400"
-            />
-          </div>
-
-          <div className="flex gap-4 items-end">
-            <div>
-              <label className="block text-sm font-bold mb-1">유형</label>
-              <select
-                value={type}
-                onChange={(e) => setType(e.target.value as "INFO" | "MAINTENANCE" | "WARNING")}
-                className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5 shadow-brutal-sm dark:[color-scheme:dark]"
-              >
-                {Object.entries(ANNOUNCEMENT_TYPE_LABELS).map(([value, label]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div
-              className={`border-4 border-black dark:border-white px-3 py-1 text-xs font-black ${getAnnouncementTypeColor(type)}`}
-            >
-              미리보기
-            </div>
-
-            {isEdit && (
-              <div>
-                <label className="block text-sm font-bold mb-1">활성</label>
-                <label className="flex items-center gap-2 text-sm font-bold cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={active}
-                    onChange={(e) => setActive(e.target.checked)}
-                    className="w-5 h-5 border-2 border-black dark:border-white accent-yellow-400"
-                  />
-                  {active ? "활성" : "비활성"}
-                </label>
-              </div>
-            )}
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-sm font-bold mb-1">시작</label>
-              <input
-                type="datetime-local"
-                value={startsAt}
-                onChange={(e) => setStartsAt(e.target.value)}
-                className="w-full border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold shadow-brutal-sm dark:[color-scheme:dark]"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-bold mb-1">종료 (선택)</label>
-              <input
-                type="datetime-local"
-                value={endsAt}
-                onChange={(e) => setEndsAt(e.target.value)}
-                className="w-full border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold shadow-brutal-sm dark:[color-scheme:dark]"
-              />
-            </div>
-          </div>
-        </div>
-
-        <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white">
+    <Dialog
+      onClose={onClose}
+      title={isEdit ? "공지 수정" : "공지 등록"}
+      maxWidth="max-w-md"
+      disableClose={isSaving}
+      footer={
+        <>
           <Button variant="secondary" size="sm" className="flex-1" onClick={onClose}>
             취소
           </Button>
           <Button size="sm" className="flex-1" onClick={handleSave} isLoading={isSaving}>
             {isEdit ? "수정" : "등록"}
           </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-bold mb-1">제목</label>
+          <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="공지 제목" />
+        </div>
+
+        <div>
+          <label className="block text-sm font-bold mb-1">내용 (선택)</label>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="공지 내용"
+            rows={3}
+            className="w-full border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-black dark:text-white px-4 py-3 font-medium text-sm focus:outline-none focus:border-indigo-500 dark:focus:border-indigo-400"
+          />
+        </div>
+
+        <div className="flex gap-4 items-end">
+          <div>
+            <label className="block text-sm font-bold mb-1">유형</label>
+            <select
+              value={type}
+              onChange={(e) => setType(e.target.value as "INFO" | "MAINTENANCE" | "WARNING")}
+              className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-sm font-bold px-3 py-1.5 shadow-brutal-sm dark:[color-scheme:dark]"
+            >
+              {Object.entries(ANNOUNCEMENT_TYPE_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div
+            className={`border-4 border-black dark:border-white px-3 py-1 text-xs font-black ${getAnnouncementTypeColor(type)}`}
+          >
+            미리보기
+          </div>
+
+          {isEdit && (
+            <div>
+              <label className="block text-sm font-bold mb-1">활성</label>
+              <label className="flex items-center gap-2 text-sm font-bold cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={active}
+                  onChange={(e) => setActive(e.target.checked)}
+                  className="w-5 h-5 border-2 border-black dark:border-white accent-yellow-400"
+                />
+                {active ? "활성" : "비활성"}
+              </label>
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-bold mb-1">시작</label>
+            <input
+              type="datetime-local"
+              value={startsAt}
+              onChange={(e) => setStartsAt(e.target.value)}
+              className="w-full border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold shadow-brutal-sm dark:[color-scheme:dark]"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-bold mb-1">종료 (선택)</label>
+            <input
+              type="datetime-local"
+              value={endsAt}
+              onChange={(e) => setEndsAt(e.target.value)}
+              className="w-full border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold shadow-brutal-sm dark:[color-scheme:dark]"
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/frontend/src/features/admin/components/CsvUploadDialog.tsx
+++ b/frontend/src/features/admin/components/CsvUploadDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Button } from "@/shared/ui/Button";
+import { Dialog } from "@/shared/ui/Dialog";
 import { useUploadCsv } from "@/features/admin/hooks/useAdminSentences";
 import { useToastStore } from "@/shared/stores/useToastStore";
 import { ApiError } from "@/shared/api/client";
@@ -13,18 +14,6 @@ export function CsvUploadDialog({ onClose }: CsvUploadDialogProps) {
   const [file, setFile] = useState<File | null>(null);
   const uploadMutation = useUploadCsv();
   const { addToast } = useToastStore();
-
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape" && !uploadMutation.isPending) {
-        onClose();
-      }
-    }
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [uploadMutation.isPending, onClose]);
 
   function handleUpload() {
     if (!file) {
@@ -40,29 +29,12 @@ export function CsvUploadDialog({ onClose }: CsvUploadDialogProps) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
-      <div className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-sm">
-        <div className="px-6 py-5 border-b-4 border-black dark:border-white">
-          <h2 className="text-xl font-black">CSV 업로드</h2>
-        </div>
-
-        <div className="px-6 py-5 space-y-4">
-          <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">
-            한 줄에 문장 하나씩 작성된 CSV 파일을 업로드하세요.
-          </p>
-
-          <input
-            ref={fileRef}
-            type="file"
-            accept=".csv"
-            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-            className="block w-full text-sm font-bold dark:[color-scheme:dark] file:mr-3 file:border-4 file:border-black file:dark:border-white file:shadow-brutal-sm file:bg-yellow-300 file:text-black file:font-bold file:px-3 file:py-1.5 file:text-sm file:cursor-pointer"
-          />
-
-          {file && <p className="text-sm font-bold">{file.name}</p>}
-        </div>
-
-        <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white">
+    <Dialog
+      onClose={onClose}
+      title="CSV 업로드"
+      disableClose={uploadMutation.isPending}
+      footer={
+        <>
           <Button variant="secondary" size="sm" className="flex-1" onClick={onClose}>
             취소
           </Button>
@@ -75,8 +47,24 @@ export function CsvUploadDialog({ onClose }: CsvUploadDialogProps) {
           >
             업로드
           </Button>
-        </div>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">
+          한 줄에 문장 하나씩 작성된 CSV 파일을 업로드하세요.
+        </p>
+
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".csv"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          className="block w-full text-sm font-bold dark:[color-scheme:dark] file:mr-3 file:border-4 file:border-black file:dark:border-white file:shadow-brutal-sm file:bg-yellow-300 file:text-black file:font-bold file:px-3 file:py-1.5 file:text-sm file:cursor-pointer"
+        />
+
+        {file && <p className="text-sm font-bold">{file.name}</p>}
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/frontend/src/features/admin/components/SentenceDetailDialog.tsx
+++ b/frontend/src/features/admin/components/SentenceDetailDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/shared/ui/Button";
+import { Dialog } from "@/shared/ui/Dialog";
 import { Input } from "@/shared/ui/Input";
 import {
   useCreateSentence,
@@ -36,18 +37,6 @@ export function SentenceDetailDialog({ sentence, onClose }: SentenceDetailDialog
   const isSuperAdmin = useAuthStore((s) => s.user?.role === "SUPERADMIN");
 
   const isSaving = createMutation.isPending || updateMutation.isPending;
-
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape" && !isSaving) {
-        onClose();
-      }
-    }
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isSaving, onClose]);
 
   function handleSave() {
     const trimmed = text.trim();
@@ -141,102 +130,102 @@ export function SentenceDetailDialog({ sentence, onClose }: SentenceDetailDialog
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
-      <div className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-lg">
-        <div className="px-6 py-5 border-b-4 border-black dark:border-white">
-          <h2 className="text-xl font-black">{isEdit ? "문장 편집" : "문장 등록"}</h2>
-        </div>
-
-        <div className="px-6 py-5 space-y-4">
-          <div>
-            <label className="block text-sm font-bold mb-1">문장</label>
-            <Input value={text} onChange={(e) => setText(e.target.value)} placeholder="문장을 입력하세요" />
-          </div>
-
-          <div className="flex gap-2">
-            <Button size="sm" variant="secondary" onClick={handleDuplicateCheck} isLoading={duplicateCheck.isPending}>
-              중복 검사
-            </Button>
-          </div>
-
-          {isEdit && (
-            <>
-              <div className="border-t-2 border-black/20 dark:border-white/20 pt-4">
-                <label className="block text-sm font-bold mb-1">출제 예약</label>
-                <div className="flex gap-2 items-center">
-                  <input
-                    type="date"
-                    value={scheduleDate}
-                    onChange={(e) => setScheduleDate(e.target.value)}
-                    className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold shadow-brutal-sm dark:[color-scheme:dark]"
-                  />
-                  <Button size="sm" onClick={handleSchedule} isLoading={scheduleMutation.isPending}>
-                    예약
-                  </Button>
-                  {sentence.scheduledAt && (
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={handleUnschedule}
-                      isLoading={unscheduleMutation.isPending}
-                    >
-                      해제
-                    </Button>
-                  )}
-                </div>
-              </div>
-
-              {stats && (
-                <div className="border-t-2 border-black/20 dark:border-white/20 pt-4">
-                  <p className="text-sm font-bold mb-2">통계</p>
-                  <div className="grid grid-cols-3 gap-3 text-center text-sm">
-                    <div className="border-2 border-black dark:border-white p-2">
-                      <p className="text-xs text-gray-500 dark:text-gray-400 font-bold">세션</p>
-                      <p className="font-black tabular-nums">{stats.totalSessions}</p>
-                    </div>
-                    <div className="border-2 border-black dark:border-white p-2">
-                      <p className="text-xs text-gray-500 dark:text-gray-400 font-bold">클리어율</p>
-                      <p className="font-black tabular-nums">{stats.clearRate.toFixed(1)}%</p>
-                    </div>
-                    <div className="border-2 border-black dark:border-white p-2">
-                      <p className="text-xs text-gray-500 dark:text-gray-400 font-bold">평균 시도</p>
-                      <p className="font-black tabular-nums">{stats.avgAttemptCount.toFixed(1)}</p>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {!sentence.usedAt && sentence.status === "ACTIVE" && (
-                <div className="border-t-2 border-black/20 dark:border-white/20 pt-4 space-y-2">
-                  <Button
-                    size="sm"
-                    variant="danger"
-                    onClick={handleEmergencyReplace}
-                    disabled={!isSuperAdmin}
-                    isLoading={emergencyReplace.isPending}
-                  >
-                    긴급 교체 (이 문장으로)
-                  </Button>
-                  {!isSuperAdmin && (
-                    <p className="text-xs font-bold text-amber-600 dark:text-amber-400">
-                      SUPERADMIN만 긴급 교체를 수행할 수 있습니다.
-                    </p>
-                  )}
-                </div>
-              )}
-            </>
-          )}
-        </div>
-
-        <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white">
+    <Dialog
+      onClose={onClose}
+      title={isEdit ? "문장 편집" : "문장 등록"}
+      maxWidth="max-w-lg"
+      disableClose={isSaving}
+      footer={
+        <>
           <Button variant="secondary" size="sm" className="flex-1" onClick={onClose}>
             닫기
           </Button>
           <Button size="sm" className="flex-1" onClick={handleSave} isLoading={isSaving}>
             {isEdit ? "수정" : "등록"}
           </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-bold mb-1">문장</label>
+          <Input value={text} onChange={(e) => setText(e.target.value)} placeholder="문장을 입력하세요" />
         </div>
+
+        <div className="flex gap-2">
+          <Button size="sm" variant="secondary" onClick={handleDuplicateCheck} isLoading={duplicateCheck.isPending}>
+            중복 검사
+          </Button>
+        </div>
+
+        {isEdit && (
+          <>
+            <div className="border-t-2 border-black/20 dark:border-white/20 pt-4">
+              <label className="block text-sm font-bold mb-1">출제 예약</label>
+              <div className="flex gap-2 items-center">
+                <input
+                  type="date"
+                  value={scheduleDate}
+                  onChange={(e) => setScheduleDate(e.target.value)}
+                  className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 px-3 py-1.5 text-sm font-bold shadow-brutal-sm dark:[color-scheme:dark]"
+                />
+                <Button size="sm" onClick={handleSchedule} isLoading={scheduleMutation.isPending}>
+                  예약
+                </Button>
+                {sentence.scheduledAt && (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={handleUnschedule}
+                    isLoading={unscheduleMutation.isPending}
+                  >
+                    해제
+                  </Button>
+                )}
+              </div>
+            </div>
+
+            {stats && (
+              <div className="border-t-2 border-black/20 dark:border-white/20 pt-4">
+                <p className="text-sm font-bold mb-2">통계</p>
+                <div className="grid grid-cols-3 gap-3 text-center text-sm">
+                  <div className="border-2 border-black dark:border-white p-2">
+                    <p className="text-xs text-gray-500 dark:text-gray-400 font-bold">세션</p>
+                    <p className="font-black tabular-nums">{stats.totalSessions}</p>
+                  </div>
+                  <div className="border-2 border-black dark:border-white p-2">
+                    <p className="text-xs text-gray-500 dark:text-gray-400 font-bold">클리어율</p>
+                    <p className="font-black tabular-nums">{stats.clearRate.toFixed(1)}%</p>
+                  </div>
+                  <div className="border-2 border-black dark:border-white p-2">
+                    <p className="text-xs text-gray-500 dark:text-gray-400 font-bold">평균 시도</p>
+                    <p className="font-black tabular-nums">{stats.avgAttemptCount.toFixed(1)}</p>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {!sentence.usedAt && sentence.status === "ACTIVE" && (
+              <div className="border-t-2 border-black/20 dark:border-white/20 pt-4 space-y-2">
+                <Button
+                  size="sm"
+                  variant="danger"
+                  onClick={handleEmergencyReplace}
+                  disabled={!isSuperAdmin}
+                  isLoading={emergencyReplace.isPending}
+                >
+                  긴급 교체 (이 문장으로)
+                </Button>
+                {!isSuperAdmin && (
+                  <p className="text-xs font-bold text-amber-600 dark:text-amber-400">
+                    SUPERADMIN만 긴급 교체를 수행할 수 있습니다.
+                  </p>
+                )}
+              </div>
+            )}
+          </>
+        )}
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/frontend/src/features/admin/components/SimilarityTestDialog.tsx
+++ b/frontend/src/features/admin/components/SimilarityTestDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/shared/ui/Button";
+import { Dialog } from "@/shared/ui/Dialog";
 import { Input } from "@/shared/ui/Input";
 import { useTestSimilarity } from "@/features/admin/hooks/useAdminSentences";
 import { getSimilarityColor } from "@/shared/utils/similarity";
@@ -15,18 +16,6 @@ export function SimilarityTestDialog({ onClose }: SimilarityTestDialogProps) {
   const [guessText, setGuessText] = useState("");
   const testMutation = useTestSimilarity();
   const { addToast } = useToastStore();
-
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    }
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [onClose]);
 
   function handleTest() {
     if (!sentence.trim() || !guessText.trim()) {
@@ -44,43 +33,42 @@ export function SimilarityTestDialog({ onClose }: SimilarityTestDialogProps) {
   const color = result ? getSimilarityColor(Number(result.similarity)) : null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
-      <div className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-md">
-        <div className="px-6 py-5 border-b-4 border-black dark:border-white">
-          <h2 className="text-xl font-black">유사도 테스트</h2>
-        </div>
-
-        <div className="px-6 py-5 space-y-4">
-          <div>
-            <label className="block text-sm font-bold mb-1">정답 문장</label>
-            <Input value={sentence} onChange={(e) => setSentence(e.target.value)} placeholder="정답 문장" />
-          </div>
-          <div>
-            <label className="block text-sm font-bold mb-1">추측 문장</label>
-            <Input value={guessText} onChange={(e) => setGuessText(e.target.value)} placeholder="추측 입력" />
-          </div>
-
-          {result && color && (
-            <div
-              className="border-4 border-black dark:border-white p-4 text-center"
-              style={{ backgroundColor: color.bg }}
-            >
-              <p className="text-3xl font-black tabular-nums" style={{ color: color.text }}>
-                {Number(result.similarity).toFixed(1)}%
-              </p>
-            </div>
-          )}
-        </div>
-
-        <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white">
+    <Dialog
+      onClose={onClose}
+      title="유사도 테스트"
+      maxWidth="max-w-md"
+      footer={
+        <>
           <Button variant="secondary" size="sm" className="flex-1" onClick={onClose}>
             닫기
           </Button>
           <Button size="sm" className="flex-1" onClick={handleTest} isLoading={testMutation.isPending}>
             테스트
           </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-bold mb-1">정답 문장</label>
+          <Input value={sentence} onChange={(e) => setSentence(e.target.value)} placeholder="정답 문장" />
         </div>
+        <div>
+          <label className="block text-sm font-bold mb-1">추측 문장</label>
+          <Input value={guessText} onChange={(e) => setGuessText(e.target.value)} placeholder="추측 입력" />
+        </div>
+
+        {result && color && (
+          <div
+            className="border-4 border-black dark:border-white p-4 text-center"
+            style={{ backgroundColor: color.bg }}
+          >
+            <p className="text-3xl font-black tabular-nums" style={{ color: color.text }}>
+              {Number(result.similarity).toFixed(1)}%
+            </p>
+          </div>
+        )}
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/frontend/src/features/admin/components/UserDetailDialog.tsx
+++ b/frontend/src/features/admin/components/UserDetailDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/shared/ui/Button";
+import { Dialog } from "@/shared/ui/Dialog";
 import { Input } from "@/shared/ui/Input";
 import {
   useUserDetail,
@@ -74,18 +75,6 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
   const { addToast } = useToastStore();
   const actorRole = useAuthStore((s) => s.user?.role);
 
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    }
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [onClose]);
-
   function handleAction(action: () => void, confirmMsg: string) {
     if (!window.confirm(confirmMsg)) {
       return;
@@ -97,37 +86,12 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
     addToast(err instanceof ApiError ? err.message : "작업 실패", "error");
   }
 
-  if (isLoading || !user) {
-    return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-        <div className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal p-8">
-          <p className="font-bold text-gray-400 animate-pulse">로딩 중...</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 overflow-y-auto py-8"
-      role="dialog"
-      aria-modal="true"
-    >
-      <div className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-lg my-auto">
-        <div className="px-6 py-5 border-b-4 border-black dark:border-white flex items-center justify-between">
-          <h2 className="text-xl font-black">사용자 상세</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="닫기"
-            className="text-2xl font-black leading-none hover:text-red-500"
-          >
-            &times;
-          </button>
-        </div>
-
-        <div className="px-6 py-5 space-y-4">
-          {/* 프로필 */}
+    <Dialog onClose={onClose} title="사용자 상세" maxWidth="max-w-lg">
+      {isLoading || !user ? (
+        <p className="font-bold text-gray-400 animate-pulse">로딩 중...</p>
+      ) : (
+        <div className="space-y-4">
           <div className="flex items-center gap-4">
             {user.profileUrl ? (
               <img
@@ -165,7 +129,6 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
             </div>
           </div>
 
-          {/* 활동 요약 */}
           <div className="grid grid-cols-4 gap-2">
             {[
               { label: "참여", value: user.activity.totalParticipations },
@@ -180,14 +143,13 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
             ))}
           </div>
 
-          {/* 액션 */}
           <div className="border-t-2 border-black/20 dark:border-white/20 pt-4 space-y-3">
             {!canModify(actorRole, user.role) && (
               <p className="text-xs font-bold text-amber-600 dark:text-amber-400">
                 이 사용자에 대한 변경 권한이 부족합니다.
               </p>
             )}
-            {/* 역할 변경 */}
+
             <div className="flex flex-col gap-1">
               <div className="flex gap-2 items-center">
                 <span className="text-sm font-bold w-20">역할:</span>
@@ -228,7 +190,6 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
               )}
             </div>
 
-            {/* 차단/해제 */}
             <div className="flex gap-2 items-center">
               <span className="text-sm font-bold w-20">차단:</span>
               {user.banned ? (
@@ -272,7 +233,6 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
               )}
             </div>
 
-            {/* 닉네임 변경 */}
             <div className="flex gap-2 items-center">
               <span className="text-sm font-bold w-20">닉네임:</span>
               <Input
@@ -306,7 +266,6 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
               </Button>
             </div>
 
-            {/* 프로필 이미지 삭제 */}
             {user.profileUrl && (
               <div className="flex gap-2 items-center">
                 <span className="text-sm font-bold w-20">프로필:</span>
@@ -331,7 +290,6 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
               </div>
             )}
 
-            {/* 강제 탈퇴 (SUPERADMIN 전용) */}
             <div className="flex flex-col gap-1">
               <div className="flex gap-2 items-center">
                 <span className="text-sm font-bold w-20">탈퇴:</span>
@@ -365,7 +323,6 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
             </div>
           </div>
 
-          {/* 게임 이력 */}
           <div className="border-t-2 border-black/20 dark:border-white/20 pt-4">
             <button
               type="button"
@@ -414,7 +371,7 @@ export function UserDetailDialog({ publicId, onClose }: UserDetailDialogProps) {
             )}
           </div>
         </div>
-      </div>
-    </div>
+      )}
+    </Dialog>
   );
 }

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -7,10 +7,9 @@ import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { type Provider, PROVIDER_COLORS, getLastProvider, saveLastProvider } from "@/shared/config/providers";
 import { KakaoIcon, GoogleIcon, NaverIcon } from "@/shared/config/providerIcons";
 import { queryClient } from "@/shared/api/queryClient";
+import { API_BASE_URL } from "@/shared/config/env";
 import { login } from "@/features/auth/api";
 import { RegisterDialog } from "@/features/auth/components/RegisterDialog";
-
-const API_BASE = import.meta.env.VITE_API_BASE_URL;
 
 const PROVIDERS: {
   id: Provider;
@@ -24,7 +23,7 @@ const PROVIDERS: {
 
 function handleOAuthLogin(provider: Provider) {
   saveLastProvider(provider);
-  window.location.href = `${API_BASE}/oauth2/authorization/${provider}`;
+  window.location.href = `${API_BASE_URL}/oauth2/authorization/${provider}`;
 }
 
 export function LoginPage() {

--- a/frontend/src/features/auth/components/ConfirmDialog.tsx
+++ b/frontend/src/features/auth/components/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
 import { Button } from "@/shared/ui/Button";
+import { Dialog } from "@/shared/ui/Dialog";
 
 interface ConfirmDialogProps {
   isOpen: boolean;
@@ -20,66 +20,24 @@ export function ConfirmDialog({
   confirmLabel,
   isLoading,
 }: ConfirmDialogProps) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !isLoading) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isOpen, isLoading, onClose]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handleClickOutside = (e: MouseEvent) => {
-      if (!isLoading && dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isOpen, isLoading, onClose]);
-
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
-      <div
-        ref={dialogRef}
-        className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-sm"
-      >
-        <div className="px-6 py-5 space-y-3">
-          <h2 className="text-xl font-black">{title}</h2>
-          <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">{message}</p>
-        </div>
-
-        <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white">
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      disableClose={isLoading}
+      footer={
+        <>
           <Button variant="secondary" size="sm" className="flex-1" onClick={onClose} disabled={isLoading}>
             취소
           </Button>
           <Button variant="danger" size="sm" className="flex-1" onClick={onConfirm} isLoading={isLoading}>
             {confirmLabel}
           </Button>
-        </div>
-      </div>
-    </div>
+        </>
+      }
+    >
+      <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">{message}</p>
+    </Dialog>
   );
 }

--- a/frontend/src/features/auth/components/NicknameEditDialog.tsx
+++ b/frontend/src/features/auth/components/NicknameEditDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import type { MeResponse } from "@/shared/api/types";
 import { ApiError } from "@/shared/api/client";
 import { Button } from "@/shared/ui/Button";
+import { Dialog } from "@/shared/ui/Dialog";
 import { Input } from "@/shared/ui/Input";
 import { changeNickname } from "@/features/auth/api";
 
@@ -72,39 +73,12 @@ export function NicknameEditDialog({ onClose, currentNickname, onSuccess }: Nick
   const [nickname, setNickname] = useState(currentNickname);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const dialogRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
   }, []);
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !isSubmitting) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isSubmitting, onClose]);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (!isSubmitting && dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isSubmitting, onClose]);
 
   const handleChange = (value: string) => {
     if (value.length <= MAX_LENGTH) {
@@ -142,55 +116,53 @@ export function NicknameEditDialog({ onClose, currentNickname, onSuccess }: Nick
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
-      <div
-        ref={dialogRef}
-        className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-sm"
-      >
-        <div className="px-6 py-5 space-y-4">
-          <h2 className="text-xl font-black">닉네임 변경</h2>
-
-          <ul className="text-xs text-gray-500 dark:text-gray-400 space-y-0.5">
-            <li>- 한글, 영문, 숫자, 밑줄(_), 공백 사용 가능</li>
-            <li>
-              - {MIN_LENGTH}~{MAX_LENGTH}자, 연속 공백은 하나로 처리
-            </li>
-            <li>- 관리자 사칭 닉네임 사용 불가</li>
-          </ul>
-
-          <div className="space-y-2">
-            <Input
-              ref={inputRef}
-              value={nickname}
-              onChange={(e) => handleChange(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && canSubmit) {
-                  handleSubmit();
-                }
-              }}
-              placeholder="새 닉네임"
-              maxLength={MAX_LENGTH}
-              disabled={isSubmitting}
-            />
-
-            <div className="flex items-center justify-between min-h-[1.25rem]">
-              {error ? <p className="text-sm font-medium text-red-500">{error}</p> : <span />}
-              <p className="text-sm text-gray-500 tabular-nums">
-                {normalized.length}/{MAX_LENGTH}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white">
+    <Dialog
+      onClose={onClose}
+      title="닉네임 변경"
+      disableClose={isSubmitting}
+      footer={
+        <>
           <Button variant="secondary" size="sm" className="flex-1" onClick={onClose} disabled={isSubmitting}>
             취소
           </Button>
           <Button size="sm" className="flex-1" onClick={handleSubmit} isLoading={isSubmitting} disabled={!canSubmit}>
             변경
           </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <ul className="text-xs text-gray-500 dark:text-gray-400 space-y-0.5">
+          <li>- 한글, 영문, 숫자, 밑줄(_), 공백 사용 가능</li>
+          <li>
+            - {MIN_LENGTH}~{MAX_LENGTH}자, 연속 공백은 하나로 처리
+          </li>
+          <li>- 관리자 사칭 닉네임 사용 불가</li>
+        </ul>
+
+        <div className="space-y-2">
+          <Input
+            ref={inputRef}
+            value={nickname}
+            onChange={(e) => handleChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canSubmit) {
+                handleSubmit();
+              }
+            }}
+            placeholder="새 닉네임"
+            maxLength={MAX_LENGTH}
+            disabled={isSubmitting}
+          />
+
+          <div className="flex items-center justify-between min-h-[1.25rem]">
+            {error ? <p className="text-sm font-medium text-red-500">{error}</p> : <span />}
+            <p className="text-sm text-gray-500 tabular-nums">
+              {normalized.length}/{MAX_LENGTH}
+            </p>
+          </div>
         </div>
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/frontend/src/features/auth/components/ProfileImageCropDialog.tsx
+++ b/frontend/src/features/auth/components/ProfileImageCropDialog.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useCallback } from "react";
 import type { CSSProperties } from "react";
 import Cropper from "react-easy-crop";
 import type { Area } from "react-easy-crop";
 import { ApiError } from "@/shared/api/client";
 import { Button } from "@/shared/ui/Button";
+import { Dialog } from "@/shared/ui/Dialog";
 import { uploadProfileImage } from "@/features/auth/api";
 import { cropImage } from "@/features/auth/utils/cropImage";
 import type { MeResponse } from "@/shared/api/types";
@@ -29,37 +30,10 @@ export function ProfileImageCropDialog({ imageSrc, onClose, onSuccess }: Profile
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const dialogRef = useRef<HTMLDivElement>(null);
 
   const onCropComplete = useCallback((_: Area, pixels: Area) => {
     setCroppedAreaPixels(pixels);
   }, []);
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !isSubmitting) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isSubmitting, onClose]);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (!isSubmitting && dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isSubmitting, onClose]);
 
   const handleSubmit = async () => {
     if (!croppedAreaPixels) {
@@ -84,57 +58,55 @@ export function ProfileImageCropDialog({ imageSrc, onClose, onSuccess }: Profile
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
-      <div
-        ref={dialogRef}
-        className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-sm"
-      >
-        <div className="px-6 py-5 space-y-4">
-          <h2 className="text-xl font-black">프로필 이미지 편집</h2>
-
-          <div className="relative w-full aspect-square border-4 border-black dark:border-white overflow-hidden bg-gray-100 dark:bg-gray-800">
-            <Cropper
-              image={imageSrc}
-              crop={crop}
-              zoom={zoom}
-              aspect={1}
-              cropShape="rect"
-              onCropChange={setCrop}
-              onZoomChange={setZoom}
-              onCropComplete={onCropComplete}
-              style={{
-                containerStyle: { position: "absolute", inset: 0 },
-              }}
-            />
-          </div>
-
-          <div className="flex items-center gap-3">
-            <span className="text-sm font-bold shrink-0">줌</span>
-            <input
-              type="range"
-              min={1}
-              max={10}
-              step={0.1}
-              value={zoom}
-              onChange={(e) => setZoom(Number(e.target.value))}
-              className="w-full"
-              style={sliderStyle}
-              disabled={isSubmitting}
-            />
-          </div>
-
-          {error && <p className="text-sm font-medium text-red-500">{error}</p>}
-        </div>
-
-        <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white">
+    <Dialog
+      onClose={onClose}
+      title="프로필 이미지 편집"
+      disableClose={isSubmitting}
+      footer={
+        <>
           <Button variant="secondary" size="sm" className="flex-1" onClick={onClose} disabled={isSubmitting}>
             취소
           </Button>
           <Button size="sm" className="flex-1" onClick={handleSubmit} isLoading={isSubmitting} disabled={isSubmitting}>
             저장
           </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div className="relative w-full aspect-square border-4 border-black dark:border-white overflow-hidden bg-gray-100 dark:bg-gray-800">
+          <Cropper
+            image={imageSrc}
+            crop={crop}
+            zoom={zoom}
+            aspect={1}
+            cropShape="rect"
+            onCropChange={setCrop}
+            onZoomChange={setZoom}
+            onCropComplete={onCropComplete}
+            style={{
+              containerStyle: { position: "absolute", inset: 0 },
+            }}
+          />
         </div>
+
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-bold shrink-0">줌</span>
+          <input
+            type="range"
+            min={1}
+            max={10}
+            step={0.1}
+            value={zoom}
+            onChange={(e) => setZoom(Number(e.target.value))}
+            className="w-full"
+            style={sliderStyle}
+            disabled={isSubmitting}
+          />
+        </div>
+
+        {error && <p className="text-sm font-medium text-red-500">{error}</p>}
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/frontend/src/features/auth/components/RegisterDialog.tsx
+++ b/frontend/src/features/auth/components/RegisterDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { ApiError } from "@/shared/api/client";
 import { Button } from "@/shared/ui/Button";
+import { Dialog } from "@/shared/ui/Dialog";
 import { Input } from "@/shared/ui/Input";
 import { register } from "@/features/auth/api";
 
@@ -41,38 +42,11 @@ export function RegisterDialog({ onClose, onSuccess }: RegisterDialogProps) {
   const [passwordConfirm, setPasswordConfirm] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const dialogRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !isSubmitting) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isSubmitting, onClose]);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (!isSubmitting && dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isSubmitting, onClose]);
 
   const usernameError = username.length > 0 ? validateUsername(username) : null;
   const passwordError = password.length > 0 ? validatePassword(password) : null;
@@ -121,102 +95,100 @@ export function RegisterDialog({ onClose, onSuccess }: RegisterDialogProps) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
-      <div
-        ref={dialogRef}
-        className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-sm"
-      >
-        <div className="px-6 py-5 space-y-4">
-          <h2 className="text-xl font-black">회원가입</h2>
-
-          <ul className="text-xs text-gray-500 dark:text-gray-400 space-y-0.5">
-            <li>
-              - 아이디: {USERNAME_MIN}~{USERNAME_MAX}자, 영문 시작, 영문/숫자/밑줄
-            </li>
-            <li>- 비밀번호: {PASSWORD_MIN}자 이상</li>
-            <li>- 닉네임은 자동 생성되며, 마이페이지에서 변경 가능</li>
-          </ul>
-
-          <div className="space-y-3">
-            <div className="space-y-1">
-              <Input
-                ref={inputRef}
-                value={username}
-                onChange={(e) => {
-                  if (e.target.value.length <= USERNAME_MAX) {
-                    setUsername(e.target.value);
-                    setError(null);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && canSubmit) {
-                    handleSubmit();
-                  }
-                }}
-                placeholder="아이디"
-                maxLength={USERNAME_MAX}
-                disabled={isSubmitting}
-                autoComplete="username"
-              />
-              {usernameError && <p className="text-sm font-medium text-red-500">{usernameError}</p>}
-            </div>
-
-            <div className="space-y-1">
-              <Input
-                type="password"
-                value={password}
-                onChange={(e) => {
-                  if (e.target.value.length <= PASSWORD_MAX) {
-                    setPassword(e.target.value);
-                    setError(null);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && canSubmit) {
-                    handleSubmit();
-                  }
-                }}
-                placeholder="비밀번호"
-                maxLength={PASSWORD_MAX}
-                disabled={isSubmitting}
-                autoComplete="new-password"
-              />
-              {passwordError && <p className="text-sm font-medium text-red-500">{passwordError}</p>}
-            </div>
-
-            <div className="space-y-1">
-              <Input
-                type="password"
-                value={passwordConfirm}
-                onChange={(e) => {
-                  setPasswordConfirm(e.target.value);
-                  setError(null);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && canSubmit) {
-                    handleSubmit();
-                  }
-                }}
-                placeholder="비밀번호 확인"
-                disabled={isSubmitting}
-                autoComplete="new-password"
-              />
-              {confirmError && <p className="text-sm font-medium text-red-500">{confirmError}</p>}
-            </div>
-          </div>
-
-          {error && <p className="text-sm font-medium text-red-500">{error}</p>}
-        </div>
-
-        <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white">
+    <Dialog
+      onClose={onClose}
+      title="회원가입"
+      disableClose={isSubmitting}
+      footer={
+        <>
           <Button variant="secondary" size="sm" className="flex-1" onClick={onClose} disabled={isSubmitting}>
             취소
           </Button>
           <Button size="sm" className="flex-1" onClick={handleSubmit} isLoading={isSubmitting} disabled={!canSubmit}>
             가입
           </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <ul className="text-xs text-gray-500 dark:text-gray-400 space-y-0.5">
+          <li>
+            - 아이디: {USERNAME_MIN}~{USERNAME_MAX}자, 영문 시작, 영문/숫자/밑줄
+          </li>
+          <li>- 비밀번호: {PASSWORD_MIN}자 이상</li>
+          <li>- 닉네임은 자동 생성되며, 마이페이지에서 변경 가능</li>
+        </ul>
+
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <Input
+              ref={inputRef}
+              value={username}
+              onChange={(e) => {
+                if (e.target.value.length <= USERNAME_MAX) {
+                  setUsername(e.target.value);
+                  setError(null);
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canSubmit) {
+                  handleSubmit();
+                }
+              }}
+              placeholder="아이디"
+              maxLength={USERNAME_MAX}
+              disabled={isSubmitting}
+              autoComplete="username"
+            />
+            {usernameError && <p className="text-sm font-medium text-red-500">{usernameError}</p>}
+          </div>
+
+          <div className="space-y-1">
+            <Input
+              type="password"
+              value={password}
+              onChange={(e) => {
+                if (e.target.value.length <= PASSWORD_MAX) {
+                  setPassword(e.target.value);
+                  setError(null);
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canSubmit) {
+                  handleSubmit();
+                }
+              }}
+              placeholder="비밀번호"
+              maxLength={PASSWORD_MAX}
+              disabled={isSubmitting}
+              autoComplete="new-password"
+            />
+            {passwordError && <p className="text-sm font-medium text-red-500">{passwordError}</p>}
+          </div>
+
+          <div className="space-y-1">
+            <Input
+              type="password"
+              value={passwordConfirm}
+              onChange={(e) => {
+                setPasswordConfirm(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canSubmit) {
+                  handleSubmit();
+                }
+              }}
+              placeholder="비밀번호 확인"
+              disabled={isSubmitting}
+              autoComplete="new-password"
+            />
+            {confirmError && <p className="text-sm font-medium text-red-500">{confirmError}</p>}
+          </div>
         </div>
+
+        {error && <p className="text-sm font-medium text-red-500">{error}</p>}
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/frontend/src/features/game/components/HelpModal.tsx
+++ b/frontend/src/features/game/components/HelpModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { Dialog } from "@/shared/ui/Dialog";
 
 interface HelpModalProps {
   isOpen: boolean;
@@ -8,240 +8,182 @@ interface HelpModalProps {
 export const HELP_SHOWN_KEY = "help_modal_shown";
 
 export function HelpModal({ isOpen, onClose }: HelpModalProps) {
-  const modalRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const handleClickOutside = (e: MouseEvent) => {
-      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isOpen, onClose]);
-
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="help-modal-title"
-    >
-      <div
-        ref={modalRef}
-        className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-w-lg max-h-[80vh] flex flex-col"
-      >
-        <div className="flex items-center justify-between border-b-4 border-black dark:border-white px-6 py-4 shrink-0">
-          <h2 id="help-modal-title" className="text-xl font-black">
-            게임 방법
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-black dark:text-white px-3 py-1 font-black text-lg transition-all duration-100 shadow-brutal-sm hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]"
-            aria-label="닫기"
-          >
-            ✕
-          </button>
+    <Dialog isOpen={isOpen} onClose={onClose} title="게임 방법" maxWidth="max-w-lg">
+      <section className="pb-5">
+        <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">개요</h3>
+        <p className="text-sm font-medium leading-relaxed">
+          <strong className="font-black">가까워</strong>는 매일 출제되는 정답 문장을 AI 유사도를 기반으로 맞추는
+          게임입니다.
+          <br />
+          정답에 가까운 <strong className="font-black">의미</strong>의 문장을 입력할수록 높은 유사도를 얻습니다.
+        </p>
+      </section>
+
+      <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
+        <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">AI 유사도란?</h3>
+        <p className="text-sm font-medium leading-relaxed mb-3">
+          이 게임의 유사도는 <strong className="font-black">문장의 의미적 유사성</strong>을 측정합니다.
+          <br />
+          글자가 겹치거나 초성이 비슷하다고 높은 점수가 나오지 않습니다.
+          <br />
+          AI가 문장의 <strong className="font-black">뜻과 맥락</strong>을 분석하여 정답과 얼마나 가까운 의미인지
+          판단합니다.
+        </p>
+        <div className="border-2 border-black dark:border-white bg-gray-50 dark:bg-gray-800 p-3 space-y-2 text-sm">
+          <p className="font-bold text-green-700 dark:text-green-400">높은 유사도 - 의미가 비슷한 경우</p>
+          <p className="font-medium text-gray-600 dark:text-gray-400">
+            정답: &quot;오늘 날씨가 좋다&quot; → &quot;화창한 하루다&quot; (비슷한 뜻)
+          </p>
+          <div className="border-t border-gray-300 dark:border-gray-600 my-1" />
+          <p className="font-bold text-red-600 dark:text-red-400">낮은 유사도 - 의미가 다른 경우</p>
+          <p className="font-medium text-gray-600 dark:text-gray-400">
+            정답: &quot;오늘 날씨가 좋다&quot; → &quot;오늘 국수가 좋다&quot; (비슷하지만 뜻이 다름)
+          </p>
         </div>
+      </section>
 
-        <div className="px-6 py-5 overflow-y-auto">
-          <section className="pb-5">
-            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">개요</h3>
-            <p className="text-sm font-medium leading-relaxed">
-              <strong className="font-black">가까워</strong>는 매일 출제되는 정답 문장을 AI 유사도를 기반으로 맞추는
-              게임입니다.
-              <br />
-              정답에 가까운 <strong className="font-black">의미</strong>의 문장을 입력할수록 높은 유사도를 얻습니다.
-            </p>
-          </section>
-
-          <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
-            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">AI 유사도란?</h3>
-            <p className="text-sm font-medium leading-relaxed mb-3">
-              이 게임의 유사도는 <strong className="font-black">문장의 의미적 유사성</strong>을 측정합니다.
-              <br />
-              글자가 겹치거나 초성이 비슷하다고 높은 점수가 나오지 않습니다.
-              <br />
-              AI가 문장의 <strong className="font-black">뜻과 맥락</strong>을 분석하여 정답과 얼마나 가까운 의미인지
-              판단합니다.
-            </p>
-            <div className="border-2 border-black dark:border-white bg-gray-50 dark:bg-gray-800 p-3 space-y-2 text-sm">
-              <p className="font-bold text-green-700 dark:text-green-400">높은 유사도 — 의미가 비슷한 경우</p>
-              <p className="font-medium text-gray-600 dark:text-gray-400">
-                정답: &quot;오늘 날씨가 좋다&quot; → &quot;화창한 하루다&quot; (비슷한 뜻)
-              </p>
-              <div className="border-t border-gray-300 dark:border-gray-600 my-1" />
-              <p className="font-bold text-red-600 dark:text-red-400">낮은 유사도 — 의미가 다른 경우</p>
-              <p className="font-medium text-gray-600 dark:text-gray-400">
-                정답: &quot;오늘 날씨가 좋다&quot; → &quot;오늘 국수가 좋다&quot; (비슷하지만 뜻이 다름)
-              </p>
-            </div>
-          </section>
-
-          <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
-            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-3">플레이 방법</h3>
-            <ol className="space-y-2.5 text-sm font-medium">
-              <li className="flex gap-3">
-                <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
-                  1
-                </span>
-                <span>
-                  힌트 마스크로 정답의 <strong className="font-black">단어 수와 글자 수</strong>를 확인하세요.
-                </span>
-              </li>
-              <li className="flex gap-3">
-                <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
-                  2
-                </span>
-                <span>정답이라고 생각하는 문장을 입력하세요.</span>
-              </li>
-              <li className="flex gap-3">
-                <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
-                  3
-                </span>
-                <span>
-                  AI가 <strong className="font-black">유사도(0~100%)</strong>를 알려줍니다.
-                </span>
-              </li>
-              <li className="flex gap-3">
-                <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
-                  4
-                </span>
-                <span>
-                  유사도 <strong className="font-black">95% 이상</strong>이면 정답!
-                </span>
-              </li>
-              <li className="flex gap-3">
-                <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
-                  5
-                </span>
-                <span>적은 시도로 맞출수록 높은 순위를 차지합니다.</span>
-              </li>
-            </ol>
-            <div className="mt-3 border-l-4 border-yellow-400 pl-3 bg-yellow-50 dark:bg-yellow-900/20 py-2">
-              <ul className="space-y-1 text-sm font-medium">
-                <li className="flex gap-2">
-                  <span className="shrink-0 font-black">·</span>
-                  <span>정답을 맞힌 이후에도 계속 추측할 수 있습니다.</span>
-                </li>
-                <li className="flex gap-2">
-                  <span className="shrink-0 font-black">·</span>
-                  <span>시도 횟수는 최초 맞춘 시점으로 고정되며, 최고 유사도만 업데이트됩니다.</span>
-                </li>
-                <li className="flex gap-2">
-                  <span className="shrink-0 font-black">·</span>
-                  <span>다른 플레이어와 유사도를 경쟁하며 순위를 올려보세요!</span>
-                </li>
-              </ul>
-            </div>
-          </section>
-
-          <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
-            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">힌트 (다른 플레이어의 추측)</h3>
-            <ul className="space-y-1.5 text-sm font-medium">
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>
-                  유사도 <strong className="font-black">60% 이상</strong> 달성 시 다른 플레이어의 추측을 볼 수 있습니다
-                </span>
-              </li>
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>내 최고 유사도보다 낮은 추측만 표시됩니다</span>
-              </li>
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>단, 90% 이상의 추측은 표시되지 않습니다</span>
-              </li>
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>좌측 패널에서 확인할 수 있습니다 (로그인 필요)</span>
-              </li>
-            </ul>
-          </section>
-
-          <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
-            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">랭킹 선정 방식</h3>
-            <ul className="space-y-1.5 text-sm font-medium">
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>유사도가 높을수록 상위 랭킹</span>
-              </li>
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>유사도가 같으면 시도 횟수가 적은 사람이 상위</span>
-              </li>
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>
-                  <strong className="font-black">100%</strong> 달성자끼리는 먼저 달성한 사람이 상위
-                </span>
-              </li>
-            </ul>
-          </section>
-
-          <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
-            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">유사도 색상</h3>
-            <div className="flex h-3 border-2 border-black dark:border-white overflow-hidden">
-              {Array.from({ length: 20 }, (_, i) => {
-                const hue = (i / 19) * 120;
-                return <div key={i} className="flex-1" style={{ backgroundColor: `hsl(${hue}, 80%, 45%)` }} />;
-              })}
-            </div>
-            <div className="flex justify-between mt-1">
-              <span className="text-[10px] font-bold text-gray-500">0% (멀어요)</span>
-              <span className="text-[10px] font-bold text-gray-500">100% (정답!)</span>
-            </div>
-          </section>
-
-          <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5">
-            <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">팁</h3>
-            <ul className="space-y-1.5 text-sm font-medium">
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>정답과 같은 주제, 같은 상황을 표현하는 문장을 시도해보세요.</span>
-              </li>
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>유사도가 오르는 방향으로 점진적으로 접근하세요.</span>
-              </li>
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>문장이 아니라 단어 단위로도 시도해보세요.</span>
-              </li>
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>익숙해진다면, 패턴이 보일지도..?</span>
-              </li>
-              <li className="flex gap-2">
-                <span className="shrink-0 font-black">·</span>
-                <span>매일 자정(KST)에 새로운 문장이 출제됩니다.</span>
-              </li>
-            </ul>
-          </section>
+      <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
+        <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-3">플레이 방법</h3>
+        <ol className="space-y-2.5 text-sm font-medium">
+          <li className="flex gap-3">
+            <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
+              1
+            </span>
+            <span>
+              힌트 마스크로 정답의 <strong className="font-black">단어 수와 글자 수</strong>를 확인하세요.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
+              2
+            </span>
+            <span>정답이라고 생각하는 문장을 입력하세요.</span>
+          </li>
+          <li className="flex gap-3">
+            <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
+              3
+            </span>
+            <span>
+              AI가 <strong className="font-black">유사도(0~100%)</strong>를 알려줍니다.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
+              4
+            </span>
+            <span>
+              유사도 <strong className="font-black">95% 이상</strong>이면 정답!
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="shrink-0 w-6 h-6 border-2 border-black dark:border-white bg-yellow-300 flex items-center justify-center text-xs font-black">
+              5
+            </span>
+            <span>적은 시도로 맞출수록 높은 순위를 차지합니다.</span>
+          </li>
+        </ol>
+        <div className="mt-3 border-l-4 border-yellow-400 pl-3 bg-yellow-50 dark:bg-yellow-900/20 py-2">
+          <ul className="space-y-1 text-sm font-medium">
+            <li className="flex gap-2">
+              <span className="shrink-0 font-black">·</span>
+              <span>정답을 맞힌 이후에도 계속 추측할 수 있습니다.</span>
+            </li>
+            <li className="flex gap-2">
+              <span className="shrink-0 font-black">·</span>
+              <span>시도 횟수는 최초 맞춘 시점으로 고정되며, 최고 유사도만 업데이트됩니다.</span>
+            </li>
+            <li className="flex gap-2">
+              <span className="shrink-0 font-black">·</span>
+              <span>다른 플레이어와 유사도를 경쟁하며 순위를 올려보세요!</span>
+            </li>
+          </ul>
         </div>
-      </div>
-    </div>
+      </section>
+
+      <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
+        <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">힌트 (다른 플레이어의 추측)</h3>
+        <ul className="space-y-1.5 text-sm font-medium">
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>
+              유사도 <strong className="font-black">60% 이상</strong> 달성 시 다른 플레이어의 추측을 볼 수 있습니다
+            </span>
+          </li>
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>내 최고 유사도보다 낮은 추측만 표시됩니다</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>단, 90% 이상의 추측은 표시되지 않습니다</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>좌측 패널에서 확인할 수 있습니다 (로그인 필요)</span>
+          </li>
+        </ul>
+      </section>
+
+      <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
+        <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">랭킹 선정 방식</h3>
+        <ul className="space-y-1.5 text-sm font-medium">
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>유사도가 높을수록 상위 랭킹</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>유사도가 같으면 시도 횟수가 적은 사람이 상위</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>
+              <strong className="font-black">100%</strong> 달성자끼리는 먼저 달성한 사람이 상위
+            </span>
+          </li>
+        </ul>
+      </section>
+
+      <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5 pb-5">
+        <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">유사도 색상</h3>
+        <div className="flex h-3 border-2 border-black dark:border-white overflow-hidden">
+          {Array.from({ length: 20 }, (_, i) => {
+            const hue = (i / 19) * 120;
+            return <div key={i} className="flex-1" style={{ backgroundColor: `hsl(${hue}, 80%, 45%)` }} />;
+          })}
+        </div>
+        <div className="flex justify-between mt-1">
+          <span className="text-[10px] font-bold text-gray-500">0% (멀어요)</span>
+          <span className="text-[10px] font-bold text-gray-500">100% (정답!)</span>
+        </div>
+      </section>
+
+      <section className="border-t-2 border-gray-200 dark:border-gray-800 pt-5">
+        <h3 className="text-base font-black text-gray-700 dark:text-gray-300 mb-2">팁</h3>
+        <ul className="space-y-1.5 text-sm font-medium">
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>정답과 같은 주제, 같은 상황을 표현하는 문장을 시도해보세요.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>유사도가 오르는 방향으로 점진적으로 접근하세요.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>문장이 아니라 단어 단위로도 시도해보세요.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>익숙해진다면, 패턴이 보일지도..?</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="shrink-0 font-black">·</span>
+            <span>매일 자정(KST)에 새로운 문장이 출제됩니다.</span>
+          </li>
+        </ul>
+      </section>
+    </Dialog>
   );
 }

--- a/frontend/src/features/ranking/hooks/useRankingSSE.ts
+++ b/frontend/src/features/ranking/hooks/useRankingSSE.ts
@@ -1,9 +1,10 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { RankingResponse } from "@/shared/api/types";
+import { API_BASE_URL } from "@/shared/config/env";
 import { useConnectionStore } from "@/shared/stores/useConnectionStore";
 
-const SSE_URL = `${import.meta.env.VITE_API_BASE_URL}/ranking/stream`;
+const SSE_URL = `${API_BASE_URL}/ranking/stream`;
 const INITIAL_DELAY = 2000;
 const MAX_DELAY = 30_000;
 

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,10 +1,5 @@
 import type { ErrorBody } from "@/shared/api/types";
-
-const API_BASE = import.meta.env.VITE_API_BASE_URL;
-
-if (!API_BASE) {
-  throw new Error("VITE_API_BASE_URL 환경변수가 설정되지 않았습니다.");
-}
+import { API_BASE_URL } from "@/shared/config/env";
 
 export class ApiError extends Error {
   status: number;
@@ -26,7 +21,7 @@ let refreshPromise: Promise<boolean> | null = null;
 
 async function refreshToken(): Promise<boolean> {
   try {
-    const res = await fetch(`${API_BASE}/auth/refresh`, {
+    const res = await fetch(`${API_BASE_URL}/auth/refresh`, {
       method: "POST",
       credentials: "include",
     });
@@ -61,7 +56,7 @@ async function handleResponse<T>(res: Response): Promise<T> {
 type ApiFetchOptions = Omit<RequestInit, "body"> & { body?: BodyInit | object | null };
 
 export async function apiFetch<T>(path: string, { body: rawBody, ...restOptions }: ApiFetchOptions = {}): Promise<T> {
-  const url = `${API_BASE}${path}`;
+  const url = `${API_BASE_URL}${path}`;
   const method = restOptions.method?.toUpperCase() ?? "GET";
   const hasBody = method !== "GET" && method !== "HEAD";
 

--- a/frontend/src/shared/config/env.ts
+++ b/frontend/src/shared/config/env.ts
@@ -1,0 +1,7 @@
+const value = import.meta.env.VITE_API_BASE_URL;
+
+if (!value) {
+  throw new Error("VITE_API_BASE_URL 환경변수가 설정되지 않았습니다.");
+}
+
+export const API_BASE_URL: string = value;

--- a/frontend/src/shared/ui/Dialog.tsx
+++ b/frontend/src/shared/ui/Dialog.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useId, useRef, type ReactNode } from "react";
+
+interface DialogProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+  maxWidth?: string;
+  disableClose?: boolean;
+}
+
+let openCount = 0;
+
+export function Dialog({
+  isOpen = true,
+  onClose,
+  title,
+  children,
+  footer,
+  className = "",
+  maxWidth = "max-w-sm",
+  disableClose = false,
+}: DialogProps) {
+  const titleId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    openCount++;
+    if (openCount === 1) {
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      openCount--;
+      if (openCount === 0) {
+        document.body.style.overflow = "";
+      }
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && !disableClose) {
+        onClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, disableClose, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handleClickOutside(e: MouseEvent) {
+      if (!disableClose && panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen, disableClose, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <div
+        ref={panelRef}
+        className={[
+          "border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-h-[85vh] flex flex-col",
+          maxWidth,
+          className,
+        ].join(" ")}
+      >
+        <div className="flex items-center justify-between border-b-4 border-black dark:border-white px-6 py-5 shrink-0">
+          <h2 id={titleId} className="text-xl font-black">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={disableClose}
+            className={[
+              "border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-black dark:text-white px-3 py-1 font-black text-lg transition-all duration-100",
+              disableClose
+                ? "opacity-50 cursor-not-allowed"
+                : "shadow-brutal-sm hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]",
+            ].join(" ")}
+            aria-label="닫기"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="px-6 py-5 overflow-y-auto flex-1">{children}</div>
+
+        {footer && (
+          <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white shrink-0">{footer}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shared/ui/ErrorFallback.tsx
+++ b/frontend/src/shared/ui/ErrorFallback.tsx
@@ -1,0 +1,69 @@
+import { useRouteError } from "react-router-dom";
+import { Card } from "@/shared/ui/Card";
+
+interface ErrorFallbackProps {
+  error: unknown;
+  resetError?: () => void;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function getErrorStack(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return error.stack;
+  }
+  return undefined;
+}
+
+export function ErrorFallback({ error, resetError }: ErrorFallbackProps) {
+  const message = getErrorMessage(error);
+  const stack = getErrorStack(error);
+
+  return (
+    <div className="max-w-md mx-auto space-y-6 text-center">
+      <h1 className="text-6xl font-black">오류</h1>
+      <Card className="space-y-4">
+        <p className="text-lg font-medium">오류가 발생했습니다</p>
+
+        {import.meta.env.DEV && (
+          <details className="text-left border-2 border-black dark:border-white bg-gray-50 dark:bg-gray-800">
+            <summary className="px-3 py-2 text-sm font-bold cursor-pointer select-none">{message}</summary>
+            {stack && (
+              <pre className="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 overflow-x-auto border-t-2 border-black dark:border-white whitespace-pre-wrap break-words">
+                {stack}
+              </pre>
+            )}
+          </details>
+        )}
+
+        <div className="flex gap-3">
+          {resetError && (
+            <button
+              type="button"
+              onClick={resetError}
+              className="flex-1 border-4 border-black dark:border-white bg-yellow-300 text-black font-bold px-6 py-3 shadow-brutal transition-all duration-100 hover:shadow-brutal-hover hover:translate-x-1 hover:translate-y-1 active:shadow-none active:translate-x-1.5 active:translate-y-1.5"
+            >
+              다시 시도
+            </button>
+          )}
+          <a
+            href="/"
+            className="flex-1 border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-black dark:text-white font-bold px-6 py-3 text-center shadow-brutal transition-all duration-100 hover:shadow-brutal-hover hover:translate-x-1 hover:translate-y-1 active:shadow-none active:translate-x-1.5 active:translate-y-1.5"
+          >
+            홈으로 돌아가기
+          </a>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export function RouteErrorFallback() {
+  const error = useRouteError();
+  return <ErrorFallback error={error} />;
+}

--- a/frontend/src/shared/utils/url.ts
+++ b/frontend/src/shared/utils/url.ts
@@ -1,6 +1,5 @@
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+import { API_BASE_URL } from "@/shared/config/env";
 
-/** 상대경로 프로필 URL에 API base URL을 붙인다. 배포 시 같은 도메인이면 이 함수만 제거. */
 export function resolveProfileUrl(url: string | null | undefined): string | null {
   if (!url) {
     return null;
@@ -8,5 +7,5 @@ export function resolveProfileUrl(url: string | null | undefined): string | null
   if (url.startsWith("http")) {
     return url;
   }
-  return `${API_BASE}${url}`;
+  return `${API_BASE_URL}${url}`;
 }


### PR DESCRIPTION
## 관련 이슈

Closes #186

## 변경 사항

### 1. VITE_API_BASE_URL 환경변수 중앙화
- `shared/config/env.ts`로 검증 로직 및 상수 일원화
- 4개 파일의 `import.meta.env` 직접 접근을 import로 전환

### 2. 공용 Dialog 컴포넌트 추출 및 다이얼로그 마이그레이션
- `shared/ui/Dialog.tsx` 생성 (backdrop/Escape/click-outside/scroll lock/aria-labelledby 통합)
- 11개 다이얼로그 보일러플레이트 제거 (~300줄 감소)
- ConfirmDialog title을 body에서 header bar로 이동 (design-system.md 명세 일치)
- 어드민 다이얼로그 5개에 click-outside 추가 (기존 Escape만 있었음, disableClose로 로딩 중 보호)
- design-system.md에 Dialog 컴포넌트 Props/기능 섹션 추가

### 3. ErrorBoundary 도입
- `ErrorBoundary` 클래스 컴포넌트로 App 전체 래핑 (라우터 외부 에러 캐치)
- `RouteErrorFallback`으로 라우터 에러 캐치 (errorElement)
- DEV 모드에서 에러 메시지/스택 상세 표시, 프로덕션은 "다시 시도" + "홈으로" UI
- NotFoundPage와 동일한 네오브루탈리즘 스타일

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다