### PR TITLE
refactor: hover:hover 검증 + FE 공통 정리

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -13,7 +13,7 @@
 7. [레이아웃](#7-layout-레이아웃)
 8. [페이지 구성](#8-페이지-구성)
 9. [로그인 프로바이더 색상](#9-로그인-프로바이더-색상)
-10. [컴포넌트 규칙](#10-컴포넌트-규칙) — 버튼, 입력창, 카드, 다이얼로그, 푸터, 랭킹, 모달, 프로필, 추측 피드백, 힌트, 어드민
+10. [컴포넌트 규칙](#10-컴포넌트-규칙) — 버튼, 입력창, 카드, 다이얼로그, 푸터, 랭킹, 모달, 프로필, 추측 피드백, 추측 기록, 힌트, 어드민
 11. [반응형](#11-반응형-responsive)
 
 ---
@@ -72,25 +72,41 @@ boxShadow: {
 
 ### md/lg 버튼 (shadow-brutal, 6px)
 
-| 상태           | 클래스                                                                      |
-| -------------- | --------------------------------------------------------------------------- |
-| 기본           | `shadow-brutal`                                                             |
-| Hover          | `hover:shadow-brutal-hover hover:translate-x-1 hover:translate-y-1`         |
-| Active (Click) | `active:shadow-none active:translate-x-1.5 active:translate-y-1.5`          |
+| 상태           | 클래스                                                                                        |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| 기본           | `shadow-brutal`                                                                               |
+| Hover          | `hover:shadow-brutal-hover hover:translate-x-1 hover:translate-y-1`                           |
+| Active (Click) | `active:shadow-none active:translate-x-1.5 active:translate-y-1.5`                            |
 | Disabled       | `opacity-50 cursor-not-allowed pointer-events-none translate-x-0 translate-y-0` (그림자 유지) |
-| Loading        | `opacity-70 cursor-wait shadow-brutal animate-pulse`                        |
+| Loading        | `opacity-70 cursor-wait shadow-brutal animate-pulse`                                          |
 
 ### sm 버튼 (shadow-brutal-sm, 3px)
 
-| 상태           | 클래스                                                                         |
-| -------------- | ------------------------------------------------------------------------------ |
-| 기본           | `shadow-brutal-sm`                                                             |
-| Hover          | `hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5`    |
-| Active (Click) | `active:shadow-none active:translate-x-[3px] active:translate-y-[3px]`         |
+| 상태           | 클래스                                                                                        |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| 기본           | `shadow-brutal-sm`                                                                            |
+| Hover          | `hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5`                    |
+| Active (Click) | `active:shadow-none active:translate-x-[3px] active:translate-y-[3px]`                        |
 | Disabled       | `opacity-50 cursor-not-allowed pointer-events-none translate-x-0 translate-y-0` (그림자 유지) |
-| Loading        | `opacity-70 cursor-wait shadow-brutal-sm animate-pulse`                        |
+| Loading        | `opacity-70 cursor-wait shadow-brutal-sm animate-pulse`                                       |
 
 모든 상태 전환에는 `transition-all duration-100`을 적용하여 부드러운 전환을 준다.
+
+### 터치 디바이스 hover 보호 (Tailwind v4)
+
+Tailwind v4는 `hover:` 변형을 `@media (hover: hover)` 안에 래핑한다. 터치 디바이스에서는 hover 상태가 발화하지 않으며, `active:` 상태가 press 피드백을 제공한다.
+
+- `@custom-variant hover (&:hover);` 등으로 hover 보호를 무력화하지 않는다
+- `group-hover:`로만 표시되는 요소는 터치 디바이스에서 보이지 않으므로, hover-only 힌트에 의존하지 않는다
+- 모바일에서 반드시 보여야 하는 요소는 `opacity-100 md:opacity-0 md:group-hover:opacity-100` 패턴 사용
+
+### 공용 훅/컴포넌트
+
+| 이름              | 경로                              | 용도                                                                 |
+| ----------------- | --------------------------------- | -------------------------------------------------------------------- |
+| `useClickOutside` | `shared/hooks/useClickOutside.ts` | click-outside 닫기. `disabled`, `excludeRefs` 옵션                   |
+| `SkeletonRow`     | `shared/ui/SkeletonRow.tsx`       | 로딩 스켈레톤. `height`, `className` props                           |
+| `MobileSideSheet` | `shared/ui/MobileSideSheet.tsx`   | 모바일 전용 오른쪽 드로어. 플로팅 트리거 + 슬라이드 인/아웃 + 백드롭 |
 
 ## 4. Color Palette (색상 규정)
 
@@ -155,25 +171,25 @@ hue = (similarity / 100) × 120
 
 ## 8. 페이지 구성
 
-| 페이지     | 경로       | 설명                                          |
-| ---------- | ---------- | --------------------------------------------- |
-| 게임       | `/`        | 추측 입력, 유사도 결과, 히스토리, 힌트 마스크, 랭킹 패널 (좌측) |
-| 로그인     | `/login`   | 소셜 로그인 + 로컬 로그인 2컬럼 + 회원가입 다이얼로그 |
-| 마이페이지 | `/mypage`  | 프로필 이미지 업로드/삭제, 닉네임 확인 (✏️ 편집), 회원 탈퇴 |
-| 어드민     | `/admin`   | 사이드바+탭 레이아웃 (대시보드/문장/사용자/시스템). ROLE_ADMIN만 접근 |
-| 개인정보 처리방침 | `/privacy` | 개인정보 수집/이용/보호 방침 |
-| 서비스 이용약관 | `/terms` | 서비스 이용 조건 및 규정 |
+| 페이지            | 경로       | 설명                                                                  |
+| ----------------- | ---------- | --------------------------------------------------------------------- |
+| 게임              | `/`        | 추측 입력, 유사도 결과, 히스토리, 힌트 마스크, 랭킹 패널 (좌측)       |
+| 로그인            | `/login`   | 소셜 로그인 + 로컬 로그인 2컬럼 + 회원가입 다이얼로그                 |
+| 마이페이지        | `/mypage`  | 프로필 이미지 업로드/삭제, 닉네임 확인 (✏️ 편집), 회원 탈퇴           |
+| 어드민            | `/admin`   | 사이드바+탭 레이아웃 (대시보드/문장/사용자/시스템). ROLE_ADMIN만 접근 |
+| 개인정보 처리방침 | `/privacy` | 개인정보 수집/이용/보호 방침                                          |
+| 서비스 이용약관   | `/terms`   | 서비스 이용 조건 및 규정                                              |
 
 ## 9. 로그인 프로바이더 색상
 
 각 프로바이더의 공식 브랜드 가이드라인을 준수한다. 로컬 계정은 중립 색상 사용.
 
-| 프로바이더 | 라이트 배경 | 다크 배경      | 텍스트 (라이트)  | 텍스트 (다크)    |
-| ---------- | ----------- | -------------- | ---------------- | ---------------- |
-| 카카오     | `#FEE500`   | `#FEE500`      | `#191919`        | `#191919`        |
-| Google     | `#FFFFFF`   | `#131314`      | `#1F1F1F`        | `#E3E3E3`        |
-| 네이버     | `#03C75A`   | `#03C75A`      | `#FFFFFF`        | `#FFFFFF`        |
-| 가까워     | `gray-200`  | `gray-700`     | `black`          | `white`          |
+| 프로바이더 | 라이트 배경 | 다크 배경  | 텍스트 (라이트) | 텍스트 (다크) |
+| ---------- | ----------- | ---------- | --------------- | ------------- |
+| 카카오     | `#FEE500`   | `#FEE500`  | `#191919`       | `#191919`     |
+| Google     | `#FFFFFF`   | `#131314`  | `#1F1F1F`       | `#E3E3E3`     |
+| 네이버     | `#03C75A`   | `#03C75A`  | `#FFFFFF`       | `#FFFFFF`     |
+| 가까워     | `gray-200`  | `gray-700` | `black`         | `white`       |
 
 - 카카오/네이버는 라이트/다크 공통 배경 (브랜드 색상이 양쪽 모드에서 충분한 대비 제공)
 - Google만 다크모드 전용 배경 (`#131314`) 사용 — 공식 Sign-In 다크 테마 기준
@@ -229,16 +245,16 @@ dark:shadow-brutal-dark bg-white dark:bg-gray-900 p-6
 
 **Props**:
 
-| prop | 타입 | 기본값 | 설명 |
-|------|------|--------|------|
-| `isOpen` | `boolean` | `true` | `false`이면 null 반환. 부모에서 조건부 렌더링 시 생략 가능 |
-| `onClose` | `() => void` | 필수 | Escape/click-outside/X 버튼에 연결 |
-| `title` | `string` | 필수 | 헤더에 표시. `aria-labelledby` 자동 연결 (`useId()`) |
-| `children` | `ReactNode` | 필수 | 콘텐츠 영역 |
-| `footer` | `ReactNode` | - | 없으면 푸터 미렌더. 버튼 조합 전달 |
-| `maxWidth` | `string` | `"max-w-sm"` | 패널 최대 너비 (`max-w-md`, `max-w-lg` 등) |
-| `disableClose` | `boolean` | `false` | 로딩 중 Escape/click-outside/X 차단 |
-| `className` | `string` | `""` | 패널에 추가 클래스 |
+| prop           | 타입         | 기본값       | 설명                                                       |
+| -------------- | ------------ | ------------ | ---------------------------------------------------------- |
+| `isOpen`       | `boolean`    | `true`       | `false`이면 null 반환. 부모에서 조건부 렌더링 시 생략 가능 |
+| `onClose`      | `() => void` | 필수         | Escape/click-outside/X 버튼에 연결                         |
+| `title`        | `string`     | 필수         | 헤더에 표시. `aria-labelledby` 자동 연결 (`useId()`)       |
+| `children`     | `ReactNode`  | 필수         | 콘텐츠 영역                                                |
+| `footer`       | `ReactNode`  | -            | 없으면 푸터 미렌더. 버튼 조합 전달                         |
+| `maxWidth`     | `string`     | `"max-w-sm"` | 패널 최대 너비 (`max-w-md`, `max-w-lg` 등)                 |
+| `disableClose` | `boolean`    | `false`      | 로딩 중 Escape/click-outside/X 차단                        |
+| `className`    | `string`     | `""`         | 패널에 추가 클래스                                         |
 
 **기능**: Escape 키, click-outside, body scroll lock (모듈 레벨 카운터로 중첩 지원), `role="dialog" aria-modal="true" aria-labelledby`
 
@@ -252,7 +268,7 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 ```
 
 - 좌측: `© 2026 가까워` (`text-sm font-bold text-gray-600 dark:text-gray-400`)
-- 우측: 이용약관, 개인정보처리방침 (내부 Link), GitHub, Blog (외부 `<a>` target="_blank")
+- 우측: 이용약관, 개인정보처리방침 (내부 Link), GitHub, Blog (외부 `<a>` target="\_blank")
 - 링크: `text-sm font-bold text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white transition-colors`
 - Layout: `flex flex-col min-h-screen` + `<main>` `flex-1` (스티키 푸터)
 
@@ -303,6 +319,13 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 - **데이터 원천**: `displayGuesses` 파생 (추가 API 없음). 새로고침 시 history API → 자동 복원
 - **FE 정규화**: `normalizeGuessText()` — BE `TextNormalizer`와 동일 로직 (`[^가-힣a-zA-Z0-9\s]` 제거). 서버 호출 전 선검증
 
+### 추측 기록 (GuessHistory)
+
+- **제목**: "추측 기록" 항상 표시 (0개일 때도)
+- **5슬롯 고정**: 페이지당 5개. 부족한 슬롯은 invisible placeholder로 채워 레이아웃 시프트 방지
+- **placeholder**: 실제 아이템과 동일한 DOM 구조 (`border-4`, `p-2 md:p-3`, `SimilarityBadge` 크기 매칭). `invisible aria-hidden`
+- **페이지네이션**: `Button size="sm" variant="secondary"` (어드민 Pagination과 통일)
+
 ### 힌트 패널
 
 - **위치**: 좌측 칼럼, RankingPanel 아래. 부모 `div.w-72.shrink-0.space-y-6`이 RankingPanel + HintPanel 래핑
@@ -346,26 +369,34 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 
 ### 패딩 축소
 
-| 대상 | 모바일 | 데스크톱 |
-|------|--------|----------|
-| Layout main | `px-4 py-6` | `md:px-6 md:py-8` |
-| Card | `p-4` | `md:p-6` |
+| 대상               | 모바일      | 데스크톱          |
+| ------------------ | ----------- | ----------------- |
+| Layout main        | `px-4 py-6` | `md:px-6 md:py-8` |
+| Card               | `p-4`       | `md:p-6`          |
 | Dialog 헤더/콘텐츠 | `px-4 py-4` | `md:px-6 md:py-5` |
-| Dialog 푸터 | `px-4 py-3` | `md:px-6 md:py-4` |
-| Dialog 패널 | `mx-4` | `md:mx-0` |
-| Footer | `px-4 py-4` | `md:px-6 md:py-6` |
-| Header | `px-4 py-3` | `md:px-6 md:py-4` |
+| Dialog 푸터        | `px-4 py-3` | `md:px-6 md:py-4` |
+| Dialog 패널        | `mx-4`      | `md:mx-0`         |
+| Footer             | `px-4 py-4` | `md:px-6 md:py-6` |
+| Header             | `px-4 py-3` | `md:px-6 md:py-4` |
 
 ### 헤더
 
-- 데스크톱: 우측 버튼 그룹 (`hidden md:flex`)
-- 모바일: 햄버거 버튼 (`md:hidden`) + 드롭다운 메뉴 (`border-b-4 border-x-4 shadow-brutal`)
-- 라우트 변경 시 자동 닫기, 외부 클릭 닫기
+- 모바일/데스크톱 동일: 우측 인라인 버튼 그룹 (설정, 관리, 닉네임/로그인)
+- 햄버거 메뉴 없음
 
 ### HomePage (게임)
 
-- 데스크톱: 사이드 패널(좌) + 게임(우) 2단 (`flex-row`)
-- 모바일: 게임(상) -> 사이드 패널(하) 1단 스택 (`flex-col`, `order-2`)
+- 데스크톱: 사이드 패널(좌 w-72) + 게임(우) 2단 (`flex-row`)
+- 모바일: 게임만 표시. 사이드 패널(랭킹/힌트)은 `MobileSideSheet` 드로어로 접근
+
+### MobileSideSheet (모바일 드로어)
+
+- **트리거**: 화면 오른쪽 `top-[38%]` 고정 버튼 2개 (랭킹/힌트). `border-l-4 border-y-4`, hover 시 `bg-yellow-300`
+- **드로어**: 오른쪽에서 슬라이드 인 (`animate-slide-in-right`, w-72). 닫을 때 슬라이드 아웃 (`animate-slide-out-right`)
+- **백드롭**: `fixed inset-0 bg-black/40` (Dialog와 동일)
+- **헤더**: 제목 + ✕ 닫기 버튼. 하단에 랭킹/힌트 탭 전환 바
+- **닫기**: 백드롭 클릭, Escape, ✕ 버튼, 같은 탭 재클릭. body scroll lock 적용
+- **데스크톱**: `md:hidden`으로 숨김
 
 ### LoginPage
 
@@ -380,11 +411,11 @@ max-w-6xl mx-auto px-6 py-6 flex items-center justify-between
 
 ### 타이포그래피
 
-| 용도 | 모바일 | 데스크톱 |
-|------|--------|----------|
-| 페이지 제목 | `text-2xl` | `md:text-4xl` |
-| 섹션 제목 | `text-xl` | `md:text-2xl` |
-| HintMask 텍스트 | `text-xl` | `md:text-2xl` |
+| 용도            | 모바일     | 데스크톱      |
+| --------------- | ---------- | ------------- |
+| 페이지 제목     | `text-2xl` | `md:text-4xl` |
+| 섹션 제목       | `text-xl`  | `md:text-2xl` |
+| HintMask 텍스트 | `text-xl`  | `md:text-2xl` |
 | GameClearedCard | `text-2xl` | `md:text-3xl` |
 
 ### Toast

--- a/frontend/src/app/layout/Header.tsx
+++ b/frontend/src/app/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { getLastProvider, PROVIDER_COLORS } from "@/shared/config/providers";
@@ -13,9 +13,6 @@ export function Header() {
   const { user, isAuthenticated } = useAuthStore();
   const location = useLocation();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [trackedPath, setTrackedPath] = useState(location.pathname);
-  const menuRef = useRef<HTMLDivElement>(null);
   const isAdmin = hasAdminAccess(user?.role);
   const provider = getLastProvider();
   const providerColors = provider ? PROVIDER_COLORS[provider] : null;
@@ -23,31 +20,9 @@ export function Header() {
     ? { kakao: KakaoIcon, google: GoogleIcon, naver: NaverIcon, local: GakkaweoIcon }[provider]
     : null;
 
-  if (location.pathname !== trackedPath) {
-    setTrackedPath(location.pathname);
-    setIsMenuOpen(false);
-  }
-
-  useEffect(() => {
-    if (!isMenuOpen) {
-      return;
-    }
-
-    function handleMouseDown(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setIsMenuOpen(false);
-      }
-    }
-
-    document.addEventListener("mousedown", handleMouseDown);
-    return () => {
-      document.removeEventListener("mousedown", handleMouseDown);
-    };
-  }, [isMenuOpen]);
-
   return (
     <>
-      <header className="relative border-b-4 border-black dark:border-white bg-white dark:bg-gray-950">
+      <header className="border-b-4 border-black dark:border-white bg-white dark:bg-gray-950">
         <div className="max-w-6xl mx-auto flex items-center justify-between px-4 py-3 md:px-6 md:py-4">
           <Link
             to="/"
@@ -57,7 +32,7 @@ export function Header() {
             가까워
           </Link>
 
-          <div className="hidden md:flex items-center gap-3">
+          <div className="flex items-center gap-2 md:gap-3">
             <button
               type="button"
               onClick={() => setIsSettingsOpen(true)}
@@ -98,74 +73,6 @@ export function Header() {
               <Link to="/login" className={`${SM_BUTTON} bg-green-400 text-black`}>
                 로그인
               </Link>
-            )}
-          </div>
-
-          <div className="md:hidden" ref={menuRef}>
-            <button
-              type="button"
-              onClick={() => setIsMenuOpen((prev) => !prev)}
-              className={`${SM_BUTTON} bg-white dark:bg-gray-950 text-black dark:text-white`}
-              aria-label={isMenuOpen ? "메뉴 닫기" : "메뉴 열기"}
-              aria-expanded={isMenuOpen}
-            >
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                {isMenuOpen ? (
-                  <path d="M5.293 5.293a1 1 0 011.414 0L10 8.586l3.293-3.293a1 1 0 111.414 1.414L11.414 10l3.293 3.293a1 1 0 01-1.414 1.414L10 11.414l-3.293 3.293a1 1 0 01-1.414-1.414L8.586 10 5.293 6.707a1 1 0 010-1.414z" />
-                ) : (
-                  <path d="M3 5h14a1 1 0 010 2H3a1 1 0 010-2zm0 4h14a1 1 0 010 2H3a1 1 0 010-2zm0 4h14a1 1 0 010 2H3a1 1 0 010-2z" />
-                )}
-              </svg>
-            </button>
-
-            {isMenuOpen && (
-              <div className="absolute right-0 left-0 border-b-4 border-x-4 border-black dark:border-white bg-white dark:bg-gray-950 shadow-brutal z-40">
-                <div className="flex flex-col p-3 gap-2">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setIsMenuOpen(false);
-                      setIsSettingsOpen(true);
-                    }}
-                    className={`w-full ${SM_BUTTON} bg-white dark:bg-gray-950 text-black dark:text-white text-left`}
-                  >
-                    설정
-                  </button>
-
-                  {isAdmin && (
-                    <Link
-                      to="/admin"
-                      className={[
-                        `w-full block ${SM_BUTTON}`,
-                        location.pathname.startsWith("/admin") ? "bg-red-400 text-black" : "bg-red-200 text-black",
-                      ].join(" ")}
-                    >
-                      관리
-                    </Link>
-                  )}
-
-                  {isAuthenticated && user ? (
-                    <Link
-                      to="/mypage"
-                      className={[
-                        `w-full inline-flex items-center gap-1.5 ${SM_BUTTON}`,
-                        providerColors ? `${providerColors.bg} ${providerColors.text}` : "bg-yellow-300 text-black",
-                      ].join(" ")}
-                    >
-                      {ProviderIcon && (
-                        <span className="flex items-center justify-center shrink-0">
-                          <ProviderIcon size={14} />
-                        </span>
-                      )}
-                      {user.nickname}
-                    </Link>
-                  ) : (
-                    <Link to="/login" className={`w-full block ${SM_BUTTON} bg-green-400 text-black`}>
-                      로그인
-                    </Link>
-                  )}
-                </div>
-              </div>
             )}
           </div>
         </div>

--- a/frontend/src/features/auth/MyPage.tsx
+++ b/frontend/src/features/auth/MyPage.tsx
@@ -170,7 +170,7 @@ export function MyPage() {
                 </svg>
               </div>
             )}
-            <div className="absolute inset-0 border-4 border-black dark:border-white bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+            <div className="absolute inset-0 border-4 border-black dark:border-white bg-black/40 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity flex items-center justify-center">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="white">
                 <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
               </svg>

--- a/frontend/src/features/auth/components/ProfileImagePopover.tsx
+++ b/frontend/src/features/auth/components/ProfileImagePopover.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { RefObject } from "react";
+import { useClickOutside } from "@/shared/hooks/useClickOutside";
 
 interface ProfileImagePopoverProps {
   hasImage: boolean;
@@ -17,20 +18,9 @@ export function ProfileImagePopover({
   onClose,
 }: ProfileImagePopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
+  const excludeRefs = useMemo(() => [triggerRef], [triggerRef]);
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (popoverRef.current && !popoverRef.current.contains(target) && !triggerRef.current?.contains(target)) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [onClose, triggerRef]);
+  useClickOutside(popoverRef, onClose, { excludeRefs });
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/frontend/src/features/game/components/GuessHistory.tsx
+++ b/frontend/src/features/game/components/GuessHistory.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Button } from "@/shared/ui/Button";
 import { SimilarityBadge } from "@/shared/ui/SimilarityBadge";
 
 interface GuessItem {
@@ -13,18 +14,33 @@ interface GuessHistoryProps {
 
 const PAGE_SIZE = 5;
 
+const ITEM_CLASS =
+  "flex items-center justify-between border-4 border-black dark:border-white shadow-brutal bg-white dark:bg-gray-900 p-2 md:p-3";
+
+const PLACEHOLDER_CLASS =
+  "flex items-center justify-between border-4 border-transparent p-2 md:p-3 shadow-brutal invisible";
+
+function PlaceholderRow() {
+  return (
+    <div className={PLACEHOLDER_CLASS} aria-hidden="true">
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-bold tabular-nums shrink-0">#0</span>
+        <span className="font-medium">&nbsp;</span>
+      </div>
+      <span className="inline-block border-2 border-transparent px-2 py-0.5 text-sm font-bold tabular-nums">0.0%</span>
+    </div>
+  );
+}
+
 export function GuessHistory({ guesses }: GuessHistoryProps) {
   const [page, setPage] = useState(0);
 
-  if (guesses.length === 0) {
-    return null;
-  }
-
   const sorted = [...guesses].reverse();
   const total = guesses.length;
-  const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages - 1);
   const pageGuesses = sorted.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+  const placeholderCount = PAGE_SIZE - pageGuesses.length;
 
   return (
     <div className="space-y-3">
@@ -32,25 +48,20 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
         <h2 className="text-xl md:text-2xl font-extrabold">추측 기록</h2>
         {totalPages > 1 && (
           <div className="flex items-center gap-2">
-            <button
-              type="button"
-              disabled={safePage === 0}
-              onClick={() => setPage(safePage - 1)}
-              className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 disabled:hover:shadow-brutal-sm disabled:hover:translate-x-0 disabled:hover:translate-y-0 disabled:active:shadow-brutal-sm disabled:active:translate-x-0 disabled:active:translate-y-0 bg-white dark:bg-gray-900"
-            >
+            <Button size="sm" variant="secondary" disabled={safePage === 0} onClick={() => setPage(safePage - 1)}>
               이전
-            </button>
+            </Button>
             <span className="text-sm font-bold text-gray-500 dark:text-gray-400 tabular-nums">
               {safePage + 1} / {totalPages}
             </span>
-            <button
-              type="button"
+            <Button
+              size="sm"
+              variant="secondary"
               disabled={safePage >= totalPages - 1}
               onClick={() => setPage(safePage + 1)}
-              className="border-2 border-black dark:border-white px-3 py-1 text-xs font-bold shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px] disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0 disabled:translate-y-0 disabled:hover:shadow-brutal-sm disabled:hover:translate-x-0 disabled:hover:translate-y-0 disabled:active:shadow-brutal-sm disabled:active:translate-x-0 disabled:active:translate-y-0 bg-white dark:bg-gray-900"
             >
               다음
-            </button>
+            </Button>
           </div>
         )}
       </div>
@@ -59,7 +70,7 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
         {pageGuesses.map((guess, i) => (
           <div
             key={`${guess.attemptNumber ?? total - (safePage * PAGE_SIZE + i)}-${guess.guessText}`}
-            className="flex items-center justify-between border-4 border-black dark:border-white shadow-brutal bg-white dark:bg-gray-900 p-2 md:p-3"
+            className={ITEM_CLASS}
           >
             <div className="flex items-center gap-3">
               <span className="text-sm font-bold text-gray-500 dark:text-gray-400 tabular-nums shrink-0">
@@ -70,6 +81,8 @@ export function GuessHistory({ guesses }: GuessHistoryProps) {
             <SimilarityBadge similarity={guess.similarity} />
           </div>
         ))}
+        {placeholderCount > 0 &&
+          Array.from({ length: placeholderCount }, (_, i) => <PlaceholderRow key={`placeholder-${i}`} />)}
       </div>
     </div>
   );

--- a/frontend/src/features/game/components/HintPanel.tsx
+++ b/frontend/src/features/game/components/HintPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
 import type { HintEntry } from "@/shared/api/types";
 import { Card } from "@/shared/ui/Card";
+import { SkeletonRow } from "@/shared/ui/SkeletonRow";
 import { SimilarityBadge } from "@/shared/ui/SimilarityBadge";
 
 interface HintPanelProps {
@@ -9,10 +10,6 @@ interface HintPanelProps {
   isLoading: boolean;
   bestSimilarity: number;
   isAuthenticated: boolean;
-}
-
-function SkeletonRow() {
-  return <div className="h-8 bg-gray-200 dark:bg-gray-700 animate-pulse" />;
 }
 
 function HintRow({ hint, isLast }: { hint: HintEntry; isLast: boolean }) {

--- a/frontend/src/features/ranking/components/RankingPanel.tsx
+++ b/frontend/src/features/ranking/components/RankingPanel.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "@/shared/stores/useAuthStore";
 import { useConnectionStore } from "@/shared/stores/useConnectionStore";
 import { RankingEntryRow } from "@/features/ranking/components/RankingEntryRow";
 import { RankingEmptyState } from "@/features/ranking/components/RankingEmptyState";
+import { SkeletonRow } from "@/shared/ui/SkeletonRow";
 
 const VISIBLE = 5;
 const ROTATE_MS = 3000;
@@ -19,10 +20,6 @@ function getCircularSlice<T>(items: T[], offset: number, count: number): T[] {
 interface RankingPanelProps {
   ranking: RankingResponse | undefined;
   isLoading: boolean;
-}
-
-function SkeletonRow() {
-  return <div className="h-10 bg-gray-200 dark:bg-gray-800 animate-pulse border-2 border-transparent" />;
 }
 
 export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
@@ -106,11 +103,11 @@ export function RankingPanel({ ranking, isLoading }: RankingPanelProps) {
 
       {isLoading ? (
         <div className="space-y-1.5">
-          <SkeletonRow />
-          <SkeletonRow />
-          <SkeletonRow />
-          <SkeletonRow />
-          <SkeletonRow />
+          <SkeletonRow height="h-10" className="border-2 border-transparent" />
+          <SkeletonRow height="h-10" className="border-2 border-transparent" />
+          <SkeletonRow height="h-10" className="border-2 border-transparent" />
+          <SkeletonRow height="h-10" className="border-2 border-transparent" />
+          <SkeletonRow height="h-10" className="border-2 border-transparent" />
         </div>
       ) : entries.length === 0 ? (
         <RankingEmptyState />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -74,3 +74,29 @@ body {
     transform: translateX(100%);
   }
 }
+
+@keyframes slide-in-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-out-right {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@utility animate-slide-in-right {
+  animation: slide-in-right 200ms ease-out;
+}
+
+@utility animate-slide-out-right {
+  animation: slide-out-right 200ms ease-in forwards;
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import { useToday, useGameStatus, useHints } from "@/features/game/hooks/useGame
 import { RankingPanel } from "@/features/ranking/components/RankingPanel";
 import { useRankings } from "@/features/ranking/hooks/useRankingQueries";
 import { useAuthStore } from "@/shared/stores/useAuthStore";
+import { MobileSideSheet } from "@/shared/ui/MobileSideSheet";
 
 export function HomePage() {
   const { data: ranking, isLoading: rankingLoading } = useRankings();
@@ -16,18 +17,32 @@ export function HomePage() {
 
   const { data: hints, isLoading: hintsLoading } = useHints(sentenceId, bestSimilarity);
 
+  const rankingPanel = <RankingPanel ranking={ranking} isLoading={rankingLoading} />;
+  const hintPanel = (
+    <HintPanel
+      hints={hints?.hints ?? []}
+      isLoading={hintsLoading}
+      bestSimilarity={bestSimilarity}
+      isAuthenticated={isAuthenticated}
+    />
+  );
+
   return (
-    <div className="flex flex-col md:flex-row gap-6 md:items-start">
-      <div className="order-2 md:order-none w-full md:w-72 md:shrink-0 space-y-6">
-        <RankingPanel ranking={ranking} isLoading={rankingLoading} />
-        <HintPanel
-          hints={hints?.hints ?? []}
-          isLoading={hintsLoading}
-          bestSimilarity={bestSimilarity}
-          isAuthenticated={isAuthenticated}
-        />
+    <>
+      <div className="flex flex-col md:flex-row gap-6 md:items-start">
+        <div className="hidden md:block w-72 shrink-0 space-y-6">
+          {rankingPanel}
+          {hintPanel}
+        </div>
+        <GamePage />
       </div>
-      <GamePage />
-    </div>
+
+      <MobileSideSheet
+        tabs={[
+          { key: "ranking", label: "랭킹", content: rankingPanel },
+          { key: "hint", label: "힌트", content: hintPanel },
+        ]}
+      />
+    </>
   );
 }

--- a/frontend/src/shared/hooks/useClickOutside.ts
+++ b/frontend/src/shared/hooks/useClickOutside.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import type { RefObject } from "react";
+
+export function useClickOutside(
+  ref: RefObject<HTMLElement | null>,
+  onClose: () => void,
+  options: { disabled?: boolean; excludeRefs?: RefObject<HTMLElement | null>[] } = {},
+) {
+  const { disabled = false, excludeRefs } = options;
+
+  useEffect(() => {
+    if (disabled) {
+      return;
+    }
+
+    function handleMouseDown(e: MouseEvent) {
+      const target = e.target as Node;
+      if (ref.current && !ref.current.contains(target)) {
+        if (excludeRefs?.some((r) => r.current?.contains(target))) {
+          return;
+        }
+        onClose();
+      }
+    }
+
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, [ref, onClose, disabled, excludeRefs]);
+}

--- a/frontend/src/shared/hooks/useScrollLock.ts
+++ b/frontend/src/shared/hooks/useScrollLock.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+
+let lockCount = 0;
+
+export function useScrollLock(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    lockCount++;
+    if (lockCount === 1) {
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      lockCount--;
+      if (lockCount === 0) {
+        document.body.style.overflow = "";
+      }
+    };
+  }, [enabled]);
+}

--- a/frontend/src/shared/ui/Dialog.tsx
+++ b/frontend/src/shared/ui/Dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, type ReactNode } from "react";
 import { useClickOutside } from "@/shared/hooks/useClickOutside";
+import { useScrollLock } from "@/shared/hooks/useScrollLock";
 
 interface DialogProps {
   isOpen?: boolean;
@@ -11,8 +12,6 @@ interface DialogProps {
   maxWidth?: string;
   disableClose?: boolean;
 }
-
-let openCount = 0;
 
 export function Dialog({
   isOpen = true,
@@ -27,23 +26,7 @@ export function Dialog({
   const titleId = useId();
   const panelRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    openCount++;
-    if (openCount === 1) {
-      document.body.style.overflow = "hidden";
-    }
-
-    return () => {
-      openCount--;
-      if (openCount === 0) {
-        document.body.style.overflow = "";
-      }
-    };
-  }, [isOpen]);
+  useScrollLock(isOpen);
 
   useEffect(() => {
     if (!isOpen) {

--- a/frontend/src/shared/ui/Dialog.tsx
+++ b/frontend/src/shared/ui/Dialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, type ReactNode } from "react";
+import { useClickOutside } from "@/shared/hooks/useClickOutside";
 
 interface DialogProps {
   isOpen?: boolean;
@@ -61,22 +62,7 @@ export function Dialog({
     };
   }, [isOpen, disableClose, onClose]);
 
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    function handleClickOutside(e: MouseEvent) {
-      if (!disableClose && panelRef.current && !panelRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isOpen, disableClose, onClose]);
+  useClickOutside(panelRef, onClose, { disabled: !isOpen || disableClose });
 
   if (!isOpen) {
     return null;

--- a/frontend/src/shared/ui/MobileSideSheet.tsx
+++ b/frontend/src/shared/ui/MobileSideSheet.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useEffect, useCallback, type ReactNode } from "react";
+import { useState, useRef, useEffect, useCallback, type ReactNode, type AnimationEvent } from "react";
 import { useClickOutside } from "@/shared/hooks/useClickOutside";
+import { useScrollLock } from "@/shared/hooks/useScrollLock";
 
 type TabKey = "ranking" | "hint";
 
@@ -28,12 +29,12 @@ export function MobileSideSheet({ tabs }: MobileSideSheetProps) {
 
   useClickOutside(drawerRef, handleClose, { disabled: !isOpen || isClosing });
 
+  useScrollLock(isOpen);
+
   useEffect(() => {
     if (!isOpen) {
       return;
     }
-
-    document.body.style.overflow = "hidden";
 
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === "Escape") {
@@ -43,12 +44,14 @@ export function MobileSideSheet({ tabs }: MobileSideSheetProps) {
 
     document.addEventListener("keydown", handleKeyDown);
     return () => {
-      document.body.style.overflow = "";
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [isOpen, handleClose]);
 
-  function handleAnimationEnd() {
+  function handleAnimationEnd(e: AnimationEvent<HTMLDivElement>) {
+    if (e.target !== e.currentTarget) {
+      return;
+    }
     if (isClosing) {
       setActiveTab(null);
       setIsClosing(false);

--- a/frontend/src/shared/ui/MobileSideSheet.tsx
+++ b/frontend/src/shared/ui/MobileSideSheet.tsx
@@ -1,0 +1,134 @@
+import { useState, useRef, useEffect, useCallback, type ReactNode } from "react";
+import { useClickOutside } from "@/shared/hooks/useClickOutside";
+
+type TabKey = "ranking" | "hint";
+
+interface Tab {
+  key: TabKey;
+  label: string;
+  content: ReactNode;
+}
+
+interface MobileSideSheetProps {
+  tabs: Tab[];
+}
+
+export function MobileSideSheet({ tabs }: MobileSideSheetProps) {
+  const [activeTab, setActiveTab] = useState<TabKey | null>(null);
+  const [isClosing, setIsClosing] = useState(false);
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const isOpen = activeTab !== null;
+
+  const handleClose = useCallback(() => {
+    if (isClosing) {
+      return;
+    }
+    setIsClosing(true);
+  }, [isClosing]);
+
+  useClickOutside(drawerRef, handleClose, { disabled: !isOpen || isClosing });
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    document.body.style.overflow = "hidden";
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        handleClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = "";
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, handleClose]);
+
+  function handleAnimationEnd() {
+    if (isClosing) {
+      setActiveTab(null);
+      setIsClosing(false);
+    }
+  }
+
+  function handleTabClick(key: TabKey) {
+    if (isClosing) {
+      return;
+    }
+    if (activeTab === key) {
+      handleClose();
+    } else {
+      setActiveTab(key);
+    }
+  }
+
+  const activeContent = tabs.find((t) => t.key === activeTab)?.content;
+  const activeLabel = tabs.find((t) => t.key === activeTab)?.label;
+
+  return (
+    <div className="md:hidden">
+      {!isOpen && (
+        <div className="fixed right-0 top-[38%] -translate-y-1/2 z-40 flex flex-col border-l-4 border-y-4 border-black dark:border-white">
+          {tabs.map((tab, i) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActiveTab(tab.key)}
+              className={[
+                "bg-white dark:bg-gray-950 text-black dark:text-white px-2 py-2.5 font-black text-[10px] transition-colors duration-100 hover:bg-yellow-300 hover:text-black active:bg-black active:text-white dark:active:bg-white dark:active:text-black",
+                i > 0 ? "border-t-2 border-black dark:border-white" : "",
+              ].join(" ")}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {(isOpen || isClosing) && (
+        <div className="fixed inset-0 z-50 bg-black/40">
+          <div
+            ref={drawerRef}
+            className={`absolute top-0 right-0 bottom-0 w-72 border-l-4 border-black dark:border-white bg-white dark:bg-gray-950 overflow-y-auto ${isClosing ? "animate-slide-out-right" : "animate-slide-in-right"}`}
+            onAnimationEnd={handleAnimationEnd}
+          >
+            <div className="flex items-center justify-between border-b-4 border-black dark:border-white px-4 py-3">
+              <h2 className="text-lg font-black">{activeLabel}</h2>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="border-4 border-black dark:border-white bg-white dark:bg-gray-900 text-black dark:text-white px-2 py-0.5 font-black text-sm shadow-brutal-sm transition-all duration-100 hover:shadow-brutal-sm-hover hover:translate-x-0.5 hover:translate-y-0.5 active:shadow-none active:translate-x-[3px] active:translate-y-[3px]"
+                aria-label="닫기"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="flex border-b-4 border-black dark:border-white">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => handleTabClick(tab.key)}
+                  className={[
+                    "flex-1 py-2 text-sm font-black text-center transition-colors",
+                    activeTab === tab.key ? "bg-yellow-300 text-black" : "text-black dark:text-white",
+                    tab.key === "ranking" ? "border-r-2 border-black dark:border-white" : "",
+                  ].join(" ")}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="p-4">{activeContent}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/shared/ui/SkeletonRow.tsx
+++ b/frontend/src/shared/ui/SkeletonRow.tsx
@@ -1,0 +1,3 @@
+export function SkeletonRow({ height = "h-8", className = "" }: { height?: string; className?: string }) {
+  return <div className={`${height} bg-gray-200 dark:bg-gray-700 animate-pulse ${className}`} />;
+}


### PR DESCRIPTION
## 관련 이슈

Closes #192

## 변경 사항

### 공용 훅/컴포넌트 추출
- `useClickOutside` 훅: Header, ProfileImagePopover, Dialog 3곳의 중복 click-outside 패턴 통합. `disabled`, `excludeRefs` 옵션
- `SkeletonRow` 컴포넌트: HintPanel, RankingPanel의 로컬 정의 통합. `height`, `className` props

### GuessHistory 개선
- 인라인 14클래스 페이지네이션 버튼을 `Button sm secondary`로 교체 (어드민 Pagination과 통일)
- 5슬롯 고정 placeholder로 페이지 전환 및 0개 상태에서 레이아웃 시프트 방지
- 추측 0개에서도 "추측 기록" 제목 + 빈 슬롯 항상 표시

### 모바일 UX 개선
- 헤더: 햄버거 메뉴 제거, 모바일/데스크톱 동일 인라인 버튼 배치
- 사이드 패널: `MobileSideSheet` 드로어 신규. 오른쪽 플로팅 버튼(랭킹/힌트) → 슬라이드 인/아웃 드로어 + 백드롭
- MyPage 프로필 오버레이: 모바일에서 항상 표시 (`opacity-100 md:opacity-0 md:group-hover:opacity-100`)

### 문서화
- design-system.md: Tailwind v4 hover 보호 규칙, 공용 훅/컴포넌트 테이블, 헤더/HomePage/GuessHistory 규칙 갱신

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다