### PR TITLE
fix: 정규화 후 최소 2자 검증 추가

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/SimilarityService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/infra/ai/service/SimilarityService.java
@@ -40,7 +40,7 @@ public class SimilarityService implements SimilarityClient {
   @Override
   public BigDecimal testSimilarity(String sentenceText, String guessText) {
     String normalized = textNormalizer.normalize(guessText);
-    if (normalized.isEmpty()) {
+    if (normalized.length() < 2) {
       throw new BusinessException(ErrorCode.INVALID_GUESS_TEXT);
     }
     return callWithCircuitBreaker(sentenceText, normalized);
@@ -50,7 +50,7 @@ public class SimilarityService implements SimilarityClient {
   public BigDecimal calculateSimilarity(
       Long sentenceId, String guessText, String sentenceText, Duration cacheTtl) {
     String normalized = textNormalizer.normalize(guessText);
-    if (normalized.isEmpty()) {
+    if (normalized.length() < 2) {
       throw new BusinessException(ErrorCode.INVALID_GUESS_TEXT);
     }
     String cacheKey = buildCacheKey(sentenceId, normalized);

--- a/backend/src/test/java/com/gakkaweo/backend/game/GameFlowIntegrationTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/game/GameFlowIntegrationTest.java
@@ -221,6 +221,25 @@ class GameFlowIntegrationTest extends IntegrationTestBase {
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
       assertThat(response.getBody().code()).isEqualTo("INVALID_GUESS_TEXT");
     }
+
+    @Test
+    @DisplayName("INVALID_GUESS_TEXT - 미완성 한글 입력 (정규화 후 1글자)")
+    void 미완성한글_400() {
+      Member member = testAuthHelper.createMember();
+      DailySentence sentence = testAuthHelper.createTodaySentence("안녕하세요");
+
+      HttpHeaders headers = authedJson(member);
+
+      ResponseEntity<ErrorBody> response =
+          restTemplate.exchange(
+              url("/daily/guess"),
+              HttpMethod.POST,
+              new HttpEntity<>(new GuessRequest(sentence.getPublicId(), "ㄱ디"), headers),
+              ErrorBody.class);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(response.getBody().code()).isEqualTo("INVALID_GUESS_TEXT");
+    }
   }
 
   @Nested

--- a/backend/src/test/java/com/gakkaweo/backend/infra/ai/SimilarityServiceTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/infra/ai/SimilarityServiceTest.java
@@ -71,6 +71,15 @@ class SimilarityServiceTest {
   }
 
   @Test
+  @DisplayName("testSimilarity - 정규화 후 1글자이면 INVALID_GUESS_TEXT")
+  void testSimilarity_1글자() {
+    assertThatThrownBy(() -> service.testSimilarity("원문", "ㄱ디"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_GUESS_TEXT);
+  }
+
+  @Test
   @DisplayName("calculateSimilarity - 캐시 HIT 시 AI 호출 안 함")
   void calculate_캐시HIT() {
     when(valueOps.get(anyString())).thenReturn("88.0");
@@ -102,6 +111,17 @@ class SimilarityServiceTest {
         .isInstanceOf(BusinessException.class)
         .extracting("errorCode")
         .isEqualTo(ErrorCode.INVALID_GUESS_TEXT);
+  }
+
+  @Test
+  @DisplayName("calculateSimilarity - 정규화 후 1글자이면 INVALID_GUESS_TEXT")
+  void calculate_1글자() {
+    assertThatThrownBy(() -> service.calculateSimilarity(1L, "ㄱ디", "원문", Duration.ofMinutes(10)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_GUESS_TEXT);
+
+    verify(aiServiceClient, never()).calculateSimilarity(anyString(), anyString());
   }
 
   @Test

--- a/backend/src/test/java/com/gakkaweo/backend/support/TestSimilarityClient.java
+++ b/backend/src/test/java/com/gakkaweo/backend/support/TestSimilarityClient.java
@@ -52,7 +52,7 @@ public class TestSimilarityClient implements SimilarityClient {
       throw new BusinessException(ErrorCode.AI_SERVICE_UNAVAILABLE);
     }
     String normalized = normalizeKey(guessText);
-    if (normalized.isEmpty()) {
+    if (normalized.length() < 2) {
       throw new BusinessException(ErrorCode.INVALID_GUESS_TEXT);
     }
     return programmedScores.getOrDefault(normalized, defaultScore);

--- a/frontend/src/features/game/GamePage.tsx
+++ b/frontend/src/features/game/GamePage.tsx
@@ -205,8 +205,8 @@ export function GamePage() {
     setInputError(null);
 
     const normalizedInput = normalizeGuessText(text);
-    if (!normalizedInput) {
-      setInputError("유효한 문자(한글, 영문, 숫자)를 포함해야 합니다");
+    if (normalizedInput.length < 2) {
+      setInputError("유효한 문자(한글, 영문, 숫자)를 2자 이상 포함해야 합니다");
       return;
     }
 


### PR DESCRIPTION
## 관련 이슈

Closes #194

## 변경 사항

- FE: `normalizeGuessText()` 후 `!normalizedInput` → `normalizedInput.length < 2` 검사로 변경, 에러 메시지 갱신
- BE: `SimilarityService` 두 메서드에서 `normalized.isEmpty()` → `normalized.length() < 2`로 변경
- BE: `TestSimilarityClient` 동일 적용
- 테스트: `SimilarityServiceTest`에 1글자 입력 단위 테스트 2개, `GameFlowIntegrationTest`에 미완성 한글 통합 테스트 1개 추가

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다