### PR TITLE
feat: 프론트엔드 모바일 반응형

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -263,7 +263,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **1등 배지**: 트로피 SVG 아이콘 (`text-black`)
 - **배지 색상**: 1등=`yellow-400/300`, 2등=`slate-300/400`, 3등=`amber-600/500 text-white`. 4+등=`gray-200/700`
 - **라이브 인디케이터**: `live-pulse` 애니메이션 (초록 펄스 도트) + `sseConnectionCount` (Zustand store, HEARTBEAT 기반)
-- **재생/정지 버튼**: `border-2 shadow-brutal-sm-hover w-7 h-7`. 호버 시 `-top-7` 위치 툴팁 (재생/정지)
+- **재생/정지 버튼**: `border-2 shadow-brutal-sm-hover w-7 h-7`. 호버 시 `-top-7 right-0` 우측 기준 툴팁 (재생/정지)
 
 ### 플레이 방법 모달
 
@@ -312,6 +312,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **상태 분기**: (1) 비로그인 → 로그인 유도 (2) bestSimilarity < 60 → 잠금 안내 (3) 빈 목록 (4) 힌트 목록 (스포일러 처리)
 - **스포일러**: 힌트 목록 기본 `blur-sm` 처리. 클릭 시 전체 해제. 새로고침 시 자동 리셋 (React state, localStorage 미사용)
 - **행 구분선**: `border-b-2 border-black/20 dark:border-white/20` (마지막 항목 제외)
+- **HintRow 툴팁**: `line-clamp-2` + `scrollHeight > clientHeight` 검출 시 hover + click(터치) 커스텀 툴팁 (네이티브 `title` 미사용). 데스크톱 hover와 모바일 터치 모두 지원
 - **갱신**: 매 추측 시 `["game", "hints", sentenceId]` invalidate + `staleTime: 60_000`
 - **힌트 범위**: 요청자의 bestSimilarity 미만 추측만 표시 (서버측 필터링)
 
@@ -333,7 +334,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **텍스트 링크 액션**: 테이블 행 내 액션은 `text-indigo-600 dark:text-indigo-400 font-black text-xs hover:underline`
 - **Pagination**: `Button sm secondary` 이전/다음 + `tabular-nums` 페이지 표시
 - **공지 유형 라벨**: 안내(blue-300), 점검(orange-300), 경고(red-500). select에서도 한글 라벨 사용. SoT는 `shared/config/announcement.ts`
-- **공지 배너**: `shared/ui/AnnouncementBanner.tsx`. 유형별 색상 배경 + `shadow-brutal-sm`. 닫기 시 localStorage `id_startsAt` 복합 키 저장
+- **공지 배너**: `shared/ui/AnnouncementBanner.tsx`. 유형별 색상 배경 + `shadow-brutal-sm`. content `break-words` (긴 단어 wrap). 닫기 버튼 `-m-3 p-3` 터치 타겟 확보. 닫기 시 localStorage `id_startsAt` 복합 키 저장
 
 ## 11. 반응형 (Responsive)
 
@@ -384,6 +385,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 | 페이지 제목 | `text-2xl` | `md:text-4xl` |
 | 섹션 제목 | `text-xl` | `md:text-2xl` |
 | HintMask 텍스트 | `text-xl` | `md:text-2xl` |
+| GameClearedCard | `text-2xl` | `md:text-3xl` |
 
 ### Toast
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -14,6 +14,7 @@
 8. [페이지 구성](#8-페이지-구성)
 9. [로그인 프로바이더 색상](#9-로그인-프로바이더-색상)
 10. [컴포넌트 규칙](#10-컴포넌트-규칙) — 버튼, 입력창, 카드, 다이얼로그, 푸터, 랭킹, 모달, 프로필, 추측 피드백, 힌트, 어드민
+11. [반응형](#11-반응형-responsive)
 
 ---
 
@@ -137,8 +138,8 @@ hue = (similarity / 100) × 120
 
 | 용도        | 클래스                                     |
 | ----------- | ------------------------------------------ |
-| 페이지 제목 | `text-4xl font-black`                      |
-| 섹션 제목   | `text-2xl font-extrabold`                  |
+| 페이지 제목 | `text-2xl md:text-4xl font-black`          |
+| 섹션 제목   | `text-xl md:text-2xl font-extrabold`       |
 | 유사도 수치 | `text-3xl font-black tabular-nums`         |
 | 본문        | `text-base font-medium`                    |
 | 보조 텍스트 | `text-sm text-gray-600 dark:text-gray-400` |
@@ -147,10 +148,10 @@ hue = (similarity / 100) × 120
 
 ## 7. Layout (레이아웃)
 
-- **PC 전용**: 최소 너비 기준 설계, 모바일 미지원
-- **반응형**: 화면 크기에 따라 유연하게 조절 (넓은 모니터에서도 자연스럽게)
+- **반응형**: mobile-first. `md:` (768px) breakpoint 기준. 접두사 없는 클래스 = 모바일, `md:` = 데스크톱
 - **최대 너비**: 게임 영역은 `max-w-2xl` 또는 `max-w-3xl` 중앙 정렬
 - **간격**: Tailwind 기본 spacing 사용 (`p-4`, `gap-4`, `space-y-4` 등)
+- **어드민**: `/admin`은 데스크톱 전용 (반응형 미적용)
 
 ## 8. 페이지 구성
 
@@ -333,3 +334,58 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **Pagination**: `Button sm secondary` 이전/다음 + `tabular-nums` 페이지 표시
 - **공지 유형 라벨**: 안내(blue-300), 점검(orange-300), 경고(red-500). select에서도 한글 라벨 사용. SoT는 `shared/config/announcement.ts`
 - **공지 배너**: `shared/ui/AnnouncementBanner.tsx`. 유형별 색상 배경 + `shadow-brutal-sm`. 닫기 시 localStorage `id_startsAt` 복합 키 저장
+
+## 11. 반응형 (Responsive)
+
+### Breakpoint
+
+- `md:` (768px) 단일 breakpoint. Tailwind 기본값
+- mobile-first: 접두사 없는 클래스 = 모바일, `md:` = 데스크톱 오버라이드
+- 어드민(`/admin`)은 대상 제외 (데스크톱 전용)
+
+### 패딩 축소
+
+| 대상 | 모바일 | 데스크톱 |
+|------|--------|----------|
+| Layout main | `px-4 py-6` | `md:px-6 md:py-8` |
+| Card | `p-4` | `md:p-6` |
+| Dialog 헤더/콘텐츠 | `px-4 py-4` | `md:px-6 md:py-5` |
+| Dialog 푸터 | `px-4 py-3` | `md:px-6 md:py-4` |
+| Dialog 패널 | `mx-4` | `md:mx-0` |
+| Footer | `px-4 py-4` | `md:px-6 md:py-6` |
+| Header | `px-4 py-3` | `md:px-6 md:py-4` |
+
+### 헤더
+
+- 데스크톱: 우측 버튼 그룹 (`hidden md:flex`)
+- 모바일: 햄버거 버튼 (`md:hidden`) + 드롭다운 메뉴 (`border-b-4 border-x-4 shadow-brutal`)
+- 라우트 변경 시 자동 닫기, 외부 클릭 닫기
+
+### HomePage (게임)
+
+- 데스크톱: 사이드 패널(좌) + 게임(우) 2단 (`flex-row`)
+- 모바일: 게임(상) -> 사이드 패널(하) 1단 스택 (`flex-col`, `order-2`)
+
+### LoginPage
+
+- 데스크톱: 소셜 + 세로 구분선 + 가까워 2단 (`flex-row`)
+- 모바일: 소셜 -> 가로 구분선("또는") -> 가까워 1단 스택 (`flex-col`)
+- 세로 구분선: `hidden md:flex` / 가로 구분선: `flex md:hidden`
+
+### Footer
+
+- 데스크톱: 좌우 배치 (`flex-row justify-between`)
+- 모바일: 세로 스택 (`flex-col gap-4`), 링크 `flex-wrap`
+
+### 타이포그래피
+
+| 용도 | 모바일 | 데스크톱 |
+|------|--------|----------|
+| 페이지 제목 | `text-2xl` | `md:text-4xl` |
+| 섹션 제목 | `text-xl` | `md:text-2xl` |
+| HintMask 텍스트 | `text-xl` | `md:text-2xl` |
+
+### Toast
+
+- 모바일: `bottom-4 right-4 left-4` (전체 너비)
+- 데스크톱: `md:left-auto md:bottom-6 md:right-6` (우측 하단)

--- a/frontend/src/app/layout/Footer.tsx
+++ b/frontend/src/app/layout/Footer.tsx
@@ -18,8 +18,8 @@ const linkClassName =
 export function Footer() {
   return (
     <footer className="border-t-4 border-black dark:border-white bg-white dark:bg-gray-950">
-      <div className="max-w-6xl mx-auto px-6 py-6 flex items-center justify-between">
-        <div className="flex items-center gap-4">
+      <div className="max-w-6xl mx-auto px-4 py-4 md:px-6 md:py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-wrap items-center gap-3 md:gap-4">
           <span className="text-sm font-bold text-gray-600 dark:text-gray-400">© 2026 가까워</span>
           {LEGAL_LINKS.map((link) => (
             <Link key={link.to} to={link.to} className={linkClassName}>
@@ -28,7 +28,7 @@ export function Footer() {
           ))}
         </div>
 
-        <nav className="flex items-center gap-4">
+        <nav className="flex flex-wrap items-center gap-3 md:gap-4">
           {EXTERNAL_LINKS.map((link) => (
             <a
               key={link.href}

--- a/frontend/src/app/layout/Header.tsx
+++ b/frontend/src/app/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { getLastProvider, PROVIDER_COLORS } from "@/shared/config/providers";
@@ -6,10 +6,16 @@ import { KakaoIcon, GoogleIcon, NaverIcon, GakkaweoIcon } from "@/shared/config/
 import { hasAdminAccess } from "@/shared/utils/role";
 import { SettingsModal } from "@/app/layout/SettingsModal";
 
+const SM_BUTTON =
+  "border-4 border-black dark:border-white px-3 py-1.5 text-sm font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]";
+
 export function Header() {
   const { user, isAuthenticated } = useAuthStore();
   const location = useLocation();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [trackedPath, setTrackedPath] = useState(location.pathname);
+  const menuRef = useRef<HTMLDivElement>(null);
   const isAdmin = hasAdminAccess(user?.role);
   const provider = getLastProvider();
   const providerColors = provider ? PROVIDER_COLORS[provider] : null;
@@ -17,10 +23,32 @@ export function Header() {
     ? { kakao: KakaoIcon, google: GoogleIcon, naver: NaverIcon, local: GakkaweoIcon }[provider]
     : null;
 
+  if (location.pathname !== trackedPath) {
+    setTrackedPath(location.pathname);
+    setIsMenuOpen(false);
+  }
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    function handleMouseDown(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, [isMenuOpen]);
+
   return (
     <>
-      <header className="border-b-4 border-black dark:border-white bg-white dark:bg-gray-950">
-        <div className="max-w-6xl mx-auto flex items-center justify-between px-6 py-4">
+      <header className="relative border-b-4 border-black dark:border-white bg-white dark:bg-gray-950">
+        <div className="max-w-6xl mx-auto flex items-center justify-between px-4 py-3 md:px-6 md:py-4">
           <Link
             to="/"
             className="flex items-center gap-2 text-2xl font-black text-black dark:text-white tracking-tight"
@@ -29,11 +57,11 @@ export function Header() {
             가까워
           </Link>
 
-          <div className="flex items-center gap-3">
+          <div className="hidden md:flex items-center gap-3">
             <button
               type="button"
               onClick={() => setIsSettingsOpen(true)}
-              className="border-4 border-black dark:border-white bg-white dark:bg-gray-950 text-black dark:text-white px-3 py-1.5 text-sm font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]"
+              className={`${SM_BUTTON} bg-white dark:bg-gray-950 text-black dark:text-white`}
               aria-label="설정"
             >
               설정
@@ -43,7 +71,7 @@ export function Header() {
               <Link
                 to="/admin"
                 className={[
-                  "border-4 border-black dark:border-white px-3 py-1.5 text-sm font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]",
+                  SM_BUTTON,
                   location.pathname.startsWith("/admin") ? "bg-red-400 text-black" : "bg-red-200 text-black",
                 ].join(" ")}
               >
@@ -55,7 +83,7 @@ export function Header() {
               <Link
                 to="/mypage"
                 className={[
-                  "inline-flex items-center gap-1.5 border-4 border-black dark:border-white px-3 py-1.5 text-sm font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]",
+                  `inline-flex items-center gap-1.5 ${SM_BUTTON}`,
                   providerColors ? `${providerColors.bg} ${providerColors.text}` : "bg-yellow-300 text-black",
                 ].join(" ")}
               >
@@ -67,12 +95,77 @@ export function Header() {
                 {user.nickname}
               </Link>
             ) : (
-              <Link
-                to="/login"
-                className="border-4 border-black dark:border-white bg-green-400 px-4 py-1.5 text-sm font-bold text-black shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]"
-              >
+              <Link to="/login" className={`${SM_BUTTON} bg-green-400 text-black`}>
                 로그인
               </Link>
+            )}
+          </div>
+
+          <div className="md:hidden" ref={menuRef}>
+            <button
+              type="button"
+              onClick={() => setIsMenuOpen((prev) => !prev)}
+              className={`${SM_BUTTON} bg-white dark:bg-gray-950 text-black dark:text-white`}
+              aria-label={isMenuOpen ? "메뉴 닫기" : "메뉴 열기"}
+              aria-expanded={isMenuOpen}
+            >
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                {isMenuOpen ? (
+                  <path d="M5.293 5.293a1 1 0 011.414 0L10 8.586l3.293-3.293a1 1 0 111.414 1.414L11.414 10l3.293 3.293a1 1 0 01-1.414 1.414L10 11.414l-3.293 3.293a1 1 0 01-1.414-1.414L8.586 10 5.293 6.707a1 1 0 010-1.414z" />
+                ) : (
+                  <path d="M3 5h14a1 1 0 010 2H3a1 1 0 010-2zm0 4h14a1 1 0 010 2H3a1 1 0 010-2zm0 4h14a1 1 0 010 2H3a1 1 0 010-2z" />
+                )}
+              </svg>
+            </button>
+
+            {isMenuOpen && (
+              <div className="absolute right-0 left-0 border-b-4 border-x-4 border-black dark:border-white bg-white dark:bg-gray-950 shadow-brutal z-40">
+                <div className="flex flex-col p-3 gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsMenuOpen(false);
+                      setIsSettingsOpen(true);
+                    }}
+                    className={`w-full ${SM_BUTTON} bg-white dark:bg-gray-950 text-black dark:text-white text-left`}
+                  >
+                    설정
+                  </button>
+
+                  {isAdmin && (
+                    <Link
+                      to="/admin"
+                      className={[
+                        `w-full block ${SM_BUTTON}`,
+                        location.pathname.startsWith("/admin") ? "bg-red-400 text-black" : "bg-red-200 text-black",
+                      ].join(" ")}
+                    >
+                      관리
+                    </Link>
+                  )}
+
+                  {isAuthenticated && user ? (
+                    <Link
+                      to="/mypage"
+                      className={[
+                        `w-full inline-flex items-center gap-1.5 ${SM_BUTTON}`,
+                        providerColors ? `${providerColors.bg} ${providerColors.text}` : "bg-yellow-300 text-black",
+                      ].join(" ")}
+                    >
+                      {ProviderIcon && (
+                        <span className="flex items-center justify-center shrink-0">
+                          <ProviderIcon size={14} />
+                        </span>
+                      )}
+                      {user.nickname}
+                    </Link>
+                  ) : (
+                    <Link to="/login" className={`w-full block ${SM_BUTTON} bg-green-400 text-black`}>
+                      로그인
+                    </Link>
+                  )}
+                </div>
+              </div>
             )}
           </div>
         </div>

--- a/frontend/src/app/layout/Layout.tsx
+++ b/frontend/src/app/layout/Layout.tsx
@@ -19,7 +19,7 @@ export function Layout() {
     <div className="flex flex-col min-h-screen bg-white dark:bg-gray-950 text-black dark:text-white">
       <Header />
 
-      <main className="flex-1 max-w-6xl w-full mx-auto px-6 py-8">
+      <main className="flex-1 max-w-6xl w-full mx-auto px-4 py-6 md:px-6 md:py-8">
         <AnnouncementBanner />
         <Outlet />
       </main>
@@ -27,7 +27,7 @@ export function Layout() {
       <Footer />
 
       {toasts.length > 0 && (
-        <div className="fixed bottom-6 right-6 flex flex-col gap-3 z-50">
+        <div className="fixed bottom-4 right-4 left-4 md:left-auto md:bottom-6 md:right-6 flex flex-col gap-3 z-50">
           {toasts.map((toast) => (
             <button
               type="button"

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -71,11 +71,11 @@ export function LoginPage() {
   return (
     <div className="max-w-2xl mx-auto space-y-6">
       <div className="space-y-2">
-        <h1 className="text-4xl font-black">로그인</h1>
+        <h1 className="text-2xl md:text-4xl font-black">로그인</h1>
         <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">소셜 또는 가까워 계정으로 시작하세요</p>
       </div>
 
-      <div className="flex gap-6 items-stretch">
+      <div className="flex flex-col md:flex-row gap-6 md:items-stretch">
         <Card className="flex-1 space-y-4">
           <h2 className="text-lg font-extrabold">소셜 로그인</h2>
           <p
@@ -119,10 +119,16 @@ export function LoginPage() {
           </div>
         </Card>
 
-        <div className="flex flex-col items-center gap-4">
+        <div className="hidden md:flex flex-col items-center gap-4">
           <div className="flex-1 border-l-2 border-gray-300 dark:border-gray-700" />
           <span className="text-sm font-bold text-gray-400">또는</span>
           <div className="flex-1 border-l-2 border-gray-300 dark:border-gray-700" />
+        </div>
+
+        <div className="flex md:hidden items-center gap-4">
+          <div className="flex-1 border-t-2 border-gray-300 dark:border-gray-700" />
+          <span className="text-sm font-bold text-gray-400">또는</span>
+          <div className="flex-1 border-t-2 border-gray-300 dark:border-gray-700" />
         </div>
 
         <Card className="flex-1 space-y-4">

--- a/frontend/src/features/auth/MyPage.tsx
+++ b/frontend/src/features/auth/MyPage.tsx
@@ -139,7 +139,7 @@ export function MyPage() {
 
   return (
     <div className="max-w-md mx-auto space-y-6">
-      <h1 className="text-4xl font-black">마이페이지</h1>
+      <h1 className="text-2xl md:text-4xl font-black">마이페이지</h1>
 
       <Card className="flex flex-col items-center space-y-4 py-8">
         <div className="relative">

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -240,7 +240,7 @@ export function GamePage() {
     const message = todayError instanceof ApiError ? todayError.message : "문제를 불러올 수 없습니다.";
     return (
       <div className="max-w-2xl flex-1 min-w-0 space-y-6">
-        <h1 className="text-4xl font-black">오늘의 문장</h1>
+        <h1 className="text-2xl md:text-4xl font-black">오늘의 문장</h1>
         <Card>
           <p className="text-lg font-bold text-red-500">{message}</p>
         </Card>
@@ -254,10 +254,10 @@ export function GamePage() {
 
   return (
     <div className="max-w-2xl flex-1 min-w-0 space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-4xl font-black">오늘의 문장</h1>
-        <div className="flex items-center gap-3">
-          <span className="text-sm font-bold text-gray-600 dark:text-gray-400">
+      <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+        <h1 className="text-2xl md:text-4xl font-black">오늘의 문장</h1>
+        <div className="flex items-center gap-2 md:gap-3">
+          <span className="text-xs md:text-sm font-bold text-gray-600 dark:text-gray-400 whitespace-nowrap">
             {isExpired ? (
               "새 문장 준비 중..."
             ) : (
@@ -269,7 +269,7 @@ export function GamePage() {
           <button
             type="button"
             onClick={() => setIsHelpOpen(true)}
-            className="border-2 border-black dark:border-white bg-yellow-300 text-black px-2 py-0.5 text-xs font-black shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]"
+            className="shrink-0 border-2 border-black dark:border-white bg-yellow-300 text-black px-2 py-0.5 text-xs font-black shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]"
             aria-label="플레이 방법"
           >
             플레이 방법

--- a/frontend/src/features/game/components/GameClearedCard.tsx
+++ b/frontend/src/features/game/components/GameClearedCard.tsx
@@ -9,7 +9,7 @@ export function GameClearedCard({ attemptCount, bestSimilarity }: GameClearedCar
   return (
     <Card className="!bg-green-50 dark:!bg-green-950">
       <div className="space-y-2 text-center">
-        <p className="text-3xl font-black">🎉 정답!</p>
+        <p className="text-2xl md:text-3xl font-black">🎉 정답!</p>
         <p className="text-lg font-bold">{attemptCount}회 만에 맞추셨습니다!</p>
         <p className="text-base font-medium text-gray-600 dark:text-gray-400">
           최고 유사도: {bestSimilarity.toFixed(1)}%

--- a/frontend/src/features/game/components/GuessHistory.tsx
+++ b/frontend/src/features/game/components/GuessHistory.tsx
@@ -29,7 +29,7 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-extrabold">추측 기록</h2>
+        <h2 className="text-xl md:text-2xl font-extrabold">추측 기록</h2>
         {totalPages > 1 && (
           <div className="flex items-center gap-2">
             <button
@@ -59,13 +59,13 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
         {pageGuesses.map((guess, i) => (
           <div
             key={`${guess.attemptNumber ?? total - (safePage * PAGE_SIZE + i)}-${guess.guessText}`}
-            className="flex items-center justify-between border-4 border-black dark:border-white shadow-brutal bg-white dark:bg-gray-900 p-3"
+            className="flex items-center justify-between border-4 border-black dark:border-white shadow-brutal bg-white dark:bg-gray-900 p-2 md:p-3"
           >
             <div className="flex items-center gap-3">
               <span className="text-sm font-bold text-gray-500 dark:text-gray-400 tabular-nums shrink-0">
                 #{guess.attemptNumber ?? total - (safePage * PAGE_SIZE + i)}
               </span>
-              <span className="font-medium">{guess.guessText}</span>
+              <span className="font-medium min-w-0 break-words">{guess.guessText}</span>
             </div>
             <SimilarityBadge similarity={guess.similarity} />
           </div>

--- a/frontend/src/features/game/components/GuessInput.tsx
+++ b/frontend/src/features/game/components/GuessInput.tsx
@@ -44,7 +44,7 @@ export function GuessInput({ onSubmit, isLoading, disabled = false }: GuessInput
 
   return (
     <div ref={wrapperRef} className="space-y-2">
-      <div className="flex gap-3">
+      <div className="flex gap-2 md:gap-3">
         <Input
           value={text}
           onChange={(e) => setText(e.target.value)}

--- a/frontend/src/features/game/components/HelpModal.tsx
+++ b/frontend/src/features/game/components/HelpModal.tsx
@@ -120,7 +120,7 @@ export function HelpModal({ isOpen, onClose }: HelpModalProps) {
           </li>
           <li className="flex gap-2">
             <span className="shrink-0 font-black">·</span>
-            <span>좌측 패널에서 확인할 수 있습니다 (로그인 필요)</span>
+            <span>좌측 패널에서 확인할 수 있습니다 (모바일: 하단, 로그인 필요)</span>
           </li>
         </ul>
       </section>

--- a/frontend/src/features/game/components/HintMask.tsx
+++ b/frontend/src/features/game/components/HintMask.tsx
@@ -7,10 +7,10 @@ export function HintMask({ hintMask, charCounts }: HintMaskProps) {
   const words = hintMask.split(" ");
 
   return (
-    <div className="flex flex-wrap gap-4 items-end">
+    <div className="flex flex-wrap gap-2 md:gap-4 items-end">
       {words.map((word, i) => (
         <div key={i} className="flex flex-col items-center gap-1">
-          <span className="text-2xl font-black tracking-widest">{word}</span>
+          <span className="text-xl md:text-2xl font-black tracking-widest">{word}</span>
           <span className="text-xs font-medium text-gray-500 dark:text-gray-400">{charCounts[i]}글자</span>
         </div>
       ))}

--- a/frontend/src/features/game/components/HintPanel.tsx
+++ b/frontend/src/features/game/components/HintPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
 import type { HintEntry } from "@/shared/api/types";
 import { Card } from "@/shared/ui/Card";
 import { SimilarityBadge } from "@/shared/ui/SimilarityBadge";
@@ -32,13 +33,26 @@ function HintRow({ hint, isLast }: { hint: HintEntry; isLast: boolean }) {
       className={[
         "relative flex items-start justify-between gap-2 py-2",
         isLast ? "" : "border-b-2 border-black/20 dark:border-white/20",
+        isTruncated ? "cursor-pointer" : "",
       ].join(" ")}
+      role={isTruncated ? "button" : undefined}
+      tabIndex={isTruncated ? 0 : undefined}
       onClick={() => {
         if (isTruncated) {
           setIsTooltipOpen((prev) => !prev);
         }
       }}
-      onMouseEnter={() => setIsTooltipOpen(true)}
+      onKeyDown={(e: KeyboardEvent) => {
+        if (isTruncated && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          setIsTooltipOpen((prev) => !prev);
+        }
+      }}
+      onMouseEnter={() => {
+        if (isTruncated) {
+          setIsTooltipOpen(true);
+        }
+      }}
       onMouseLeave={() => setIsTooltipOpen(false)}
     >
       <span ref={textRef} className="text-sm font-medium line-clamp-2 break-all">

--- a/frontend/src/features/game/components/HintPanel.tsx
+++ b/frontend/src/features/game/components/HintPanel.tsx
@@ -17,7 +17,7 @@ function SkeletonRow() {
 function HintRow({ hint, isLast }: { hint: HintEntry; isLast: boolean }) {
   const textRef = useRef<HTMLSpanElement>(null);
   const [isTruncated, setIsTruncated] = useState(false);
-  const [isHover, setIsHover] = useState(false);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
   useEffect(() => {
     const el = textRef.current;
@@ -33,8 +33,13 @@ function HintRow({ hint, isLast }: { hint: HintEntry; isLast: boolean }) {
         "relative flex items-start justify-between gap-2 py-2",
         isLast ? "" : "border-b-2 border-black/20 dark:border-white/20",
       ].join(" ")}
-      onMouseEnter={() => setIsHover(true)}
-      onMouseLeave={() => setIsHover(false)}
+      onClick={() => {
+        if (isTruncated) {
+          setIsTooltipOpen((prev) => !prev);
+        }
+      }}
+      onMouseEnter={() => setIsTooltipOpen(true)}
+      onMouseLeave={() => setIsTooltipOpen(false)}
     >
       <span ref={textRef} className="text-sm font-medium line-clamp-2 break-all">
         {hint.guessText}
@@ -42,7 +47,7 @@ function HintRow({ hint, isLast }: { hint: HintEntry; isLast: boolean }) {
       <span className="shrink-0">
         <SimilarityBadge similarity={hint.similarity} />
       </span>
-      {isTruncated && isHover && (
+      {isTruncated && isTooltipOpen && (
         <div
           role="tooltip"
           className="absolute z-20 inset-x-0 top-full mt-1 border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal-sm px-3 py-2 text-sm font-medium break-all"

--- a/frontend/src/features/game/components/YesterdayAnswer.tsx
+++ b/frontend/src/features/game/components/YesterdayAnswer.tsx
@@ -7,7 +7,7 @@ export function YesterdayAnswer({ sentence, date }: YesterdayAnswerProps) {
   return (
     <div className="border-4 border-black dark:border-white shadow-brutal bg-indigo-50 dark:bg-gray-800 p-4">
       <p className="text-sm font-medium text-gray-600 dark:text-gray-400">어제의 정답 ({date})</p>
-      <p className="text-lg font-extrabold mt-1">{sentence}</p>
+      <p className="text-lg font-extrabold mt-1 break-words">{sentence}</p>
     </div>
   );
 }

--- a/frontend/src/features/ranking/components/RankingPanel.tsx
+++ b/frontend/src/features/ranking/components/RankingPanel.tsx
@@ -97,7 +97,7 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
             aria-label={isPaused ? "자동 순환 시작" : "자동 순환 정지"}
           >
             {isPaused ? "▶" : "❚❚"}
-            <span className="absolute -top-7 left-1/2 -translate-x-1/2 hidden group-hover:block bg-black dark:bg-white text-white dark:text-black text-[10px] font-bold px-1.5 py-0.5 whitespace-nowrap z-50">
+            <span className="absolute -top-7 right-0 hidden group-hover:block bg-black dark:bg-white text-white dark:text-black text-[10px] font-bold px-1.5 py-0.5 whitespace-nowrap z-50">
               {isPaused ? "재생" : "정지"}
             </span>
           </button>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -17,8 +17,8 @@ export function HomePage() {
   const { data: hints, isLoading: hintsLoading } = useHints(sentenceId, bestSimilarity);
 
   return (
-    <div className="flex gap-6 items-start">
-      <div className="w-72 shrink-0 space-y-6">
+    <div className="flex flex-col md:flex-row gap-6 md:items-start">
+      <div className="order-2 md:order-none w-full md:w-72 md:shrink-0 space-y-6">
         <RankingPanel ranking={ranking} isLoading={rankingLoading} />
         <HintPanel
           hints={hints?.hints ?? []}

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -7,7 +7,7 @@ export function NotFoundPage() {
 
   return (
     <div className="max-w-md mx-auto space-y-6 text-center">
-      <h1 className="text-6xl font-black">404</h1>
+      <h1 className="text-4xl md:text-6xl font-black">404</h1>
       <Card>
         <p className="text-lg font-medium mb-6">페이지를 찾을 수 없습니다</p>
         <Button variant="primary" onClick={() => navigate("/")}>

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -19,7 +19,7 @@ export function PrivacyPolicyPage() {
   return (
     <div className="max-w-3xl mx-auto space-y-6">
       <div className="space-y-2">
-        <h1 className="text-4xl font-black">개인정보 처리방침</h1>
+        <h1 className="text-2xl md:text-4xl font-black">개인정보 처리방침</h1>
         <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">시행일: {EFFECTIVE_DATE}</p>
       </div>
 

--- a/frontend/src/pages/TermsOfServicePage.tsx
+++ b/frontend/src/pages/TermsOfServicePage.tsx
@@ -19,7 +19,7 @@ export function TermsOfServicePage() {
   return (
     <div className="max-w-3xl mx-auto space-y-6">
       <div className="space-y-2">
-        <h1 className="text-4xl font-black">서비스 이용약관</h1>
+        <h1 className="text-2xl md:text-4xl font-black">서비스 이용약관</h1>
         <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">시행일: {EFFECTIVE_DATE}</p>
       </div>
 

--- a/frontend/src/shared/ui/AnnouncementBanner.tsx
+++ b/frontend/src/shared/ui/AnnouncementBanner.tsx
@@ -47,14 +47,16 @@ function BannerItem({
       <div className="flex-1 min-w-0">
         <p className="font-black text-sm">{announcement.title}</p>
         {announcement.content && (
-          <p className="whitespace-pre-line text-xs font-medium mt-0.5 opacity-80">{announcement.content}</p>
+          <p className="whitespace-pre-line break-words text-xs font-medium mt-0.5 opacity-80">
+            {announcement.content}
+          </p>
         )}
       </div>
       <button
         type="button"
         onClick={() => onDismiss(toDismissKey(announcement))}
         aria-label="공지 닫기"
-        className="text-lg font-black leading-none shrink-0 hover:opacity-60 transition-opacity"
+        className="-m-3 p-3 text-lg font-black leading-none shrink-0 hover:opacity-60 transition-opacity"
       >
         &times;
       </button>

--- a/frontend/src/shared/ui/Card.tsx
+++ b/frontend/src/shared/ui/Card.tsx
@@ -9,7 +9,7 @@ export function Card({ children, className = "" }: CardProps) {
   return (
     <div
       className={[
-        "border-4 border-black dark:border-white rounded-none shadow-brutal bg-white dark:bg-gray-900 p-6",
+        "border-4 border-black dark:border-white rounded-none shadow-brutal bg-white dark:bg-gray-900 p-4 md:p-6",
         className,
       ].join(" ")}
     >

--- a/frontend/src/shared/ui/Dialog.tsx
+++ b/frontend/src/shared/ui/Dialog.tsx
@@ -92,12 +92,12 @@ export function Dialog({
       <div
         ref={panelRef}
         className={[
-          "border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-h-[85vh] flex flex-col",
+          "border-4 border-black dark:border-white bg-white dark:bg-gray-900 shadow-brutal w-full max-h-[85vh] flex flex-col mx-4 md:mx-0",
           maxWidth,
           className,
         ].join(" ")}
       >
-        <div className="flex items-center justify-between border-b-4 border-black dark:border-white px-6 py-5 shrink-0">
+        <div className="flex items-center justify-between border-b-4 border-black dark:border-white px-4 py-4 md:px-6 md:py-5 shrink-0">
           <h2 id={titleId} className="text-xl font-black">
             {title}
           </h2>
@@ -117,10 +117,12 @@ export function Dialog({
           </button>
         </div>
 
-        <div className="px-6 py-5 overflow-y-auto flex-1">{children}</div>
+        <div className="px-4 py-4 md:px-6 md:py-5 overflow-y-auto flex-1">{children}</div>
 
         {footer && (
-          <div className="flex gap-3 px-6 py-4 border-t-4 border-black dark:border-white shrink-0">{footer}</div>
+          <div className="flex gap-3 px-4 py-3 md:px-6 md:py-4 border-t-4 border-black dark:border-white shrink-0">
+            {footer}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## 관련 이슈

Closes #190

## 변경 사항

### Phase 1: 주요 레이아웃 반응형
- Header 햄버거 메뉴 (모바일) / 버튼 그룹 (데스크톱) 분기
- HomePage 2단(데스크톱) -> 1단 스택(모바일) 레이아웃 전환
- LoginPage 2컬럼 -> 1컬럼 스택 + 구분선 방향 전환
- Footer 좌우 배치 -> 세로 스택
- Layout/Card/Dialog/Header/Footer 패딩 반응형 축소
- 타이포그래피 반응형 (페이지 제목, 섹션 제목, HintMask)

### Phase 2: 세부 디테일 보강
- GameClearedCard 타이포그래피 반응형 (text-2xl md:text-3xl)
- YesterdayAnswer/AnnouncementBanner 긴 텍스트 break-words 추가
- GuessInput gap 모바일 축소 (gap-2 md:gap-3)
- HintPanel 툴팁 hover + click 토글 (모바일 터치 호환)
- AnnouncementBanner 닫기 버튼 터치 타겟 확보 (-m-3 p-3)
- RankingPanel 툴팁 우측 기준 정렬 (360px 클리핑 방지)
- design-system.md 11절 반응형 섹션 신설 + 10절 컴포넌트 업데이트

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- Playwright 시각 검증: 360px / 375px / 768px, 라이트/다크 모두 확인
- 어드민(/admin)은 데스크톱 전용으로 반응형 대상 제외
- hover 잔류 문제(@media(hover:hover))는 별도 후속 이슈로 분리