### PR TITLE
fix: BE/FE 코드 품질 개선

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ranking/service/RankingService.java
@@ -37,7 +37,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -120,7 +119,6 @@ public class RankingService {
     }
   }
 
-  @Transactional(readOnly = true)
   public RankingResponse getRankingsForUser(UUID memberPublicId) {
     try {
       LocalDate today = LocalDate.now(clock);

--- a/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/RateLimitFilter.java
+++ b/backend/src/main/java/com/gakkaweo/backend/ratelimit/filter/RateLimitFilter.java
@@ -14,7 +14,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.Instant;
+import java.time.Clock;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +36,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
   private final BucketStore bucketStore;
   private final ObjectMapper objectMapper;
   private final MeterRegistry meterRegistry;
+  private final Clock clock;
 
   @Value("${management.server.port:#{null}}")
   private Integer managementPort;
@@ -96,7 +97,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
             errorCode.getStatus().value(),
             errorCode.name(),
             errorCode.getMessage(),
-            Instant.now().toString());
+            clock.instant().toString());
 
     response.setStatus(errorCode.getStatus().value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/frontend/src/app/layout/SettingsModal.tsx
+++ b/frontend/src/app/layout/SettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Dialog } from "@/shared/ui/Dialog";
-import { useThemeStore } from "@/shared/stores/useThemeStore";
+import { useThemeStore, type Theme } from "@/shared/stores/useThemeStore";
 import {
   SOUND_VOLUME_KEY,
   type SoundType,
@@ -11,8 +11,6 @@ import {
   setLastVolume,
   stopCurrentSound,
 } from "@/shared/config/sound";
-
-type Theme = "light" | "dark" | "system";
 
 const THEME_OPTIONS: { value: Theme; label: string; icon: string }[] = [
   { value: "light", label: "라이트", icon: "☀" },

--- a/frontend/src/features/admin/components/AuditLogViewer.tsx
+++ b/frontend/src/features/admin/components/AuditLogViewer.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/shared/ui/Button";
 import { useAuditLogs } from "@/features/admin/hooks/useAdminSystem";
 import { useSortState } from "@/features/admin/hooks/useSortState";
 import { SortableHeader } from "@/features/admin/components/SortableHeader";
+import { Pagination } from "@/features/admin/components/Pagination";
 import { AuditLogDetailDialog } from "@/features/admin/components/AuditLogDetailDialog";
 import { AUDIT_ACTION_LABELS, getAuditActionLabel, getAuditTargetTypeLabel } from "@/features/admin/labels";
 import type { AuditLog } from "@/features/admin/types";
@@ -164,24 +165,7 @@ export function AuditLogViewer() {
             </table>
           </div>
 
-          {data.totalPages > 1 && (
-            <div className="flex items-center gap-2 justify-center">
-              <Button size="sm" variant="secondary" disabled={page === 0} onClick={() => setPage(page - 1)}>
-                이전
-              </Button>
-              <span className="text-xs font-bold tabular-nums">
-                {page + 1} / {data.totalPages}
-              </span>
-              <Button
-                size="sm"
-                variant="secondary"
-                disabled={page >= data.totalPages - 1}
-                onClick={() => setPage(page + 1)}
-              >
-                다음
-              </Button>
-            </div>
-          )}
+          <Pagination page={page} totalPages={data.totalPages} onPageChange={setPage} />
         </>
       ) : (
         <p className="text-gray-500 dark:text-gray-400 font-bold text-sm">로그가 없습니다.</p>

--- a/frontend/src/features/auth/components/ProfileImagePopover.tsx
+++ b/frontend/src/features/auth/components/ProfileImagePopover.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo, useRef } from "react";
 import type { RefObject } from "react";
 import { useClickOutside } from "@/shared/hooks/useClickOutside";
+import { useEscapeStack } from "@/shared/hooks/useEscapeStack";
 
 interface ProfileImagePopoverProps {
   hasImage: boolean;
@@ -21,19 +22,7 @@ export function ProfileImagePopover({
   const excludeRefs = useMemo(() => [triggerRef], [triggerRef]);
 
   useClickOutside(popoverRef, onClose, { excludeRefs });
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [onClose]);
+  useEscapeStack(onClose, true);
 
   return (
     <div

--- a/frontend/src/shared/stores/useThemeStore.ts
+++ b/frontend/src/shared/stores/useThemeStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-type Theme = "light" | "dark" | "system";
+export type Theme = "light" | "dark" | "system";
 
 const VALID_THEMES: Theme[] = ["light", "dark", "system"];
 

--- a/frontend/src/shared/ui/Button.tsx
+++ b/frontend/src/shared/ui/Button.tsx
@@ -61,7 +61,7 @@ export function Button({
         isLoading
           ? `opacity-70 cursor-wait ${INTERACTION_CLASSES[size].base} animate-pulse`
           : isDisabled
-            ? `opacity-50 cursor-not-allowed ${INTERACTION_CLASSES[size].base}`
+            ? `opacity-50 cursor-not-allowed pointer-events-none translate-x-0 translate-y-0 ${INTERACTION_CLASSES[size].base}`
             : `${INTERACTION_CLASSES[size].base} ${INTERACTION_CLASSES[size].hover} ${INTERACTION_CLASSES[size].active}`,
         className,
       ].join(" ")}


### PR DESCRIPTION
## 관련 이슈

Closes #200

## 변경 사항

### BE (2파일)
- RankingService: `@Transactional(readOnly = true)` 제거 — Redis I/O가 TX 안에 있어 TX 경계 규칙 위반
- RateLimitFilter: `Clock` 주입으로 `Instant.now()` 제거 — GlobalExceptionHandler 등 기존 패턴 통일

### FE (5파일)
- Button: disabled 상태에 `pointer-events-none translate-x-0 translate-y-0` 추가 — design-system 명세 준수
- ProfileImagePopover: 인라인 `useEffect` keydown 리스너 → `useEscapeStack` 전환 — Dialog/MobileSideSheet와 공용 훅 통일
- AuditLogViewer: 인라인 페이지네이션 17행 → `Pagination` 컴포넌트 1행 — SentenceTab/UserTab과 통일
- Theme 타입: `useThemeStore`에서 `export type Theme`, `SettingsModal` 로컬 중복 제거

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다