### PR TITLE
refactor: FE staleTime 상수 중앙화 + design-system translate 표기 수렴

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -74,8 +74,8 @@ boxShadow: {
 | 상태           | 클래스                                                                      |
 | -------------- | --------------------------------------------------------------------------- |
 | 기본           | `shadow-brutal`                                                             |
-| Hover          | `hover:shadow-brutal-hover hover:translate-x-[4px] hover:translate-y-[4px]` |
-| Active (Click) | `active:shadow-none active:translate-x-[6px] active:translate-y-[6px]`      |
+| Hover          | `hover:shadow-brutal-hover hover:translate-x-1 hover:translate-y-1`         |
+| Active (Click) | `active:shadow-none active:translate-x-1.5 active:translate-y-1.5`          |
 | Disabled       | `opacity-50 cursor-not-allowed pointer-events-none translate-x-0 translate-y-0` (그림자 유지) |
 | Loading        | `opacity-70 cursor-wait shadow-brutal animate-pulse`                        |
 
@@ -84,7 +84,7 @@ boxShadow: {
 | 상태           | 클래스                                                                         |
 | -------------- | ------------------------------------------------------------------------------ |
 | 기본           | `shadow-brutal-sm`                                                             |
-| Hover          | `hover:shadow-brutal-sm-hover hover:translate-x-[2px] hover:translate-y-[2px]` |
+| Hover          | `hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5`    |
 | Active (Click) | `active:shadow-none active:translate-x-[3px] active:translate-y-[3px]`         |
 | Disabled       | `opacity-50 cursor-not-allowed pointer-events-none translate-x-0 translate-y-0` (그림자 유지) |
 | Loading        | `opacity-70 cursor-wait shadow-brutal-sm animate-pulse`                        |
@@ -186,8 +186,8 @@ hue = (similarity / 100) × 120
 ```
 기본: border-4 border-black bg-{color} shadow-brutal rounded-none font-bold
       px-6 py-3 transition-all duration-100
-호버: hover:shadow-brutal-hover hover:translate-x-[4px] hover:translate-y-[4px]
-클릭: active:shadow-none active:translate-x-[6px] active:translate-y-[6px]
+호버: hover:shadow-brutal-hover hover:translate-x-1 hover:translate-y-1
+클릭: active:shadow-none active:translate-x-1.5 active:translate-y-1.5
 비활성: disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none
         disabled:shadow-none disabled:translate-x-0 disabled:translate-y-0
 ```

--- a/frontend/src/features/game/hooks/useGameQueries.ts
+++ b/frontend/src/features/game/hooks/useGameQueries.ts
@@ -1,13 +1,14 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { getHints, getHistory, getStatus, getToday, submitGuess } from "@/features/game/api";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
+import { STALE_TIME } from "@/shared/config/query";
 import type { GuessRequest } from "@/shared/api/types";
 
 export function useToday() {
   return useQuery({
     queryKey: ["game", "today"],
     queryFn: getToday,
-    staleTime: Infinity,
+    staleTime: STALE_TIME.IMMUTABLE,
   });
 }
 
@@ -17,7 +18,7 @@ export function useGameStatus(sentenceId: string | undefined) {
   return useQuery({
     queryKey: ["game", "status", sentenceId],
     queryFn: getStatus,
-    staleTime: 30_000,
+    staleTime: STALE_TIME.SHORT,
     enabled: isAuthenticated && !!sentenceId,
   });
 }
@@ -28,7 +29,7 @@ export function useGameHistory(sentenceId: string | undefined) {
   return useQuery({
     queryKey: ["game", "history", sentenceId],
     queryFn: () => getHistory(sentenceId!),
-    staleTime: 0,
+    staleTime: STALE_TIME.NONE,
     enabled: isAuthenticated && !!sentenceId,
   });
 }
@@ -39,7 +40,7 @@ export function useHints(sentenceId: string | undefined, bestSimilarity: number)
   return useQuery({
     queryKey: ["game", "hints", sentenceId],
     queryFn: () => getHints(sentenceId!),
-    staleTime: 60_000,
+    staleTime: STALE_TIME.LONG,
     enabled: isAuthenticated && !!sentenceId && bestSimilarity >= 60,
   });
 }

--- a/frontend/src/features/ranking/hooks/useRankingQueries.ts
+++ b/frontend/src/features/ranking/hooks/useRankingQueries.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { getRankings } from "@/features/ranking/api";
+import { STALE_TIME } from "@/shared/config/query";
 
 export function useRankings() {
   return useQuery({
     queryKey: ["ranking"],
     queryFn: getRankings,
-    staleTime: 30_000,
+    staleTime: STALE_TIME.SHORT,
   });
 }

--- a/frontend/src/shared/config/query.ts
+++ b/frontend/src/shared/config/query.ts
@@ -1,0 +1,6 @@
+export const STALE_TIME = {
+  NONE: 0,
+  SHORT: 30_000,
+  LONG: 60_000,
+  IMMUTABLE: Infinity,
+} as const;

--- a/frontend/src/shared/ui/AnnouncementBanner.tsx
+++ b/frontend/src/shared/ui/AnnouncementBanner.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getActiveAnnouncements } from "@/shared/api/announcements";
 import type { ActiveAnnouncementResponse } from "@/shared/api/types";
 import { getAnnouncementTypeColor } from "@/shared/config/announcement";
+import { STALE_TIME } from "@/shared/config/query";
 
 const STORAGE_KEY = "gakkaweo-dismissed-announcements";
 
@@ -66,7 +67,7 @@ export function AnnouncementBanner() {
   const { data: announcements } = useQuery({
     queryKey: ["announcements", "active"],
     queryFn: getActiveAnnouncements,
-    staleTime: 60_000,
+    staleTime: STALE_TIME.LONG,
   });
 
   const [dismissed, setDismissed] = useState<Set<string>>(loadDismissed);


### PR DESCRIPTION
## 관련 이슈

Closes #188

## 변경 사항

- 6곳에 산재된 staleTime 매직 넘버를 `shared/config/query.ts`의 `STALE_TIME` 상수(`NONE`/`SHORT`/`LONG`/`IMMUTABLE`)로 중앙화
- `design-system.md`의 translate arbitrary 표기(`[2px]`/`[4px]`/`[6px]`)를 코드와 동일한 Tailwind 스케일(`0.5`/`1`/`1.5`)로 수렴

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다