### PR TITLE
fix: AdminAuditService 감사 로그 트랜잭션 독립성 확보

### DIFF
--- a/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminAuditService.java
+++ b/backend/src/main/java/com/gakkaweo/backend/admin/service/AdminAuditService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -26,13 +27,13 @@ public class AdminAuditService {
   private final ApplicationEventPublisher eventPublisher;
   private final Clock clock;
 
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void log(
       Member admin, AuditAction action, String targetId, String detail, String ipAddress) {
     doLog(admin, action, targetId, detail, ipAddress);
   }
 
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void log(
       UUID adminPublicId, AuditAction action, String targetId, String detail, String ipAddress) {
     Member admin =

--- a/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditAtomicityTest.java
+++ b/backend/src/test/java/com/gakkaweo/backend/admin/AdminAuditAtomicityTest.java
@@ -28,6 +28,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @DisplayName("Admin 감사 로그 원자성 회귀 가드")
 class AdminAuditAtomicityTest extends IntegrationTestBase {
@@ -36,6 +37,7 @@ class AdminAuditAtomicityTest extends IntegrationTestBase {
   @Autowired DailySentenceRepository dailySentenceRepository;
   @Autowired MemberRepository memberRepository;
   @Autowired AuditLogRepository auditLogRepository;
+  @Autowired TransactionTemplate transactionTemplate;
 
   @Test
   @DisplayName("문장 등록 중 audit 실패 시 DailySentence 쓰기가 롤백된다")
@@ -86,6 +88,24 @@ class AdminAuditAtomicityTest extends IntegrationTestBase {
     Member reloaded = memberRepository.findByPublicId(target.getPublicId()).orElseThrow();
     assertThat(reloaded.getRole()).isEqualTo(MemberRole.USER);
     assertThat(auditRowsByAction(AuditAction.ROLE_CHANGE)).isZero();
+  }
+
+  @Test
+  @DisplayName("외부 트랜잭션 롤백 시 감사 로그는 REQUIRES_NEW로 독립 커밋되어 유지된다")
+  void 외부TX_롤백_감사로그_REQUIRES_NEW_유지() {
+    Member admin = testAuthHelper.createAdmin();
+
+    try {
+      transactionTemplate.execute(
+          status -> {
+            adminAuditService.log(
+                admin, AuditAction.SENTENCE_CREATE, "t-1", "REQUIRES_NEW 검증", "127.0.0.1");
+            throw new RuntimeException("outer TX rollback");
+          });
+    } catch (RuntimeException ignored) {
+    }
+
+    assertThat(auditRowsByAction(AuditAction.SENTENCE_CREATE)).isOne();
   }
 
   private long auditRowsByAction(AuditAction action) {


### PR DESCRIPTION
## 관련 이슈

Closes #211

## 변경 사항

- `AdminAuditService.log()` 두 오버로드의 트랜잭션 전파 수준을 `REQUIRED`에서 `REQUIRES_NEW`로 변경
  - 외부 트랜잭션 롤백 시에도 감사 로그가 독립 커밋되어 유지됨
  - 16곳의 호출 사이트(AdminSentenceService, AdminUserService, AdminSystemService, CsvUploadService) 모두 영향
- 외부 TX 롤백 후 감사 로그 생존을 검증하는 통합 테스트 추가 (`외부TX_롤백_감사로그_REQUIRES_NEW_유지`)
- 기존 테스트 2건(audit 실패 시 비즈니스 롤백) 정상 통과 확인

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다