### PR TITLE
chore: pre-commit 훅에 en-dash/em-dash 차단 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,21 @@
 set -e
 
+# en-dash(U+2013), em-dash(U+2014) 사용 금지 - hyphen(-) 사용
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR || true)
+if [ -n "$STAGED_FILES" ]; then
+  EN_DASH=$(printf '\xe2\x80\x93')
+  EM_DASH=$(printf '\xe2\x80\x94')
+  VIOLATIONS=$(git diff --cached --name-only -z --diff-filter=ACMR | xargs -0 git grep --cached -I -n -H -e "$EN_DASH" -e "$EM_DASH" -- 2>/dev/null || true)
+  if [ -n "$VIOLATIONS" ]; then
+    echo ""
+    echo "ERROR: en-dash(U+2013) or em-dash(U+2014) detected. Use hyphen(-) instead."
+    echo ""
+    echo "$VIOLATIONS"
+    echo ""
+    exit 1
+  fi
+fi
+
 # GitHub Desktop의 MinGW에는 gradlew가 필요시하는 cygpath가 없으므로, cygpath 명령어를 대체하게끔 설정
 if ! command -v cygpath &>/dev/null; then
   cygpath() { echo "${@: -1}"; }


### PR DESCRIPTION
## 관련 이슈

Closes #221

## 변경 사항

- `.husky/pre-commit`에 staged 파일 대상 en-dash(U+2013)/em-dash(U+2014) grep 검사 추가
- 차단 시 파일명:줄번호 출력으로 수정 위치 안내
- 선행 작업 #219에서 정리한 결과의 재유입 방지 가드

## 셀프 리뷰 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했다
- [x] 불필요한 코드나 주석을 제거했다
- [x] 변경 사항이 다른 기능에 영향을 주지 않는지 확인했다

## 참고자료

- 테스트: en-dash/em-dash 포함 파일 커밋 시도 → 정상 차단 + 줄번호 출력 확인